### PR TITLE
Add Navia roadmap documentation

### DIFF
--- a/docs/modules/aexperience/navia-roadmap.md
+++ b/docs/modules/aexperience/navia-roadmap.md
@@ -1,0 +1,148 @@
+# 🌊 Navia – Roadmap de la Experiencia Aumentada en Homedir
+
+## 🧠 Contexto
+
+**Navia** es la evolución directa de *EventFlow3 (Surfer View)*, ahora integrada como el **módulo experimental de experiencia aumentada (aExperience)** dentro del proyecto **Homedir**.
+
+Su misión es **rediseñar la forma en que los usuarios interactúan con las plataformas digitales**, reemplazando la navegación tradicional por un modelo adaptativo, guiado por intención e impulsado por IA.
+
+Navia busca crear una interfaz que **aprende del usuario y se adapta a él**, mientras **hace visible y accesible el valor real de las funciones**, eliminando fricción y complejidad.
+
+---
+
+## 💡 Propuesta de Valor
+
+### Pilar 1 – Funciones que se vuelven protagonistas
+El valor de las funcionalidades deja de estar oculto detrás de menús o capas visuales.  
+Navia convierte cada acción en una oportunidad guiada y contextual, donde el usuario simplemente expresa su intención y el sistema responde con orientación directa y proactiva.
+
+> **De la búsqueda manual al descubrimiento inteligente.**
+
+### Pilar 2 – Una interfaz que aprende y se adapta
+Navia analiza las interacciones del usuario para aprender qué tareas realiza con mayor frecuencia y cómo prefiere hacerlo.  
+Con esa información, simplifica la interfaz, prioriza accesos, y ajusta su presentación al estilo y necesidades reales del usuario.
+
+> **De una UI fija a una experiencia evolutiva.**
+
+---
+
+## 🏗️ Arquitectura de Integración
+
+Navia se implementa como un **módulo desacoplado** dentro de Homedir:
+
+```
+homedir/
+├── modules/
+│   ├── aexperience/
+│   │   ├── navia/
+│   │   │   ├── src/
+│   │   │   ├── README.md
+│   │   │   └── manifest.yaml
+```
+
+- **Integrado pero no acoplado:** puede activarse o desactivarse con un *feature flag*.  
+- **UI opt-in:** el usuario puede habilitar la experiencia desde la barra superior →   
+  “🧠 Activar experiencia aumentada (experimental)”.  
+- **Sin impacto en el núcleo:** la desactivación no altera la funcionalidad base de Homedir.
+
+---
+
+## 🔄 Etapas de Desarrollo y Evolución
+
+Las etapas están diseñadas para avanzar desde la experimentación controlada hasta la adopción estable, siguiendo un flujo de **aprendizaje → validación → integración.**
+
+---
+
+### 🧩 **Etapa 1 – Fundamento Experimental (MVP técnico)**
+**Objetivo:** Probar la interacción guiada por intención.
+
+**Basado en EventFlow3 (Surfer View):**
+- Implementar el *Surfer Assistant* como interfaz conversacional y contextual.  
+- Conexión con APIs del core de Homedir (usuarios, eventos, notificaciones).  
+- Introducir el *dock dinámico* con accesos recientes y frecuentes.  
+- Añadir el **flag de activación experimental** (`feature.experimental.navia`).
+
+**Resultado esperado:**  
+Validar que el asistente puede entender y ejecutar tareas dentro del ecosistema Homedir.
+
+---
+
+### 🧠 **Etapa 2 – Aprendizaje Adaptativo**
+**Objetivo:** Que la interfaz empiece a aprender y priorizar.  
+
+**Desarrollos clave:**
+- Registro anónimo de uso (frecuencia de funciones, rutas, comandos).  
+- Modelo de **recomendación local** para ordenar accesos más utilizados.  
+- Personalización de vistas (layout adaptable por usuario).  
+- Persistencia de preferencias y estilo de interacción.
+
+**Resultado esperado:**  
+Demostrar que Navia puede **reducir fricción y simplificar la experiencia** de manera tangible.
+
+---
+
+### ⚡ **Etapa 3 – Experiencia Contextual Inteligente**
+**Objetivo:** Integrar inteligencia predictiva y orientación proactiva.  
+
+**Desarrollos clave:**
+- Incorporar un modelo LLM (LangChain4j) para detección de intención compleja.  
+- Destacar visualmente las acciones más relevantes según contexto (“resalta lo que importa”).  
+- Integrar lenguaje natural + navegación mixta (voz, texto, click).  
+- Panel de “Sugerencias inteligentes”.
+
+**Resultado esperado:**  
+Una experiencia **proactiva, guiada y personalizada**, donde las funciones se presentan antes de que el usuario las busque.
+
+---
+
+### 🌱 **Etapa 4 – Validación de Valor (aExperience Release Candidate)**
+**Objetivo:** Medir impacto y definir adopción estable.  
+
+**Métricas:**
+- Tasa de activación de la experiencia aumentada.  
+- Tareas completadas con éxito vía Navia vs interfaz tradicional.  
+- Reducción en tiempo de navegación o clicks promedio.  
+- Feedback directo del usuario sobre utilidad y satisfacción.
+
+**Criterio de éxito:**  
+Si el uso sostenido y la retroalimentación son positivos, Navia pasa a **feature estable** y deja el estado experimental.
+
+---
+
+### 🚀 **Etapa 5 – Integración Plena y Extensión**
+**Objetivo:** Convertir Navia en parte del ecosistema Homedir a largo plazo.  
+
+**Acciones:**
+- Refactorización y modularización final para `homedir-core`.  
+- Exposición de APIs para que otros módulos (comunidades, proyectos, comunicación) adopten la experiencia aumentada.  
+- Documentación y guía de integración para nuevos desarrolladores.  
+- Declarar versión estable: `Homedir aExperience powered by Navia`.
+
+---
+
+## 🧭 Gobernanza y Transparencia
+
+| Rol | Responsabilidad |
+|------|----------------|
+| **aExperience Lab** | Experimentación, prototipado y métricas. |
+| **Equipo Homedir Core** | Revisión técnica, seguridad y compatibilidad. |
+| **Comunidad OS Santiago** | Testing, feedback y adopción gradual. |
+
+Todas las versiones experimentales estarán **etiquetadas, documentadas y reversibles.**  
+Si una versión no cumple su objetivo, puede **desactivarse o eliminarse** sin impacto en producción.
+
+---
+
+## 🌈 Visión Final
+
+Navia no es solo una mejora de interfaz:  
+es un paso hacia una **nueva forma de relación entre las personas y la tecnología**.  
+Un sistema que entiende, acompaña y evoluciona con el usuario.
+
+> **Del clic al diálogo.  
+> De la navegación al descubrimiento.  
+> De la interfaz estática a la experiencia viva.**
+
+---
+
+**Navia** – *La experiencia aumentada de Homedir, donde el usuario no busca el valor: lo encuentra.*


### PR DESCRIPTION
## Summary
- add the Navia roadmap document under docs/modules/aexperience

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc15ac4dd8833391183f59e1a89139