### PR TITLE
Fix upload chunk content type

### DIFF
--- a/scripts/upload_chunks.py
+++ b/scripts/upload_chunks.py
@@ -60,7 +60,7 @@ def create_doc(agent_id: str, meta: dict, text: str, index: int) -> dict:
     if metadata:
         data["metadata"] = json.dumps(metadata, ensure_ascii=False)
     filename = f"chunk-{index}.txt"
-    files = {"file": (filename, text.encode("utf-8"), "text/plain; charset=utf-8")}
+    files = {"file": (filename, text.encode("utf-8"), "text/plain")}
     response = requests.post(url, headers=AUTH_HEADERS, params=params, data=data, files=files, timeout=60)
     try:
         response.raise_for_status()


### PR DESCRIPTION
## Summary
- adjust upload script to send text chunks with the plain text content type expected by ElevenLabs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fced3bd8808333bcde5da2a02fecc4