### PR TITLE
Fix conversation creation fallback method

### DIFF
--- a/scripts/ask_agent.py
+++ b/scripts/ask_agent.py
@@ -222,7 +222,7 @@ def main() -> None:
             "POST",
             "/v1/convai/agents/{agent_id}/conversations",
             fallback_path="/v1/convai/conversations",
-            fallback_method="GET",
+            fallback_method="POST",
             json_payload={"mode": "text", "agent_id": AGENT},
         )
     except requests.HTTPError as exc:


### PR DESCRIPTION
## Summary
- ensure the fallback path for conversation creation uses POST instead of GET so the API returns a conversation id

## Testing
- not run (API key required)

------
https://chatgpt.com/codex/tasks/task_e_68fcffc96a708333af82a4b3a1f15d88