### PR TITLE
Add content field to chunk output

### DIFF
--- a/scripts/normalize_and_chunk.py
+++ b/scripts/normalize_and_chunk.py
@@ -53,7 +53,10 @@ def main() -> None:
                 "title_guess": path.stem.replace("-", " ").title(),
             }
             out_path = CHUNK_DIR / f"{doc_id}.json"
-            out_path.write_text(json.dumps({"meta": metadata, "text": chunk}, ensure_ascii=False), encoding="utf-8")
+            out_path.write_text(
+                json.dumps({"meta": metadata, "content": chunk, "text": chunk}, ensure_ascii=False),
+                encoding="utf-8",
+            )
             records.append(metadata)
 
     print(f"Chunks creados: {len(records)} → {CHUNK_DIR}")


### PR DESCRIPTION
## Summary
- add a content attribute to chunk JSON output so extracted HTML text is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd26dbb8a88333a19aa895ace7ca90