### PR TITLE
Add Chirpy site and configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,58 @@
+name: Deploy documentation site
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'website/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'github-pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: website
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        working-directory: website
+        env:
+          JEKYLL_ENV: production
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/_site
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,10 @@ cosign.key
 .venv/
 __pycache__/
 
+
+# Jekyll build artifacts
+website/_site/
+website/.jekyll-cache/
+website/.sass-cache/
+website/vendor/
+website/.bundle/

--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,0 +1,13 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+
+group :jekyll_plugins do
+  gem "jekyll-archives", "~> 2.2", ">= 2.2.1"
+  gem "jekyll-seo-tag", "~> 2.8"
+  gem "jekyll-sitemap", "~> 1.4"
+end
+
+gem "jekyll-theme-chirpy", "~> 6.4"
+
+gem "webrick", "~> 1.8"

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -1,0 +1,185 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
+    bigdecimal (3.3.1)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.33.0)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.0-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.0-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.0-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.0-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.0-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.0-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.0-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.0-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-archives (2.3.0)
+      jekyll (>= 3.6, < 5.0)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-paginate (1.1.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-theme-chirpy (6.5.5)
+      jekyll (~> 4.3)
+      jekyll-archives (~> 2.2)
+      jekyll-include-cache (~> 0.2)
+      jekyll-paginate (~> 1.1)
+      jekyll-redirect-from (~> 0.16)
+      jekyll-seo-tag (~> 2.8)
+      jekyll-sitemap (~> 1.4)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.15.2)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (6.0.2)
+    rake (13.3.0)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.6.1)
+    safe_yaml (1.0.5)
+    sass-embedded (1.93.2)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.93.2-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll (~> 4.3)
+  jekyll-archives (~> 2.2, >= 2.2.1)
+  jekyll-seo-tag (~> 2.8)
+  jekyll-sitemap (~> 1.4)
+  jekyll-theme-chirpy (~> 6.4)
+  webrick (~> 1.8)
+
+BUNDLED WITH
+   2.6.7

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,19 @@
+# EventFlow site (Chirpy)
+
+Sitio estático generado con [Jekyll](https://jekyllrb.com/) y el tema [Chirpy](https://chirpy.cotes.page/).
+
+## Requisitos
+- Ruby 3.2 o superior
+- Bundler 2.4+
+
+## Uso local
+
+```bash
+bundle install
+bundle exec jekyll serve --config _config.yml,_config.dev.yml
+```
+
+El sitio estará disponible en `http://localhost:4000`.
+
+## Despliegue
+El workflow [`Deploy documentation site`](../.github/workflows/pages.yml) construye y publica automáticamente el sitio en GitHub Pages cuando hay cambios en `website/`.

--- a/website/_config.dev.yml
+++ b/website/_config.dev.yml
@@ -1,0 +1,7 @@
+url: ""
+baseurl: ""
+livereload: true
+
+# Speed up local builds
+profile: false
+future: true

--- a/website/_config.yml
+++ b/website/_config.yml
@@ -1,0 +1,111 @@
+# EventFlow documentation powered by Jekyll theme Chirpy
+
+lang: es
+timezone: America/Santiago
+
+# Site settings
+url: "https://scanalesespinoza.github.io"
+baseurl: "/eventflow"
+
+title: "EventFlow"
+tagline: "Plataforma inteligente para la gestión de eventos"
+description: "Documentación, noticias y notas técnicas de EventFlow"
+
+# Theme
+theme: jekyll-theme-chirpy
+
+# Build settings
+markdown: kramdown
+permalink: pretty
+paginate: 10
+paginate_path: "page/:num"
+
+kramdown:
+  input: GFM
+  hard_wrap: false
+  syntax_highlighter: rouge
+
+plugins:
+  - jekyll-archives
+  - jekyll-seo-tag
+  - jekyll-sitemap
+
+collections:
+  posts:
+    output: true
+
+# Archives configuration for Chirpy
+jekyll-archives:
+  enabled:
+    - categories
+    - tags
+  layout: archives
+  permalinks:
+    category: /categories/:name/
+    tag: /tags/:name/
+
+# Theme configuration overrides
+# See https://chirpy.cotes.page/posts/getting-started/ for the full list of options
+
+theme_mode: light
+
+avatar: /assets/img/avatar.svg
+
+social:
+  name: EventFlow
+  github: scanalesespinoza
+  twitter: opensourcescl
+  rss: true
+
+footer:
+  since: 2020
+  license:
+    enabled: true
+    name: Apache-2.0
+    link: https://www.apache.org/licenses/LICENSE-2.0
+
+defaults:
+  - scope:
+      path: ""
+      type: posts
+    values:
+      layout: post
+      author: eventflow
+      toc: true
+      comments: false
+  - scope:
+      path: ""
+      type: pages
+    values:
+      layout: page
+      comments: false
+
+compress_html:
+  clippings: all
+  comments: ["<!--", "-->" ]
+  endings: all
+  profile: false
+  blanklines: false
+
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - node_modules/
+  - vendor/
+  - README.md
+
+keep_files:
+  - .git
+
+include:
+  - .htaccess
+
+# Site metadata
+repository: scanalesespinoza/eventflow
+
+analytics:
+  provider: false
+
+comment:
+  provider: false
+

--- a/website/_data/authors.yml
+++ b/website/_data/authors.yml
@@ -1,0 +1,5 @@
+eventflow:
+  name: Equipo EventFlow
+  url: https://github.com/scanalesespinoza/eventflow
+  avatar: /assets/img/avatar.svg
+  bio: "Equipo de ingeniería detrás de la plataforma EventFlow"

--- a/website/_posts/2025-02-15-eventflow-221.md
+++ b/website/_posts/2025-02-15-eventflow-221.md
@@ -1,0 +1,16 @@
+---
+title: "EventFlow 2.2.1 disponible"
+date: 2025-02-15 09:00:00 -0400
+categories: [Lanzamientos]
+tags: [eventflow, release]
+---
+
+La versión **2.2.1** de EventFlow incorpora mejoras de estabilidad en la importación de eventos, optimizaciones para el inicio de sesión con Google y un refuerzo de la seguridad de la cadena de suministro con SBOMs generados automáticamente.
+
+Para comenzar, revisa la [guía rápida de desarrollo](https://github.com/scanalesespinoza/eventflow/blob/main/README.md) y ejecuta:
+
+```bash
+mvn -f quarkus-app/pom.xml quarkus:dev
+```
+
+Luego accede a `http://localhost:8080` y autentícate con una cuenta de desarrollo. Si necesitas credenciales de administrador agrega tu correo a la variable `ADMIN_LIST`.

--- a/website/_tabs/about.md
+++ b/website/_tabs/about.md
@@ -1,0 +1,11 @@
+---
+title: Acerca de
+icon: fas fa-info-circle
+order: 2
+---
+
+EventFlow es una plataforma para gestionar espacios, actividades, ponentes, asistentes y planificación personalizada de eventos.
+
+- Código fuente: [GitHub](https://github.com/scanalesespinoza/eventflow)
+- Comunidad: [Discord de OpenSource Santiago](https://discord.gg/3eawzc9ybc)
+- Licencia: [Apache-2.0](https://github.com/scanalesespinoza/eventflow/blob/main/LICENSE)

--- a/website/_tabs/home.md
+++ b/website/_tabs/home.md
@@ -1,0 +1,8 @@
+---
+title: Inicio
+icon: fas fa-home
+order: 1
+layout: home
+---
+
+Bienvenido a la documentación de EventFlow. Explora las publicaciones y recursos técnicos más recientes en la plataforma.

--- a/website/assets/img/avatar.svg
+++ b/website/assets/img/avatar.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">EventFlow Avatar</title>
+  <desc id="desc">Isotipo circular con iniciales EF</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff6f61" />
+      <stop offset="100%" stop-color="#6c63ff" />
+    </linearGradient>
+  </defs>
+  <circle cx="64" cy="64" r="60" fill="url(#grad)" />
+  <path d="M42 40h32v12H54v12h16v12H54v12h20v12H42z" fill="#ffffff"/>
+  <path d="M78 40h26v12H90v12h12v12H90v24H78z" fill="#ffffff"/>
+</svg>

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,3 @@
+---
+layout: home
+---


### PR DESCRIPTION
## Summary
- add a Chirpy-based Jekyll site under `website/` with configuration, authors, tabs, and an initial release post
- document how to run the site locally and include a simple SVG avatar asset
- add a GitHub Pages workflow that builds the Jekyll site and deploys it on pushes to `main`

## Testing
- `cd website && bundle exec jekyll build --config _config.yml,_config.dev.yml`


------
https://chatgpt.com/codex/tasks/task_e_690177b45ec48333b45246c1203331f8