### PR TITLE
chore(deps): bump surefire-plugin.version in /quarkus-app

### DIFF
--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -11,7 +11,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.26.2</quarkus.platform.version>
         <compiler-plugin.version>3.14.0</compiler-plugin.version>
-        <surefire-plugin.version>3.5.3</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
Bumps `surefire-plugin.version` from 3.5.3 to 3.5.4.

Updates `org.apache.maven.plugins:maven-surefire-plugin` from 3.5.3 to 3.5.4
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.5.3...surefire-3.5.4)

Updates `org.apache.maven.plugins:maven-failsafe-plugin` from 3.5.3 to 3.5.4
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.5.3...surefire-3.5.4)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-surefire-plugin dependency-version: 3.5.4 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.maven.plugins:maven-failsafe-plugin dependency-version: 3.5.4 dependency-type: direct:production update-type: version-update:semver-patch ...

### Summary
Problem → Solution

### Checks
- [ ] Closes #<issue> / Refs INC-<id>
- [ ] CI green (build + tests + linters)
- [ ] SBOM generated (Maven) & image SBOM (Syft)
- [ ] Image scanned (Grype) — thresholds respected
- [ ] Rollout/feature flags notes if applicable
- [ ] Docs updated (README/SECURITY) if needed
