### PR TITLE
Handle 405 responses when falling back to shared ConvAI endpoints

### DIFF
--- a/scripts/ask_agent.py
+++ b/scripts/ask_agent.py
@@ -108,7 +108,7 @@ def request_with_fallback(
         timeout=timeout,
     )
 
-    if response.status_code == 404 and fallback_path:
+    if response.status_code in {404, 405} and fallback_path:
         fallback_json = clone_payload(json_payload)
         fallback_params = clone_payload(params)
 


### PR DESCRIPTION
## Summary
- allow ConvAI requests to retry against the shared endpoint when the agent-scoped path returns HTTP 405

## Testing
- not run (requires external service access)


------
https://chatgpt.com/codex/tasks/task_e_68fcefc218588333b08a6a5561069eb9