### PR TITLE
Fix ConvAI conversation fallback endpoints

### DIFF
--- a/scripts/ask_agent.py
+++ b/scripts/ask_agent.py
@@ -179,7 +179,7 @@ def main() -> None:
     conv_response = request_with_fallback(
         "POST",
         "/v1/convai/agents/{agent_id}/conversations",
-        fallback_path="/v1/convai/conversations/create",
+        fallback_path="/v1/convai/conversations",
         json_payload={"mode": "text", "agent_id": AGENT},
     )
     conversation = conv_response.json()
@@ -194,7 +194,7 @@ def main() -> None:
     request_with_fallback(
         "POST",
         f"/v1/convai/agents/{{agent_id}}/conversations/{conv_id}/messages",
-        fallback_path=f"/v1/convai/conversations/{conv_id}/messages/create",
+        fallback_path=f"/v1/convai/conversations/{conv_id}/messages",
         json_payload={"role": "user", "content": question, "agent_id": AGENT},
     )
 


### PR DESCRIPTION
## Summary
- update the shared ConvAI conversation creation fallback to use the documented `/v1/convai/conversations` endpoint
- drop the legacy `/create` suffix from the shared message fallback path so POST requests hit `/v1/convai/conversations/{id}/messages`

## Testing
- python -m compileall scripts/ask_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68fcf8c2db0c83339883a4a59e41ce42