### PR TITLE
Enable local dev login without Google

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -29,6 +29,15 @@ mvn -f quarkus-app/pom.xml quarkus:dev
 
 Luego navega a `http://localhost:8080`.
 
+### Autenticación local en desarrollo
+El perfil de desarrollo desactiva el inicio de sesión con Google y habilita cuentas en memoria
+definidas en `quarkus-app/src/main/resources/application.properties`:
+
+- `user@example.com` / `userpass` — usuario sin privilegios
+- `admin@example.org` / `adminpass` — administrador
+
+Usa estas credenciales con el formulario de "Modo local" en `/ingresar`.
+
 ### Configuración de Google OAuth 2.0
 Configura estas propiedades en `application.properties` o variables de entorno:
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ mvn -f quarkus-app/pom.xml quarkus:dev
 
 Then browse to `http://localhost:8080`.
 
+### Local authentication in development
+The dev profile disables Google Sign-In and enables in-memory accounts defined in
+`quarkus-app/src/main/resources/application.properties`:
+
+- `user@example.com` / `userpass` — regular user
+- `admin@example.org` / `adminpass` — administrator
+
+Use these credentials with the "Development mode" form on `/ingresar`.
+
 ### Google OAuth 2.0 setup
 Configure these properties in `application.properties` or environment variables:
 

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -68,6 +68,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-jwt</artifactId>
             <optional>true</optional>
         </dependency>

--- a/quarkus-app/src/main/java/com/scanales/eventflow/auth/LoginPageResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/auth/LoginPageResource.java
@@ -7,10 +7,12 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 /** Login page served at /ingresar. */
 @Path("/ingresar")
