### PR TITLE
Update documentation for notifications simulation and Now Box

### DIFF
--- a/docs/en/notifications-global-ws.md
+++ b/docs/en/notifications-global-ws.md
@@ -21,6 +21,9 @@ Configuration is done via `application.properties`:
 - `notifications.global.dedupe-window`
 - `notifications.upcoming.window` (default `PT5M`)
 - `notifications.endingSoon.window` (default `PT5M`)
+- `notifications.simulation.enabled`
+- `notifications.simulation.allow-real`
+- `notifications.simulation.max-items`
 
 The browser script `global-notifications-ws.js` connects automatically and forwards notifications to `window.EventFlowNotifications.accept` for toast display. It also stores messages locally so the notifications center page can render them without hitting the backend.
 
@@ -35,16 +38,45 @@ State changes for events and break slots are published five minutes before they 
 Example payloads:
 
 ```json
-{"id":"01","type":"UPCOMING","category":"event","eventId":"e1","title":"El evento comienza pronto","message":"Conf"}
-{"id":"02","type":"STARTED","category":"break","eventId":"e1","talkId":"b1","title":"Break en curso","message":"Coffee break"}
+{"id":"01","type":"UPCOMING","category":"event","eventId":"e1","title":"Event starting soon","message":"Conference keynote"}
+{"id":"02","type":"STARTED","category":"break","eventId":"e1","talkId":"b1","title":"Break in progress","message":"Coffee break"}
 ```
 
 ## Admin broadcast
 
 Administrators may send announcements and prune the backlog through `/admin/api/notifications`:
 
-* `POST /admin/api/notifications/broadcast` &ndash; broadcast a new notification to all connected clients and persist it.
-* `GET /admin/api/notifications/latest?limit=N` &ndash; fetch the last N notifications in the ring buffer.
-* `DELETE /admin/api/notifications/{id}` &ndash; remove a notification so new clients will not receive it.
+* `POST /admin/api/notifications/broadcast` – broadcast a new notification to all connected clients and persist it.
+* `GET /admin/api/notifications/latest?limit=N` – fetch the last N notifications in the ring buffer.
+* `DELETE /admin/api/notifications/{id}` – remove a notification so new clients will not receive it.
 
 An accompanying admin page at `/admin/notifications` uses `admin-notifications.js` to interact with these endpoints.
+
+## Simulation tools for administrators
+
+The simulation workflow helps teams validate notification timelines without touching production users. All endpoints are protected with the `admin` role and honour the simulation configuration keys listed above.
+
+### REST endpoints
+
+* `POST /admin/api/notifications/sim/dry-run` plans notifications for an event around an optional pivot instant and returns the simulated payloads without queuing them.
+* `POST /admin/api/notifications/sim/execute` enqueues the simulated notifications. The body accepts:
+  - `mode`: `preview` (default), `test-broadcast`, or `real-broadcast`. Real broadcasts are rejected unless `notifications.simulation.allow-real=true`.
+  - `sequence`: when `true`, enqueue notifications sequentially using `paceMs` as the delay between items; otherwise they are enqueued immediately.
+  - `paceMs`: delay in milliseconds between sequential emissions (defaults to `1500`).
+  - `includeEvent`, `includeTalks`, `includeBreaks`: booleans to filter the sources considered.
+  - `states`: limit the lifecycle states included (`UPCOMING`, `STARTED`, `ENDING_SOON`, `FINISHED`).
+  - `eventId` and `pivot`: scope the simulation to a single event and time snapshot.
+
+Both endpoints cap the response or enqueued items to `notifications.simulation.max-items` to avoid accidental floods.
+
+### Admin UI
+
+The admin panel links to `/admin/notifications/sim`, a dedicated page that lets administrators:
+
+- Choose the target event ID and pivot date/time.
+- Toggle whether to include the event wrapper, talks, and breaks.
+- Limit which lifecycle states are simulated.
+- Preview results inline, launch a test broadcast, or replay the plan sequentially (mirroring `sequence`/`paceMs`).
+- Opt-in the current browser to receive the `test` notifications that are emitted during simulations.
+
+The page relies on `admin-notifications-sim.js`, which stores the opt-in flag in `localStorage` so administrators can subscribe to follow-up test emissions.

