### PR TITLE
Update chunk output format to include URL and HTML

### DIFF
--- a/scripts/normalize_and_chunk.py
+++ b/scripts/normalize_and_chunk.py
@@ -63,9 +63,8 @@ def main() -> None:
             out_path.write_text(
                 json.dumps(
                     {
-                        "meta": metadata,
-                        "content": f"{url}\n{html}",
-                        "text": chunk,
+                        "text": f"{url}\n{html}",
+                        "name": metadata["doc_id"],
                     },
                     ensure_ascii=False,
                 ),


### PR DESCRIPTION
## Summary
- update `scripts/normalize_and_chunk.py` to emit JSON objects with only `text` and `name` fields
- populate `text` with the source URL and raw HTML, and `name` with the generated document identifier

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fd4bf834448333b45b669a1f186f41