### PR TITLE
feat: add navia elevenlabs mvp tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+ELEVENLABS_API_KEY=changeme
+ELEVENLABS_BASE_URL=https://api.elevenlabs.io
+NAVIA_CACHE_DIR=./.navia/site-cache
+NAVIA_CHUNK_DIR=./.navia/chunks
+NAVIA_SITE_BASE=http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,10 @@ buildNumber.properties
 
 # Cosign key material
 cosign.key
+
+# Navia MVP artifacts
+.navia/
+.env
+.venv/
+__pycache__/
+

--- a/README.es.md
+++ b/README.es.md
@@ -69,3 +69,7 @@ La compilación produce SBOMs para dependencias e imágenes de contenedor y esca
 Proyecto respaldado por la comunidad OpenSource Santiago. Únete a nuestro [servidor de Discord](https://discord.gg/3eawzc9ybc).
 
 Para divulgación coordinada de vulnerabilidades, consulta [SECURITY.es.md](SECURITY.es.md).
+
+## Integración Navia × ElevenLabs
+Para ejecutar el MVP local que valida cache + RAG consulta [docs/es/navia-elevenlabs-mvp.md](docs/es/navia-elevenlabs-mvp.md).
+

--- a/docs/es/navia-elevenlabs-mvp.md
+++ b/docs/es/navia-elevenlabs-mvp.md
@@ -1,0 +1,82 @@
+# Navia × ElevenLabs — MVP local
+
+Este documento describe cómo reproducir el MVP que valida la integración entre el cache de Navia y los Agents de ElevenLabs utilizando RAG para respuestas con trazabilidad.
+
+## 1. Preparación
+
+1. Levanta EventFlow (o el sitio a indexar) en `http://localhost:8080`.
+2. Copia `.env.example` a `.env` y completa `ELEVENLABS_API_KEY`.
+3. Crea y activa un entorno virtual de Python, luego instala dependencias mínimas:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install beautifulsoup4 requests
+```
+
+> Nota: todos los comandos se asumen desde la raíz del repositorio.
+
+## 2. Cache del sitio
+
+```bash
+mkdir -p ./.navia/site-cache/raw
+wget \
+  --recursive --page-requisites --html-extension \
+  --convert-links --no-parent --adjust-extension \
+  --directory-prefix=./.navia/site-cache/raw \
+  http://localhost:8080/
+```
+
+El resultado es una copia navegable en `./.navia/site-cache/raw`.
+
+## 3. Normalización y chunking
+
+Convierte los HTML cacheados a texto, conserva metadatos relevantes y crea chunks reutilizables por RAG.
+
+```bash
+python scripts/normalize_and_chunk.py
+```
+
+El script genera archivos JSON en `./.navia/chunks/` con el texto y metadatos necesarios (`source_url`, `doc_id`, etc.).
+
+## 4. Crear el agente de ElevenLabs
+
+```bash
+ELEVENLABS_API_KEY=... scripts/create_agent.sh
+```
+
+El comando crea un agente en modo texto con RAG habilitado y guarda el resultado en `./.navia/agent.json`.
+
+## 5. Subir chunks y construir el índice RAG
+
+```bash
+python scripts/upload_chunks.py
+```
+
+Cada chunk se carga como documento en la base de conocimiento del agente y se indexa inmediatamente para RAG.
+
+## 6. Consultar al agente
+
+```bash
+python scripts/ask_agent.py
+```
+
+El flujo crea una conversación, envía la pregunta y muestra tanto la respuesta como las URLs de origen de los documentos consultados. Si la API no devuelve referencias directas, el script realiza un mapeo `doc_id → metadata` para preservar la trazabilidad.
+
+## 7. Renderizar HTML confiable
+
+Para presentar contenido sin alucinaciones, renderiza el HTML directamente desde el cache local:
+
+```bash
+python scripts/render_from_cache.py http://localhost:8080/ruta/del/recurso
+```
+
+Opcionalmente añade un `anchor` como segundo argumento para devolver solo un fragmento.
+
+## 8. Métricas de validación
+
+- % de consultas con al menos una fuente válida.
+- Latencia p50 de las consultas (RAG agrega ~500 ms).
+- Exactitud de la URL/fragmento devuelto en un set de pruebas canónicas.
+
+Con estos pasos dispones de un MVP funcional que demuestra la cadena completa: cache local → normalización → ingestión ElevenLabs → consulta con RAG → renderizado confiable desde el cache.

--- a/scripts/ask_agent.py
+++ b/scripts/ask_agent.py
@@ -1,0 +1,107 @@
+import json
+import os
+import time
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import requests
+
+API = os.environ.get("ELEVENLABS_BASE_URL", "https://api.elevenlabs.io")
+KEY = os.environ["ELEVENLABS_API_KEY"]
+AGENT_PATH = Path("./.navia/agent.json")
+
+if not AGENT_PATH.exists():
+    raise SystemExit("No se encontró ./.navia/agent.json. Ejecuta scripts/create_agent.sh primero.")
+
+AGENT = json.loads(AGENT_PATH.read_text())["id"]
+HEADERS = {"xi-api-key": KEY, "Content-Type": "application/json"}
+
+
+def map_documents(agent_id: str) -> Dict[str, Dict]:
+    """Return a mapping doc_id -> metadata by walking the knowledge base."""
+    url = f"{API}/v1/agents/{agent_id}/knowledge-base/documents"
+    response = requests.get(url, headers={"xi-api-key": KEY}, timeout=60)
+    response.raise_for_status()
+    payload = response.json()
+    if isinstance(payload, dict):
+        docs = payload.get("documents", [])
+    else:
+        docs = payload
+    mapping = {}
+    for doc in docs:
+        mapping[doc["id"]] = doc.get("metadata", {})
+    return mapping
+
+
+def poll_conversation(conv_id: str, delay: float = 1.0, attempts: int = 10) -> dict:
+    url = f"{API}/v1/agents/{AGENT}/conversations/{conv_id}"
+    for _ in range(attempts):
+        response = requests.get(url, headers=HEADERS, timeout=60)
+        response.raise_for_status()
+        data = response.json()
+        messages: List[dict] = data.get("messages", [])
+        if messages and messages[-1].get("role") == "assistant":
+            return data
+        time.sleep(delay)
+    return data
+
+
+def extract_references(payload: dict) -> Iterable[Dict]:
+    refs = payload.get("rag_references") or []
+    if refs:
+        return refs
+    # Fallback: ElevenLabs may expose doc IDs in conversation metadata
+    last_message = payload.get("messages", [{}])[-1]
+    return last_message.get("documents", [])
+
+
+def main() -> None:
+    question = input("Pregunta (ej: ¿Dónde está el evento 'Test event'?): ")
+
+    conv_response = requests.post(
+        f"{API}/v1/agents/{AGENT}/conversations", headers=HEADERS, json={"mode": "text"}, timeout=60
+    )
+    conv_response.raise_for_status()
+    conversation = conv_response.json()
+    conv_id = conversation["id"]
+
+    requests.post(
+        f"{API}/v1/agents/{AGENT}/conversations/{conv_id}/messages",
+        headers=HEADERS,
+        json={"role": "user", "content": question},
+        timeout=60,
+    ).raise_for_status()
+
+    data = poll_conversation(conv_id)
+
+    answer = data.get("messages", [{}])[-1].get("content", "(sin respuesta)")
+    print("\n=== RESPUESTA DEL AGENTE ===\n", answer)
+
+    references = list(extract_references(data))
+    if not references:
+        print("\nNo se recibieron referencias directas. Intentando mapear doc_ids → metadata...")
+        docs = map_documents(AGENT)
+        doc_ids = set()
+        for ref in data.get("messages", []):
+            for document in ref.get("documents", []) or []:
+                if isinstance(document, dict):
+                    doc_ids.add(document.get("id") or document.get("doc_id"))
+                else:
+                    doc_ids.add(document)
+        references = [
+            {"document": {"metadata": docs.get(doc_id, {"doc_id": doc_id})}}
+            for doc_id in doc_ids
+            if doc_id
+        ]
+
+    if references:
+        print("\nFuentes:")
+        for ref in references:
+            metadata = (ref.get("document") or {}).get("metadata", {})
+            print("-", metadata.get("source_url") or metadata.get("doc_id", "(sin url)"))
+    else:
+        print("\n(Sin referencias disponibles. Revisa la configuración del agente RAG.)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/create_agent.sh
+++ b/scripts/create_agent.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${ELEVENLABS_API_KEY:?Missing ELEVENLABS_API_KEY}"
+: "${ELEVENLABS_BASE_URL:=https://api.elevenlabs.io}"
+
+mkdir -p ./.navia
+
+curl -s -X POST "${ELEVENLABS_BASE_URL}/v1/agents" \
+  -H "xi-api-key: ${ELEVENLABS_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Navia MVP Agent",
+    "description": "Agente para responder preguntas sobre el contenido del sitio EventFlow cacheado",
+    "text_only": true,
+    "voice_enabled": false,
+    "rag_enabled": true
+  }' | tee ./.navia/agent.json

--- a/scripts/normalize_and_chunk.py
+++ b/scripts/normalize_and_chunk.py
@@ -1,0 +1,63 @@
+import json
+import hashlib
+import os
+import pathlib
+from typing import Iterable
+
+from bs4 import BeautifulSoup
+
+RAW_CACHE = pathlib.Path(os.environ.get("NAVIA_CACHE_DIR", "./.navia/site-cache")) / "raw"
+CHUNK_DIR = pathlib.Path(os.environ.get("NAVIA_CHUNK_DIR", "./.navia/chunks"))
+CHUNK_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def clean_text(html: str) -> str:
+    """Return a lightly normalised text version of the HTML document."""
+    soup = BeautifulSoup(html, "html.parser")
+    # Preserve original anchors so we can map chunks back to fragments later on.
+    for tag in soup.find_all(True):
+        if "id" in tag.attrs:
+            tag["data-anchor-id"] = tag["id"]
+    return soup.get_text("\n", strip=True)
+
+
+def chunk_text(text: str, max_len: int = 1200) -> Iterable[str]:
+    """Yield chunks of roughly ``max_len`` tokens (approximated with words)."""
+    words = text.split()
+    for index in range(0, len(words), max_len):
+        yield " ".join(words[index : index + max_len])
+
+
+def main() -> None:
+    records = []
+    if not RAW_CACHE.exists():
+        raise SystemExit(f'No se encontró el cache en {RAW_CACHE}. Ejecuta el scrape primero.')
+
+    base_url = os.environ.get("NAVIA_SITE_BASE", "http://localhost:8080")
+
+    for path in RAW_CACHE.rglob("*.html"):
+        url_suffix = '/' + str(path.relative_to(RAW_CACHE)).replace('\\', '/')
+        url = base_url.rstrip('/') + url_suffix
+        html = path.read_text(errors="ignore")
+        text = clean_text(html)
+        if len(text) < 40:
+            continue
+
+        for chunk_index, chunk in enumerate(chunk_text(text)):
+            doc_id = hashlib.md5((url + str(chunk_index)).encode()).hexdigest()
+            metadata = {
+                "doc_id": doc_id,
+                "source_url": url,
+                "source_path": str(path),
+                "chunk_index": chunk_index,
+                "title_guess": path.stem.replace("-", " ").title(),
+            }
+            out_path = CHUNK_DIR / f"{doc_id}.json"
+            out_path.write_text(json.dumps({"meta": metadata, "text": chunk}, ensure_ascii=False), encoding="utf-8")
+            records.append(metadata)
+
+    print(f"Chunks creados: {len(records)} → {CHUNK_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/render_from_cache.py
+++ b/scripts/render_from_cache.py
@@ -1,0 +1,51 @@
+import os
+import pathlib
+import sys
+from typing import Optional
+
+CACHE_DIR = pathlib.Path(os.environ.get("NAVIA_CACHE_DIR", "./.navia/site-cache"))
+RAW_DIR = CACHE_DIR / "raw"
+
+
+def page_path_from_url(url: str) -> pathlib.Path:
+    base = os.environ.get("NAVIA_SITE_BASE", "http://localhost:8080")
+    if not url.startswith(base):
+        raise ValueError(f"La URL '{url}' no pertenece a la base configurada {base}.")
+    suffix = url[len(base) :]
+    raw_path = RAW_DIR / suffix.lstrip("/")
+    if raw_path.is_dir():
+        raw_path = raw_path / "index.html"
+    return raw_path
+
+
+def extract_fragment(html: str, anchor: Optional[str]) -> str:
+    if not anchor:
+        return html
+    marker = f'id="{anchor}"'
+    if marker not in html:
+        return html
+    _, _, rest = html.partition(marker)
+    snippet = rest.split("</", 1)[0]
+    return f"<div id=\"{anchor}\">{snippet}</div>"
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit("Uso: python scripts/render_from_cache.py <url> [anchor]")
+
+    url = sys.argv[1]
+    anchor = sys.argv[2] if len(sys.argv) > 2 else None
+
+    path = page_path_from_url(url)
+    if not path.exists():
+        raise SystemExit(f"No se encontró la página cacheada en {path}.")
+
+    html = path.read_text(errors="ignore")
+    fragment = extract_fragment(html, anchor)
+
+    print(f"<!-- Origen: {url} -->")
+    print(fragment)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upload_chunks.py
+++ b/scripts/upload_chunks.py
@@ -1,0 +1,51 @@
+import glob
+import json
+import os
+import time
+from pathlib import Path
+
+import requests
+
+API = os.environ.get("ELEVENLABS_BASE_URL", "https://api.elevenlabs.io")
+KEY = os.environ["ELEVENLABS_API_KEY"]
+AGENT_PATH = Path("./.navia/agent.json")
+
+if not AGENT_PATH.exists():
+    raise SystemExit("No se encontró ./.navia/agent.json. Ejecuta scripts/create_agent.sh primero.")
+
+AGENT = json.loads(AGENT_PATH.read_text())["id"]
+HEADERS = {"xi-api-key": KEY, "Content-Type": "application/json"}
+
+
+def create_doc(agent_id: str, meta: dict, text: str) -> dict:
+    url = f"{API}/v1/agents/{agent_id}/knowledge-base/documents"
+    payload = {"title": meta.get("title_guess", "Navia Chunk"), "metadata": meta, "text": text}
+    response = requests.post(url, headers=HEADERS, json=payload, timeout=60)
+    response.raise_for_status()
+    return response.json()
+
+
+def compute_rag(agent_id: str, doc_id: str) -> dict:
+    url = f"{API}/v1/agents/{agent_id}/knowledge-base/documents/{doc_id}/rag-index"
+    response = requests.post(url, headers=HEADERS, timeout=60)
+    response.raise_for_status()
+    return response.json()
+
+
+def main() -> None:
+    files = glob.glob("./.navia/chunks/*.json")
+    if not files:
+        raise SystemExit("No se encontraron chunks en ./.navia/chunks. Ejecuta scripts/normalize_and_chunk.py primero.")
+
+    for index, file_path in enumerate(files, start=1):
+        data = json.loads(Path(file_path).read_text())
+        doc = create_doc(AGENT, data["meta"], data["text"])
+        compute_rag(AGENT, doc["id"])
+        if index % 25 == 0:
+            time.sleep(1)
+
+    print(f"Subidos {len(files)} chunks al agente {AGENT}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add scripts to normalise cached HTML, upload chunks to ElevenLabs, and query agents with RAG references
- document the local Navia × ElevenLabs MVP workflow and expose the guide from the Spanish README
- provide environment defaults and cache rendering helper while ignoring local artifacts

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68fcd2f10624833384e153e6fe9673e5