--- a/docs/en/tasks/event-break-notifications.md
+++ b/docs/en/tasks/event-break-notifications.md
@@ -1,10 +1,12 @@
 # Tasks – Event and break notifications
 
-To support the requirement of notifying state changes for events and break slots five minutes before they start or end, implement the following tasks:
+Status: ✅ Completed. These notes capture the scope that was delivered for reference.
 
-- [ ] Set `notifications.upcoming.window` and `notifications.endingSoon.window` defaults to **PT5M**.
-- [ ] Create an `EventStateEvaluator` to emit `UPCOMING`, `STARTED`, `ENDING_SOON` and `FINISHED` notifications for the overall event.
-- [ ] Evaluate break slots (talks marked as `break`) and emit the same state notifications, reusing `TalkStateEvaluator` or introducing a dedicated evaluator.
-- [ ] Surface event and break notifications in the notification center alongside talk alerts.
-- [ ] Update documentation to describe event and break coverage and the new five‑minute windows.
-- [ ] Add integration tests that verify event and break notifications are enqueued at the expected times.
+To support the requirement of notifying state changes for events and break slots five minutes before they start or end, we implemented the following tasks:
+
+- [x] Set `notifications.upcoming.window` and `notifications.endingSoon.window` defaults to **PT5M**.
+- [x] Create an `EventStateEvaluator` to emit `UPCOMING`, `STARTED`, `ENDING_SOON` and `FINISHED` notifications for the overall event.
+- [x] Evaluate break slots (talks marked as `break`) and emit the same state notifications through a dedicated evaluator that reuses the talk logic.
+- [x] Surface event and break notifications in the notification center alongside talk alerts.
+- [x] Update documentation to describe event and break coverage and the new five‑minute windows.
+- [x] Add integration tests that verify event and break notifications are enqueued at the expected times.

--- a/docs/en/ui/home-sections.md
+++ b/docs/en/ui/home-sections.md
@@ -6,13 +6,28 @@ The home page now differentiates events in two blocks:
 - Ordered from the closest to the furthest.
 - Automatic classification according to the date/time of the event.
 - Badge `in progress` when the event has already started but it still does not end.
-- Start Microcopy: `Start today's,` starts in X days `or` date to be confirmed.
-- Empty state: *"There are no next events for now. Come back 👀" *
+- Start microcopy: `Starts today`, `Starts in X days` or `Date to be confirmed`.
+- Empty state: *"There are no next events for now. Come back 👀"*
 
 ## Past events
 - Ordered from the most recent to the oldest.
-- Badge `finished 'for all listed events.
+- Badge `finished` for all listed events.
 - They are shown with an appearance equivalent to the available events, but in gray scale to indicate that they have already finished.
-- Empty state: *"We still don't have previous events." *
+- Empty state: *"We still don't have previous events."*
 
-> Captures before/then pending.
+## Now Box
+
+A dedicated Now Box block highlights what is happening inside each event that is currently running:
+
+- Displays, per active event, the last finished activity, the one in progress and the next within a configurable window.
+- Breaks are labeled explicitly so that the agenda context remains clear even when nothing is on stage.
+- Each card links back to the event agenda or talk detail (`/event/{id}`, `/event/{id}/talk/{talkId}` or `#break-{talkId}`) to speed up navigation.
+- The list prioritises events with an activity in progress; the rest are ordered by the nearest upcoming item.
+
+Configuration keys in `application.properties` control its behaviour:
+
+- `nowbox.lookback` (default `PT30M`) defines how far into the past the Now Box searches for the “last” activity.
+- `nowbox.lookahead` (default `PT60M`) limits how far ahead it looks for the “next” activity.
+- `nowbox.refresh-interval` (default `PT30S`) tells the frontend how often to refresh the block.
+
+If no activities fall within the windows, the event is omitted from the Now Box to keep the section focused on immediate context.

--- a/docs/es/notifications-global-ws.md
+++ b/docs/es/notifications-global-ws.md
@@ -1,50 +1,82 @@
 # Notificaciones globales sobre WebSocket
 
