### PR TITLE
Remove latency indicator from ask_agent script

### DIFF
--- a/scripts/ask_agent.py
+++ b/scripts/ask_agent.py
@@ -564,7 +564,6 @@ async def main_async(args: argparse.Namespace) -> None:
         ),
         callback_agent_response=collector.handle_agent_response,
         callback_user_transcript=prompt_printer.make_printer("👤 Usuario: "),
-        callback_latency_measurement=prompt_printer.make_printer("⏱️ Latencia: "),
     )
 
     conversation.start_session()


### PR DESCRIPTION
## Summary
- remove the latency measurement callback from the ask_agent script so the latency indicator is no longer displayed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fd421a86d8833392190b9f855d1ccd