### PR TITLE
Handle missing ElevenLabs API key in upload_chunks script

### DIFF
--- a/scripts/upload_chunks.py
+++ b/scripts/upload_chunks.py
@@ -7,7 +7,12 @@ from pathlib import Path
 import requests
 
 API = os.environ.get("ELEVENLABS_BASE_URL", "https://api.elevenlabs.io")
-KEY = os.environ["ELEVENLABS_API_KEY"]
+KEY = os.environ.get("ELEVENLABS_API_KEY")
+if not KEY:
+    raise SystemExit(
+        "No se encontró la variable de entorno ELEVENLABS_API_KEY. "
+        "Configúrala con tu API key de ElevenLabs antes de ejecutar este script."
+    )
 AGENT_PATH = Path("./.navia/agent.json")
 DOC_MAP_PATH = Path("./.navia/documents.json")
 


### PR DESCRIPTION
## Summary
- stop upload_chunks.py from crashing when ELEVENLABS_API_KEY is unset
- provide a clear instruction on how to configure the required API key

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcea73cc808333bec1cd1f3d5dbd7c