### PR TITLE
Fix URL generation in normalize_and_chunk

### DIFF
--- a/scripts/normalize_and_chunk.py
+++ b/scripts/normalize_and_chunk.py
@@ -3,6 +3,7 @@ import hashlib
 import os
 import pathlib
 from typing import Iterable
+from urllib.parse import urlparse
 
 from bs4 import BeautifulSoup
 
@@ -36,13 +37,20 @@ def main() -> None:
         raise SystemExit(f'No se encontró el cache en {RAW_CACHE}. Ejecuta el scrape primero.')
 
     base_url = os.environ.get("NAVIA_SITE_BASE", "http://localhost:8080")
+    parsed_base_url = urlparse(base_url)
+    base_netloc = parsed_base_url.netloc or parsed_base_url.path.lstrip("/")
 
     for path in RAW_CACHE.rglob("*.html"):
-        url_suffix = '/' + str(path.relative_to(RAW_CACHE)).replace('\\', '/')
+        relative_path = path.relative_to(RAW_CACHE)
+        relative_parts = list(relative_path.parts)
+        if base_netloc and relative_parts and relative_parts[0] == base_netloc:
+            relative_parts = relative_parts[1:]
+
+        normalized_relative = pathlib.PurePosixPath(*relative_parts)
+        url_suffix = f"/{normalized_relative}" if relative_parts else ""
         url = base_url.rstrip('/') + url_suffix
         html = path.read_text(errors="ignore")
         # Guardar una copia del HTML original junto al chunk normalizado.
-        relative_path = path.relative_to(RAW_CACHE)
         raw_dump_path = (CHUNK_RAW_DIR / relative_path).with_suffix(".txt")
         raw_dump_path.parent.mkdir(parents=True, exist_ok=True)
         raw_dump_path.write_text(html, encoding="utf-8", errors="ignore")


### PR DESCRIPTION
## Summary
- parse the configured base URL and remove any duplicated host directory from cached HTML paths
- build chunk metadata URLs without repeating the host segment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd4f55dcb88333833125e99e20f708