### PR TITLE
Fix chunk URLs to omit .html suffix

### DIFF
--- a/scripts/normalize_and_chunk.py
+++ b/scripts/normalize_and_chunk.py
@@ -47,6 +47,8 @@ def main() -> None:
             relative_parts = relative_parts[1:]
 
         normalized_relative = pathlib.PurePosixPath(*relative_parts)
+        if normalized_relative.suffix == ".html":
+            normalized_relative = normalized_relative.with_suffix("")
         url_suffix = f"/{normalized_relative}" if relative_parts else ""
         url = base_url.rstrip('/') + url_suffix
         html = path.read_text(errors="ignore")


### PR DESCRIPTION
## Summary
- ensure normalized chunk URLs remove the trailing .html suffix
- keep source URLs aligned with server resource paths

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd5219d87483338953366184f4e99d