### PR TITLE
Fix fallback endpoints for ElevenLabs conversations

### DIFF
--- a/scripts/ask_agent.py
+++ b/scripts/ask_agent.py
@@ -179,7 +179,7 @@ def main() -> None:
     conv_response = request_with_fallback(
         "POST",
         "/v1/convai/agents/{agent_id}/conversations",
-        fallback_path="/v1/convai/conversations",
+        fallback_path="/v1/convai/conversations/create",
         json_payload={"mode": "text", "agent_id": AGENT},
     )
     conversation = conv_response.json()
@@ -194,7 +194,7 @@ def main() -> None:
     request_with_fallback(
         "POST",
         f"/v1/convai/agents/{{agent_id}}/conversations/{conv_id}/messages",
-        fallback_path=f"/v1/convai/conversations/{conv_id}/messages",
+        fallback_path=f"/v1/convai/conversations/{conv_id}/messages/create",
         json_payload={"role": "user", "content": question, "agent_id": AGENT},
     )
 


### PR DESCRIPTION
## Summary
- switch the fallback conversation creation request to /v1/convai/conversations/create
- update the message creation fallback to /v1/convai/conversations/{id}/messages/create

## Testing
- python -m compileall scripts/ask_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68fcf4d85660833388b218462ce5ac49