### PR TITLE
Switch chunk uploader to knowledge base APIs

### DIFF
--- a/tests/test_prompt_printer.py
+++ b/tests/test_prompt_printer.py
@@ -5,7 +5,6 @@ import sys
 import types
 import unittest
 from pathlib import Path
-from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -92,12 +91,10 @@ class DiagnoseAgentContextTest(unittest.TestCase):
                 )
             )
             with io.StringIO() as buf, contextlib.redirect_stdout(buf):
-                with mock.patch("scripts.ask_agent.load_local_doc_map", return_value={}):
-                    await diagnose_agent_context(client, "agent-x", {"agent_id": "agent-x"})
+                await diagnose_agent_context(client, "agent-x", {"agent_id": "agent-x"})
                 return buf.getvalue()
 
         output = asyncio.run(_run())
-        self.assertIn("No se encontraron documentos cacheados", output)
         self.assertIn("La base de conocimiento del agente no tiene documentos disponibles", output)
 
 


### PR DESCRIPTION
## Summary
- switch chunk ingestion to use `knowledge_base.create_from_text` and assign documents through `agents.update`
- streamline document tracking and assignment output while keeping metadata persistence intact
- refresh the Navia MVP flow test double to cover the new SDK calls

## Testing
- pytest tests/test_navia_mvp_flow.py tests/test_prompt_printer.py

------
https://chatgpt.com/codex/tasks/task_e_68fd53dfc83c83338a9246f0b7abe5d1