@@ -20,16 +22,26 @@ public class LoginPageResource {
 
   @CheckedTemplate(basePath = "LoginPage")
   static class Templates {
-    static native TemplateInstance ingresar();
+    static native TemplateInstance ingresar(
+        boolean localEnabled, boolean loginError, String localUsersDescription);
   }
 
   @GET
   @Produces(MediaType.TEXT_HTML)
-  public Response ingresar() {
+  public Response ingresar(@QueryParam("error") String error) {
     if (identity != null && !identity.isAnonymous()) {
       return Response.seeOther(URI.create("/profile")).build();
     }
-    return Response.ok(Templates.ingresar())
+    boolean loginError = error != null;
+    boolean localEnabled =
+        ConfigProvider.getConfig()
+            .getOptionalValue("app.auth.local-enabled", Boolean.class)
+            .orElse(false);
+    String localUsersDescription =
+        ConfigProvider.getConfig()
+            .getOptionalValue("app.auth.local-users", String.class)
+            .orElse("");
+    return Response.ok(Templates.ingresar(localEnabled, loginError, localUsersDescription))
         .header(HttpHeaders.CACHE_CONTROL, "no-store, no-cache, must-revalidate")
         .header("Pragma", "no-cache")
         .header("Vary", "Cookie")

--- a/quarkus-app/src/main/java/com/scanales/eventflow/security/LocalDevIdentityAugmentor.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/security/LocalDevIdentityAugmentor.java
@@ -1,0 +1,46 @@
+package com.scanales.eventflow.security;
+
+import io.quarkus.arc.profile.IfBuildProfile;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+/** Adds default identity attributes for the embedded dev users. */
+@ApplicationScoped
+@IfBuildProfile("dev")
+public class LocalDevIdentityAugmentor implements SecurityIdentityAugmentor {
+
+  @Override
+  public Uni<SecurityIdentity> augment(
+      SecurityIdentity identity, AuthenticationRequestContext context) {
+    boolean localAuthEnabled =
+        ConfigProvider.getConfig()
+            .getOptionalValue("app.auth.local-enabled", Boolean.class)
+            .orElse(false);
+    if (!localAuthEnabled || identity == null || identity.isAnonymous()) {
+      return Uni.createFrom().item(identity);
+    }
+    boolean hasEmail = identity.getAttribute("email") != null;
+    boolean hasName = identity.getAttribute("name") != null;
+    if (hasEmail && hasName) {
+      return Uni.createFrom().item(identity);
+    }
+    QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
+    if (!hasEmail) {
+      builder.addAttribute("email", identity.getPrincipal().getName());
+    }
+    if (!hasName) {
+      builder.addAttribute("name", identity.getPrincipal().getName());
+    }
+    return Uni.createFrom().item(builder.build());
+  }
+
+  @Override
+  public int priority() {
+    return 0;
+  }
+}

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -2,8 +2,8 @@
 quarkus.oidc.provider=google
 quarkus.oidc.application-type=web-app
 quarkus.oidc.authentication.redirect-path=/auth/post-login
-quarkus.oidc.client-id=${OIDC_CLIENT_ID}
-quarkus.oidc.credentials.secret=${OIDC_CLIENT_SECRET}
+quarkus.oidc.client-id=${OIDC_CLIENT_ID:dev-client}
+quarkus.oidc.credentials.secret=${OIDC_CLIENT_SECRET:dev-secret}
 quarkus.oidc.authentication.scopes=openid profile email
 quarkus.oidc.logout.post-logout-path=/
 # Disable Quarkus built-in logout as Google does not provide an
@@ -41,6 +41,25 @@ quarkus.http.auth.session.encryption-key=${SESSION_KEY}
 quarkus.http.auth.session.timeout=PT15M
 quarkus.http.auth.permission.private.paths=/private/*
 quarkus.http.auth.permission.private.policy=authenticated
+
+# Local development authentication (disabled outside the dev profile)
+%dev.quarkus.oidc.enabled=false
+%dev.quarkus.security.users.embedded.enabled=true
+%dev.quarkus.security.users.embedded.plain-text=true
+%dev.quarkus.security.users.embedded.users.user@example.com=userpass
+%dev.quarkus.security.users.embedded.roles.user@example.com=user
+%dev.quarkus.security.users.embedded.users.admin@example.org=adminpass
+%dev.quarkus.security.users.embedded.roles.admin@example.org=admin,user
+%dev.quarkus.http.auth.form.enabled=true
+%dev.quarkus.http.auth.form.login-page=/ingresar
+%dev.quarkus.http.auth.form.error-page=/ingresar?error=1
+%dev.quarkus.http.auth.form.post-location=/j_security_check
+%dev.quarkus.http.auth.form.username-parameter=username
+%dev.quarkus.http.auth.form.password-parameter=password
+%dev.quarkus.http.auth.form.landing-page=/profile
+%dev.ADMIN_LIST=admin@example.org,sergio.canales.e@gmail.com
+%dev.app.auth.local-enabled=true
+%dev.app.auth.local-users=usuario: user@example.com / userpass; admin: admin@example.org / adminpass
 
 # Comma separated list of admin emails
 ADMIN_LIST=sergio.canales.e@gmail.com

--- a/quarkus-app/src/main/resources/templates/LoginPage/ingresar.html
+++ b/quarkus-app/src/main/resources/templates/LoginPage/ingresar.html
@@ -2,9 +2,51 @@
 {#title}Ingresar{/title}
 {#main}
 <h1>Ingresar</h1>
+{#if loginError}
+<div class="alert alert-danger" role="alert">
+  No se pudo iniciar sesión. Verifica tus credenciales e inténtalo nuevamente.
+</div>
+{/if}
 <p>
   <a href="/profile" class="btn btn-primary login-button">Ingresar con Google</a>
 </p>
+{#if localEnabled}
+<section class="card my-4">
+  <div class="card-body">
+    <h2 class="card-title h5">Modo local de desarrollo</h2>
+    <p class="card-text">
+      Usa las credenciales definidas en <code>application.properties</code> para iniciar sesión sin
+      depender de Google.
+    </p>
+    {#if localUsersDescription}
+    <p class="card-text"><strong>Cuentas disponibles:</strong> {localUsersDescription}</p>
+    {/if}
+    <form method="post" action="/j_security_check" class="mt-3" novalidate>
+      <div class="mb-3">
+        <label for="username" class="form-label">Correo electrónico</label>
+        <input
+          id="username"
+          name="username"
+          type="email"
+          class="form-control"
+          autocomplete="username"
+          required>
+      </div>
+      <div class="mb-3">
+        <label for="password" class="form-label">Contraseña</label>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          class="form-control"
+          autocomplete="current-password"
+          required>
+      </div>
+      <button type="submit" class="btn btn-outline-primary">Ingresar en modo local</button>
+    </form>
+  </div>
+</section>
+{/if}
 <p><a href="/">Volver al inicio</a></p>
 {/main}
 {/include}


### PR DESCRIPTION
## Summary
- disable Google OIDC in the dev profile and configure embedded users for local testing
- add a development login form and identity augmentor to surface local account attributes
- document the local credentials and include the security properties dependency

## Testing
- mvn -f quarkus-app/pom.xml test

------
https://chatgpt.com/codex/tasks/task_e_68fc1bf5c90c8333abfcde97404f9354