### PR TITLE
Handle missing ElevenLabs dependency in ask_agent script

### DIFF
--- a/docs/es/navia-elevenlabs-mvp.md
+++ b/docs/es/navia-elevenlabs-mvp.md
@@ -11,7 +11,7 @@ Este documento describe cómo reproducir el MVP que valida la integración entre
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install beautifulsoup4 requests
+pip install beautifulsoup4 requests elevenlabs
 ```
 
 > Nota: todos los comandos se asumen desde la raíz del repositorio.

--- a/scripts/ask_agent.py
+++ b/scripts/ask_agent.py
@@ -25,12 +25,18 @@ import sys
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
-from elevenlabs.client import ElevenLabs
-from elevenlabs.conversational_ai.conversation import (
-    AudioInterface,
-    Conversation,
-    ConversationInitiationData,
-)
+try:
+    from elevenlabs.client import ElevenLabs
+    from elevenlabs.conversational_ai.conversation import (
+        AudioInterface,
+        Conversation,
+        ConversationInitiationData,
+    )
+except ModuleNotFoundError as exc:  # pragma: no cover - dependency error path
+    raise SystemExit(
+        "No se encontró la dependencia 'elevenlabs'. "
+        "Instálala con 'pip install elevenlabs' y vuelve a intentar."
+    ) from exc
 
 AGENT_PATH = Path("./.navia/agent.json")
 DOC_MAP_PATH = Path("./.navia/documents.json")


### PR DESCRIPTION
## Summary
- add a helpful error message when the ElevenLabs SDK is not installed
- document the ElevenLabs dependency in the local MVP setup guide

## Testing
- python -m compileall scripts/ask_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68fd188750908333b08c60a5c66ffe98