### PR TITLE
Ignore Quarkus app data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ cosign.key
 .venv/
 __pycache__/
 
+# Local Quarkus application data
+quarkus-app/data/
+


### PR DESCRIPTION
## Summary
- add gitignore rule to exclude persistent quarkus-app/data directory from version control

## Testing
- mvn -q -DskipTests -pl quarkus-app validate *(fails: Could not find the selected project in the reactor: quarkus-app)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692779be7a5083338003918c71a7a09d)