### PR TITLE
Refuerza la búsqueda RAG con URLs verificables

### DIFF
--- a/docs/es/navia-elevenlabs-mvp.md
+++ b/docs/es/navia-elevenlabs-mvp.md
@@ -45,7 +45,7 @@ El script genera archivos JSON en `./.navia/chunks/` con el texto y metadatos ne
 ELEVENLABS_API_KEY=... scripts/create_agent.sh
 ```
 
-El comando crea un agente en modo texto con RAG habilitado y guarda el resultado en `./.navia/agent.json`.
+El comando crea un agente en modo texto con RAG habilitado, instruido para buscar el contenido solicitado dentro de los chunks recuperados, corroborar que coincide y responder únicamente con evidencias recuperadas del índice señalando la URL (`source_url`) correspondiente. El resultado se guarda en `./.navia/agent.json`.
 
 ## 5. Subir chunks y construir el índice RAG
 

--- a/scripts/create_agent.sh
+++ b/scripts/create_agent.sh
@@ -19,10 +19,10 @@ cat >"${payload_tmp}" <<'JSON'
 {
   "conversation_config": {
     "agent": {
-      "first_message": "Hola, soy Navia. ¿En qué puedo ayudarte?",
+      "first_message": "Hola, soy Navia. Buscaré en mis documentos indexados y te responderé solo con información verificada indicando la URL exacta de donde proviene.",
       "language": "es",
       "prompt": {
-        "prompt": "Eres Navia, un asistente experto en el contenido cacheado del sitio EventFlow. Responde en español y cita la información relevante cuando la tengas.",
+        "prompt": "Eres Navia, un asistente experto en el contenido cacheado del sitio EventFlow. Tu tarea es buscar el contenido solicitado por la persona usuaria dentro de los chunks recuperados por RAG, verificar que el texto del chunk (campo content) coincide con lo pedido y responder en español citando la URL del metadata (source_url) desde la que proviene la evidencia. Usa exclusivamente la información recuperada mediante RAG desde tu base de conocimiento y, si no existe evidencia suficiente o el chunk no coincide, responde de forma explícita que no cuentas con datos para responder.",
         "llm": "gpt-4o-mini",
         "rag": {
           "enabled": true,


### PR DESCRIPTION
## Summary
- ajusta el mensaje inicial del agente para aclarar que buscará en el índice y devolverá la URL exacta de la evidencia
- actualiza las instrucciones del prompt para exigir coincidencia del contenido y citar el `source_url` del metadata recuperado
- documenta que el agente solo responde tras validar el chunk y reportar la URL de origen

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fd2bb9ba30833382a2dd39bd46bb3b