### PR TITLE
Include original HTML in chunk content

### DIFF
--- a/scripts/normalize_and_chunk.py
+++ b/scripts/normalize_and_chunk.py
@@ -61,7 +61,14 @@ def main() -> None:
             }
             out_path = CHUNK_DIR / f"{doc_id}.json"
             out_path.write_text(
-                json.dumps({"meta": metadata, "content": chunk, "text": chunk}, ensure_ascii=False),
+                json.dumps(
+                    {
+                        "meta": metadata,
+                        "content": f"{url}\n{html}",
+                        "text": chunk,
+                    },
+                    ensure_ascii=False,
+                ),
                 encoding="utf-8",
             )
             records.append(metadata)


### PR DESCRIPTION
## Summary
- update chunk generation to embed the source URL and original HTML in the content field

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd440effc48333835e9886562816c9