-Este módulo expone notificaciones públicas a cualquier visitante a través del punto final `/WS/Global-Notifications`.
+Este módulo expone notificaciones públicas a cualquier visitante a través del endpoint `/ws/global-notifications`.
 
-Los clientes se conectan a través de WebSocket y envían un mensaje `Hello` con el último cursor` CreateAT` recibido. El servidor reconoce y transmite notificaciones de retraso seguidas de actualizaciones en vivo. Las notificaciones se almacenan en un búfer de anillo ligero persisten a `Datos/notificaciones-global-Ws.json`.
+Los clientes se conectan mediante WebSocket y envían un mensaje `hello` con el último cursor `createdAt` recibido. El servidor lo reconoce y transmite primero las notificaciones pendientes y luego las actualizaciones en vivo. Las notificaciones se almacenan en un búfer circular ligero persistido en `data/notifications-global-ws.json`.
 
 Ejemplo de protocolo:
 
-`` `JSON
+```json
 // Cliente -> servidor
-{"t": "hola", "cursor": 0}
-// servidor -> cliente
-{"T": "Hello-Aack"}
-{"id": "01 ...", "tipo": "agenda_updated", "título": "agenda actualizada", "t": "notif"}
-`` `` ``
+{"t":"hello","cursor":0}
+// Servidor -> cliente
+{"t":"hello-ack"}
+{"id":"01...","type":"AGENDA_UPDATED","title":"Agenda actualizada","t":"notif"}
+```
 
-La configuración se realiza a través de `Application.Properties`:
+La configuración se realiza en `application.properties`:
 
-- `notificaciones.global.enabled`
-- `notificaciones.global.buffer-size`
-- `notificaciones.global.dedupe-window`
-- `Notifications.Upcoming.Window` (predeterminado` PT5M`)
-- `Notifications.endingSoon.Window` (predeterminado` PT5M`)
+- `notifications.global.enabled`
+- `notifications.global.buffer-size`
+- `notifications.global.dedupe-window`
+- `notifications.upcoming.window` (valor por defecto `PT5M`)
+- `notifications.endingSoon.window` (valor por defecto `PT5M`)
+- `notifications.simulation.enabled`
+- `notifications.simulation.allow-real`
+- `notifications.simulation.max-items`
 
-El script de navegador `global-notifications-ws.js` conecta automáticamente y reenvía notificaciones a` Window.Eventflownotifications.accept` para la pantalla de tostadas. También almacena mensajes localmente para que la página del centro de notificaciones pueda renderizarlos sin golpear el backend.
+El script de navegador `global-notifications-ws.js` se conecta automáticamente y reenvía las notificaciones a `window.EventFlowNotifications.accept` para mostrarlas como toasts. También almacena los mensajes localmente para que la página del centro de notificaciones pueda renderizarlos sin consultar el backend.
 
 ## Centro de notificaciones
 
-Los visitantes pueden revisar la acumulación de avisos globales en `/Notificaciones/Center`. La página se presenta completamente en el cliente utilizando datos de 'LocalStorage' y ofrece filtros para mensajes no leídos o recientes, así como acciones locales para marcar las notificaciones como leerlos o eliminarlos.
+Las personas usuarias pueden revisar el historial de avisos globales en `/notifications/center`. La página se renderiza completamente en el cliente usando datos de `localStorage` y ofrece filtros para mensajes no leídos o recientes, además de acciones locales para marcarlos como leídos o eliminarlos.
 
-### Notificaciones de evento y descanso
+### Notificaciones de eventos y descansos
 
-Los cambios de estado para los eventos y las ranuras para romper se publican cinco minutos antes de que comiencen o terminen. El campo 'Categoría' distingue la fuente y las notificaciones se dedican por `(categoría, id, tipo, slotedge)` en la zona horaria del evento.
+Los cambios de estado de eventos y descansos se publican cinco minutos antes de que comiencen o terminen. El campo `category` distingue la fuente y las notificaciones se desduplican por `(category, id, type, slotEdge)` en la zona horaria del evento.
 
-Ejemplo de carga útil:
+Ejemplos de carga útil:
 
-`` `JSON
-{"id": "01", "tipo": "upcuartion", "categoría": "evento", "eventId": "e1", "title": "el eviento comienza pronto", "mensaje": "conf"}
-{"id": "02", "tipo": "iniciado", "categoría": "break", "eventId": "e1", "talkId": "b1", "title": "break en curso", "mensaje": "café"}}
-`` `` ``
+```json
+{"id":"01","type":"UPCOMING","category":"event","eventId":"e1","title":"El evento comienza pronto","message":"Keynote"}
+{"id":"02","type":"STARTED","category":"break","eventId":"e1","talkId":"b1","title":"Break en curso","message":"Coffee break"}
+```
 
