### PR TITLE
Fix agent conversation creation API call

### DIFF
--- a/scripts/ask_agent.py
+++ b/scripts/ask_agent.py
@@ -263,7 +263,7 @@ def main() -> None:
     try:
         conv_response = request_with_fallback(
             "POST",
-            "/v1/convai/agents/{agent_id}/conversations",
+            "/v1/convai/agents/{agent_id}/conversations/create",
             # According to the public API docs the non agent scoped endpoint uses the
             # ``/create`` suffix for conversation creation. Using ``/v1/convai/conversations``
             # results in a 405 Method Not Allowed response.


### PR DESCRIPTION
## Summary
- call the agent-scoped conversation creation endpoint with the `/create` suffix to avoid 405 responses

## Testing
- python -m compileall scripts/ask_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68fd0b57869c8333aac07587dd4848ad