### PR TITLE
Fix conversation creation endpoint

### DIFF
--- a/scripts/ask_agent.py
+++ b/scripts/ask_agent.py
@@ -166,8 +166,8 @@ def main() -> None:
 
     conv_response = request_with_fallback(
         "POST",
-        "/v1/convai/agents/{agent_id}/conversations",
-        fallback_path="/v1/convai/conversations",
+        "/v1/convai/agents/{agent_id}/conversations/initiate",
+        fallback_path="/v1/convai/conversations/initiate",
         json_payload={"mode": "text", "agent_id": AGENT},
     )
     conversation = conv_response.json()


### PR DESCRIPTION
## Summary
- update the conversation creation request to use the new `/conversations/initiate` endpoint so that the API no longer returns 405

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcf11e41048333ad953adf66b48e39