-## transmisión de administración
+## Difusión desde administración
 
-Los administradores pueden enviar anuncios y podar el acumulación a través de `/admin/API/Notifications`:
+Las personas administradoras pueden enviar avisos y depurar el historial mediante `/admin/api/notifications`:
 
-* `Post/admin/api/notifications/broadcast` & ndash; Transmitir una nueva notificación a todos los clientes conectados y persistirlo.
-* `Get/admin/api/notifications/último? Limit = n` & ndash; Obtenga las últimas N notificaciones en el búfer de anillo.
-* `Delete/admin/api/notifications/{id}` & ndash; Eliminar una notificación para que los nuevos clientes no lo reciban.
+* `POST /admin/api/notifications/broadcast` – emite una notificación a todas las personas conectadas y la persiste.
+* `GET /admin/api/notifications/latest?limit=N` – obtiene las últimas N notificaciones del búfer.
+* `DELETE /admin/api/notifications/{id}` – elimina una notificación para que las nuevas conexiones no la reciban.
 
-Una página de administración adjunta en `/admin/notifications` utiliza` admin-notations.js` para interactuar con estos puntos finales.
+La página `/admin/notifications` usa `admin-notifications.js` para trabajar con estos endpoints.
+
+## Herramientas de simulación para administración
+
+El flujo de simulación permite validar cronogramas de notificaciones sin impactar a las personas usuarias reales. Todos los endpoints requieren el rol `admin` y respetan las claves de configuración de simulación listadas arriba.
+
+### Endpoints REST
+
+* `POST /admin/api/notifications/sim/dry-run` planifica notificaciones para un evento alrededor de un instante pivote opcional y devuelve los mensajes simulados sin encolarlos.
+* `POST /admin/api/notifications/sim/execute` encola las notificaciones simuladas. El cuerpo acepta:
+  - `mode`: `preview` (por defecto), `test-broadcast` o `real-broadcast`. Las emisiones reales se rechazan si `notifications.simulation.allow-real=false`.
+  - `sequence`: cuando es `true`, encola las notificaciones de forma secuencial usando `paceMs` como retraso entre cada una; de lo contrario se encolan al instante.
+  - `paceMs`: retraso en milisegundos entre emisiones secuenciales (por defecto `1500`).
+  - `includeEvent`, `includeTalks`, `includeBreaks`: booleanos para filtrar las fuentes consideradas.
+  - `states`: limita los estados incluidos (`UPCOMING`, `STARTED`, `ENDING_SOON`, `FINISHED`).
+  - `eventId` y `pivot`: acotan la simulación a un evento y momento específicos.
+
+Ambos endpoints limitan la respuesta o la cola a `notifications.simulation.max-items` para evitar emisiones accidentales masivas.
+
+### Interfaz administrativa
+
+El panel incluye la página `/admin/notifications/sim`, donde se puede:
+
+- Elegir el ID del evento objetivo y la fecha/hora pivote.
+- Activar o desactivar la inclusión del evento, charlas y descansos.
+- Limitar qué estados del ciclo de vida se simulan.
+- Previsualizar los resultados en la página, lanzar una emisión de prueba o reproducir el plan de forma secuencial (siguiendo `sequence`/`paceMs`).
+- Optar por recibir, desde el navegador actual, las notificaciones marcadas como `test` que se generan durante la simulación.
+
+La página depende de `admin-notifications-sim.js`, que guarda la preferencia de opt-in en `localStorage` para suscribirse a las emisiones de prueba posteriores.

--- a/docs/es/tasks/event-break-notifications.md
+++ b/docs/es/tasks/event-break-notifications.md
@@ -1,10 +1,12 @@
-# Tareas: notificaciones de eventos y ruptura
+# Tareas – notificaciones de eventos y descansos
 
-Para apoyar el requisito de notificar los cambios en el estado para los eventos y romper las ranuras cinco minutos antes de que comiencen o terminen, implementen las siguientes tareas:
+Estado: ✅ Completado. Estas notas documentan el alcance que se entregó.
 
-- [] Establecer `notificaciones.upround.window` y` notifications.endingsoon.window` predeterminada a ** pt5m **.
-- [] Crear un `eventstateEvaluator` para emitir` upcoming`, `iniciado`,` ending_soon` y 'terminados' notificaciones para el evento general.
-- [] Evalúe las ranuras para romper (las conversaciones marcadas como `break`) y emiten las mismas notificaciones de estado, reutilizando` talkstateEvaluator` o introduciendo un evaluador dedicado.
-- [] Notificaciones de eventos de superficie y ruptura en el centro de notificaciones junto con alertas de charlas.
-- [] Actualizar documentación para describir la cobertura de eventos y romper y las nuevas ventanas de cinco minutos.
-- [] Agregar pruebas de integración que verifican las notificaciones de eventos y rupturas están enqueadas en los momentos esperados.
+Para apoyar el requisito de notificar los cambios de estado de los eventos y los descansos cinco minutos antes de que comiencen o terminen, se implementó lo siguiente:
+
+- [x] Configurar los valores predeterminados de `notifications.upcoming.window` y `notifications.endingSoon.window` en **PT5M**.
+- [x] Crear un `EventStateEvaluator` que emite notificaciones `UPCOMING`, `STARTED`, `ENDING_SOON` y `FINISHED` para el evento general.
+- [x] Evaluar las sesiones marcadas como `break` y emitir las mismas notificaciones de estado mediante un evaluador dedicado que reutiliza la lógica de charlas.
+- [x] Mostrar las notificaciones de eventos y descansos en el centro de notificaciones junto con las alertas de charlas.
+- [x] Actualizar la documentación para describir la cobertura de eventos y descansos y las ventanas de cinco minutos.
+- [x] Agregar pruebas de integración que verifican que las notificaciones de eventos y descansos se encolan en los momentos esperados.

--- a/docs/es/ui/home-sections.md
+++ b/docs/es/ui/home-sections.md
@@ -15,4 +15,19 @@ La página de inicio ahora diferencia eventos en dos bloques:
 - Se muestran con una apariencia equivalente a los eventos disponibles, pero en escala de grises para indicar que ya finalizaron.
 - Estado vacío: *"Aún no tenemos eventos anteriores."*
 
-> Capturas antes/después pendientes.
+## Now Box
+
+Un bloque exclusivo de Now Box destaca qué está ocurriendo dentro de cada evento que está en curso:
+
+- Muestra, por evento activo, la última actividad finalizada, la que está en progreso y la siguiente dentro de una ventana configurable.
+- Identifica explícitamente los descansos para conservar el contexto de agenda incluso cuando no hay charlas en vivo.
+- Cada tarjeta enlaza a la agenda del evento o al detalle de la actividad (`/event/{id}`, `/event/{id}/talk/{talkId}` o `#break-{talkId}`) para acelerar la navegación.
+- La lista prioriza eventos con una actividad en curso; el resto se ordena por el próximo elemento más cercano.
+
+Las claves de configuración en `application.properties` controlan su comportamiento:
+
+- `nowbox.lookback` (valor por defecto `PT30M`) define cuán lejos mira al pasado para la actividad "anterior".
+- `nowbox.lookahead` (valor por defecto `PT60M`) limita la búsqueda de la actividad "siguiente".
+- `nowbox.refresh-interval` (valor por defecto `PT30S`) indica al frontend cada cuánto actualizar el bloque.
+
+Si ninguna actividad cae dentro de las ventanas, el evento se omite del Now Box para mantener la sección enfocada en el contexto inmediato.


### PR DESCRIPTION
## Summary
- mark the event and break notification task lists as completed in English and Spanish docs
- extend the global notifications guide with simulation endpoints, admin UI details, and configuration keys
- document the Now Box home section behaviour and configuration for both languages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f81468cc6c833393d1265d8ef87234