### PR TITLE
Improve admin layout coherence

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -1405,6 +1405,120 @@ footer {
     animation: spin 1s linear infinite;
 }
 
+/* --- Admin layout coherence --- */
+.admin-page {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+}
+
+.admin-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-md);
+}
+
+.admin-card {
+    background: var(--color-light);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
+    padding: var(--space-md);
+}
+
+.admin-actions {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: var(--space-sm);
+}
+.admin-actions .btn,
+.admin-actions form {
+    width: 100%;
+}
+.admin-actions form {
+    display: flex;
+    gap: var(--space-sm);
+    align-items: center;
+    flex-wrap: wrap;
+}
+.admin-actions input[type=\"file\"] {
+    flex: 1 1 auto;
+}
+
+.admin-table-wrapper {
+    overflow-x: auto;
+}
+.admin-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+.admin-table th,
+.admin-table td {
+    padding: 0.65rem;
+}
+.admin-table th {
+    background-color: var(--color-dark);
+    color: var(--color-light);
+    text-align: left;
+}
+.admin-table tbody tr:nth-child(even) {
+    background: #f7f9fb;
+}
+.admin-table .action-group {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.admin-form {
+    display: grid;
+    gap: var(--space-sm);
+}
+.admin-form label {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}
+.admin-form input,
+.admin-form select,
+.admin-form textarea {
+    width: 100%;
+    padding: var(--space-sm);
+    border: 1px solid #d0d7de;
+    border-radius: var(--radius-sm);
+}
+.admin-form fieldset {
+    border: 1px solid #e5e7eb;
+    border-radius: var(--radius-md);
+    padding: var(--space-sm);
+    margin: var(--space-sm) 0;
+}
+.admin-form legend {
+    font-weight: 600;
+    padding: 0 var(--space-xs);
+}
+.form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--space-sm);
+}
+.admin-card button:not(.btn) {
+    background-color: var(--color-primary);
+    color: var(--color-light);
+    border: none;
+    padding: var(--space-sm) var(--space-md);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    min-height: 2.5rem;
+    font-weight: 600;
+    transition: background-color 0.2s ease, transform 0.1s ease;
+}
+.admin-card button:not(.btn):hover {
+    background-color: var(--color-accent);
+}
+.admin-card button:not(.btn):active {
+    transform: scale(0.98);
+}
+
 @media (max-width: 600px) {
     .nav-links {
         display: none;

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -8,205 +8,140 @@ Nuevo Evento
 {/title}
 {#breadcrumbs}<a href="/private/admin">Admin</a><span class="sep">/</span><a href="/private/admin/events">Eventos</a><span class="sep">/</span><span>{#if event.id}{event.title}{#else}Nuevo Evento{/if}</span>{/breadcrumbs}
 {#main}
-<h1>
-{#if event.id}
-Editar Evento
-{#else}
-Nuevo Evento
-{/if}
-</h1>
-{#if message}<p class="section-subtitle">{message}</p>{/if}
-<nav class="sub-nav">
-  <a href="#event-info">Evento</a>
-  {#if event.id}
-  <a href="#scenarios">Escenarios</a>
-  <a href="#talks">Charlas</a>
-  <a href="#breaks">Breaks</a>
-  <a href="#agenda">Agenda</a>
-  {/if}
-</nav>
-<section id="event-info">
-<form method="post" action="{#if event.id}/private/admin/events/{event.id}/edit{#else}/private/admin/events/new{/if}">
+<section class="admin-page">
+  <div class="admin-header">
+    <div>
+      <p class="section-subtitle">Evento</p>
+      <h1 class="page-title">
+      {#if event.id}
+      Editar Evento
+      {#else}
+      Nuevo Evento
+      {/if}
+      </h1>
+      {#if message}<p class="section-subtitle">{message}</p>{/if}
+    </div>
+  </div>
+  <nav class="sub-nav">
+    <a href="#event-info">Evento</a>
     {#if event.id}
-        <p>ID: {event.id}</p>
+    <a href="#scenarios">Escenarios</a>
+    <a href="#talks">Charlas</a>
+    <a href="#breaks">Breaks</a>
+    <a href="#agenda">Agenda</a>
     {/if}
-    <label for="title">Titulo</label>
-    <input id="title" name="title" type="text" value="{event.title}">
-    <label for="description">Descripcion</label>
-    <textarea id="description" name="description">{event.description}</textarea>
-    <label for="date">Fecha de realización</label>
-    <input id="date" name="date" type="date" value="{event.dateStr}">
-    <p class="event-time-info">Horario calculado: {#if event.startTimeStr}{event.startTimeStr} - {event.endTimeStr}{#else}Sin charlas{/if}</p>
-    <label for="timezone">Zona horaria</label>
-    <select id="timezone" name="timezone">
-      {#for tz in app:commonTimezones()}
-      <option value="{tz}"{#if tz == event.timezone} selected{/if}>{tz} ({app:zoneDetail(tz)})</option>
-      {/for}
-    </select>
-    <label for="days">Días del evento</label>
-    <input id="days" name="days" type="number" min="1" max="10" value="{event.days}">
-    <label for="logoUrl">Logo URL</label>
-    <input id="logoUrl" name="logoUrl" type="url" value="{event.logoUrl}">
-    <label for="mapUrl">Mapa URL</label>
-    <input id="mapUrl" name="mapUrl" type="url" value="{event.mapUrl}">
-    <label for="website">Sitio Web</label>
-    <input id="website" name="website" type="url" value="{event.website}">
-    <label for="contactEmail">Correo de contacto</label>
-    <input id="contactEmail" name="contactEmail" type="email" value="{event.contactEmail}">
-    <label for="ticketsUrl">Link de entradas</label>
-    <input id="ticketsUrl" name="ticketsUrl" type="url" value="{event.ticketsUrl}">
-    <fieldset>
-      <legend>Redes Sociales</legend>
-      <label for="twitter">Twitter/X</label>
-      <input id="twitter" name="twitter" type="url" value="{event.twitter}">
-      <label for="linkedin">LinkedIn</label>
-      <input id="linkedin" name="linkedin" type="url" value="{event.linkedin}">
-      <label for="instagram">Instagram</label>
-      <input id="instagram" name="instagram" type="url" value="{event.instagram}">
-    </fieldset>
-    <button type="submit">Guardar</button>
-</form>
-</section>
-{#if event.id}
-<section id="scenarios">
-  <h2><span class="icon">🏟️</span>Escenarios</h2>
-  <div class="card">
-  <table>
-    <thead><tr><th>ID</th><th>Nombre</th><th>Acciones</th></tr></thead>
-    <tbody>
-    {#for sc in event.scenarios}
-    <tr>
-      <form method="post" action="/private/admin/events/{event.id}/scenario">
-      <td>{sc.id}<input type="hidden" name="scenarioId" value="{sc.id}"></td>
-      <td><input name="name" value="{sc.name}"></td>
-      <td>
-        <input name="features" value="{sc.features}" placeholder="Caracteristicas">
-        <input name="location" value="{sc.location}" placeholder="Ubicacion">
-        <button type="submit">Guardar</button>
-      </form>
-      <form method="post" action="/private/admin/events/{event.id}/scenario/{sc.id}/delete" style="display:inline" class="needs-confirm">
-        <button type="submit">Eliminar</button>
-      </form>
-      </td>
-    </tr>
-    {/for}
-    <tr>
-      <form method="post" action="/private/admin/events/{event.id}/scenario">
-      <td>Nuevo</td>
-      <td><input name="name"></td>
-      <td>
-        <input name="features" placeholder="Caracteristicas">
-        <input name="location" placeholder="Ubicacion">
-        <button type="submit">Agregar</button>
-      </td>
-      </form>
-    </tr>
-    </tbody>
-  </table>
-  </div>
-</section>
-<section id="talks">
-  <h2><span class="icon">🗣️</span>Charlas</h2>
-  <div class="card">
-  <table>
-  <thead><tr><th>ID</th><th>Charla</th><th>Acciones</th></tr></thead>
-  <tbody>
-  {#for t in event.agenda}
-  {#if !t.break}
-  <tr>
-  <form method="post" action="/private/admin/events/{event.id}/talk">
-  <td>{t.id}<input type="hidden" name="talkId" value="{t.id}"></td>
-  <td>{t.name}{#if !t.speakers.isEmpty()}<br><small>{t.getSpeakerNames()}</small>{/if}</td>
-  <td>
-  <select name="location">
-  {#for sc in event.scenarios}
-  <option value="{sc.id}"{#if sc.id == t.location} selected{/if}>{sc.name}</option>
-  {/for}
-  </select>
-  <input name="startTime" type="time" value="{t.startTimeStr}">
-  <select name="day">
-  {#for d in event.dayList}
-  <option value="{d}"{#if t.day == d} selected{/if}>Día {d}</option>
-  {/for}
-  </select>
-  <button type="submit">Guardar</button>
-  </form>
-  <form method="post" action="/private/admin/events/{event.id}/talk/{t.id}/delete" style="display:inline" class="needs-confirm">
-  <button type="submit">Eliminar</button>
-  </form>
-  </td>
-  </tr>
-  {/if}
-  {/for}
-  <tr>
-  <form method="post" action="/private/admin/events/{event.id}/talk">
-  <td>Nuevo</td>
-  <td>
-    <select id="speakerSelect" name="speakerId">
-      <option value="">Seleccione orador</option>
-      {#for sp in speakers}
-      <option value="{sp.id}">{sp.name}</option>
-      {/for}
-    </select>
-    <select id="talkSelect" name="talkId">
-      <option value="">Seleccione charla</option>
-      {#for sp in speakers}
-        {#for t in sp.talks}
-        <option value="{t.id}" data-speaker="{sp.id}">{t.name}</option>
+  </nav>
+  <section id="event-info" class="admin-card admin-subsection">
+    <h2 class="card-title">Datos del evento</h2>
+    <form method="post" action="{#if event.id}/private/admin/events/{event.id}/edit{#else}/private/admin/events/new{/if}" class="admin-form">
+      {#if event.id}
+        <p class="item-id">ID: {event.id}</p>
+      {/if}
+      <div class="form-grid">
+        <label for="title">Titulo
+          <input id="title" name="title" type="text" value="{event.title}">
+        </label>
+        <label for="date">Fecha de realización
+          <input id="date" name="date" type="date" value="{event.dateStr}">
+        </label>
+        <label for="timezone">Zona horaria
+          <select id="timezone" name="timezone">
+            {#for tz in app:commonTimezones()}
+            <option value="{tz}"{#if tz == event.timezone} selected{/if}>{tz} ({app:zoneDetail(tz)})</option>
+            {/for}
+          </select>
+        </label>
+        <label for="days">Días del evento
+          <input id="days" name="days" type="number" min="1" max="10" value="{event.days}">
+        </label>
+        <label for="logoUrl">Logo URL
+          <input id="logoUrl" name="logoUrl" type="url" value="{event.logoUrl}">
+        </label>
+        <label for="mapUrl">Mapa URL
+          <input id="mapUrl" name="mapUrl" type="url" value="{event.mapUrl}">
+        </label>
+        <label for="website">Sitio Web
+          <input id="website" name="website" type="url" value="{event.website}">
+        </label>
+        <label for="contactEmail">Correo de contacto
+          <input id="contactEmail" name="contactEmail" type="email" value="{event.contactEmail}">
+        </label>
+        <label for="ticketsUrl">Link de entradas
+          <input id="ticketsUrl" name="ticketsUrl" type="url" value="{event.ticketsUrl}">
+        </label>
+      </div>
+      <label for="description">Descripcion
+        <textarea id="description" name="description">{event.description}</textarea>
+      </label>
+      <p class="event-time-info">Horario calculado: {#if event.startTimeStr}{event.startTimeStr} - {event.endTimeStr}{#else}Sin charlas{/if}</p>
+      <fieldset>
+        <legend>Redes Sociales</legend>
+        <div class="form-grid">
+          <label for="twitter">Twitter/X
+            <input id="twitter" name="twitter" type="url" value="{event.twitter}">
+          </label>
+          <label for="linkedin">LinkedIn
+            <input id="linkedin" name="linkedin" type="url" value="{event.linkedin}">
+          </label>
+          <label for="instagram">Instagram
+            <input id="instagram" name="instagram" type="url" value="{event.instagram}">
+          </label>
+        </div>
+      </fieldset>
+      <button type="submit" class="btn">Guardar</button>
+    </form>
+  </section>
+  {#if event.id}
+  <section id="scenarios" class="admin-card admin-subsection">
+    <h2><span class="icon">🏟️</span>Escenarios</h2>
+    <div class="admin-table-wrapper">
+      <table class="admin-table">
+        <thead><tr><th>ID</th><th>Nombre</th><th>Acciones</th></tr></thead>
+        <tbody>
+        {#for sc in event.scenarios}
+        <tr>
+          <form method="post" action="/private/admin/events/{event.id}/scenario">
+          <td>{sc.id}<input type="hidden" name="scenarioId" value="{sc.id}"></td>
+          <td><input name="name" value="{sc.name}"></td>
+          <td>
+            <input name="features" value="{sc.features}" placeholder="Caracteristicas">
+            <input name="location" value="{sc.location}" placeholder="Ubicacion">
+            <button type="submit">Guardar</button>
+          </form>
+          <form method="post" action="/private/admin/events/{event.id}/scenario/{sc.id}/delete" style="display:inline" class="needs-confirm">
+            <button type="submit">Eliminar</button>
+          </form>
+          </td>
+        </tr>
         {/for}
-      {/for}
-    </select>
-  </td>
-  <td>
-  <select name="location">
-  {#for sc in event.scenarios}
-  <option value="{sc.id}">{sc.name}</option>
-  {/for}
-  </select>
-  <input name="startTime" type="time">
-  <select name="day">
-  {#for d in event.dayList}
-  <option value="{d}">Día {d}</option>
-  {/for}
-  </select>
-  <button type="submit">Agregar</button>
-  </td>
-  </form>
-  </tr>
-  </tbody>
-  </table>
-  <script>
-    (function(){
-      const speakerSelect = document.getElementById('speakerSelect');
-      const talkSelect = document.getElementById('talkSelect');
-      function filterTalks(){
-        const sid = speakerSelect.value;
-        Array.from(talkSelect.options).forEach(opt => {
-          if(!opt.value) return;
-          opt.hidden = sid && opt.dataset.speaker !== sid;
-        });
-        talkSelect.value = '';
-      }
-      speakerSelect.addEventListener('change', filterTalks);
-      filterTalks();
-    })();
-  </script>
-  </div>
-</section>
-<section id="breaks">
-  <h2><span class="icon">☕</span>Breaks</h2>
-  <div class="card">
-  <table>
-    <thead><tr><th>ID</th><th>Break</th><th>Acciones</th></tr></thead>
-    <tbody>
-    {#for t in event.agenda}
-    {#if t.break}
-    <tr>
-    <form method="post" action="/private/admin/events/{event.id}/break">
-    <td>{t.id}<input type="hidden" name="breakId" value="{t.id}"></td>
-    <td><input name="name" value="{t.name}"></td>
-    <td>
-      <input name="duration" type="number" min="1" value="{t.durationMinutes}">
+        <tr>
+          <form method="post" action="/private/admin/events/{event.id}/scenario">
+          <td>Nuevo</td>
+          <td><input name="name"></td>
+          <td>
+            <input name="features" placeholder="Caracteristicas">
+            <input name="location" placeholder="Ubicacion">
+            <button type="submit">Agregar</button>
+          </td>
+          </form>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+  <section id="talks" class="admin-card admin-subsection">
+    <h2><span class="icon">🗣️</span>Charlas</h2>
+    <div class="admin-table-wrapper">
+      <table class="admin-table">
+      <thead><tr><th>ID</th><th>Charla</th><th>Acciones</th></tr></thead>
+      <tbody>
+      {#for t in event.agenda}
+      {#if !t.break}
+      <tr>
+      <form method="post" action="/private/admin/events/{event.id}/talk">
+      <td>{t.id}<input type="hidden" name="talkId" value="{t.id}"></td>
+      <td>{t.name}{#if !t.speakers.isEmpty()}<br><small>{t.getSpeakerNames()}</small>{/if}</td>
+      <td>
       <select name="location">
       {#for sc in event.scenarios}
       <option value="{sc.id}"{#if sc.id == t.location} selected{/if}>{sc.name}</option>
@@ -219,20 +154,34 @@ Nuevo Evento
       {/for}
       </select>
       <button type="submit">Guardar</button>
-    </form>
-    <form method="post" action="/private/admin/events/{event.id}/break/{t.id}/delete" style="display:inline" class="needs-confirm">
+      </form>
+      <form method="post" action="/private/admin/events/{event.id}/talk/{t.id}/delete" style="display:inline" class="needs-confirm">
       <button type="submit">Eliminar</button>
-    </form>
-    </td>
-    </tr>
-    {/if}
-    {/for}
-    <tr>
-    <form method="post" action="/private/admin/events/{event.id}/break">
-    <td>Nuevo</td>
-    <td><input name="name"></td>
-    <td>
-      <input name="duration" type="number" min="1">
+      </form>
+      </td>
+      </tr>
+      {/if}
+      {/for}
+      <tr>
+      <form method="post" action="/private/admin/events/{event.id}/talk">
+      <td>Nuevo</td>
+      <td>
+        <select id="speakerSelect" name="speakerId">
+          <option value="">Seleccione orador</option>
+          {#for sp in speakers}
+          <option value="{sp.id}">{sp.name}</option>
+          {/for}
+        </select>
+        <select id="talkSelect" name="talkId">
+          <option value="">Seleccione charla</option>
+          {#for sp in speakers}
+            {#for t in sp.talks}
+            <option value="{t.id}" data-speaker="{sp.id}">{t.name}</option>
+            {/for}
+          {/for}
+        </select>
+      </td>
+      <td>
       <select name="location">
       {#for sc in event.scenarios}
       <option value="{sc.id}">{sc.name}</option>
@@ -245,32 +194,110 @@ Nuevo Evento
       {/for}
       </select>
       <button type="submit">Agregar</button>
-    </td>
-    </form>
-    </tr>
-    </tbody>
-  </table>
-  </div>
-</section>
-<section id="agenda">
-  <h2><span class="icon">🗓️</span>Agenda</h2>
-  {#for d in event.dayList}
-  <div class="agenda-day">
-    <h3>Día {d}</h3>
-    {#for sc in event.scenarios}
-      {#if !event.getAgendaForDayAndScenario(d, sc.id).isEmpty()}
-      <h4>{sc.name}</h4>
-      <ul class="agenda-list">
-        {#for t in event.getAgendaForDayAndScenario(d, sc.id)}
-          <li class="agenda-item"><span class="icon">{#if t.break}☕{#else}🗣️{/if}</span>{t.startTimeStr} - {t.endTimeStr} | {t.name} <span class="badge {app:talkStateClass(t, event)}">{app:talkState(t, event)}</span></li>
+      </td>
+      </form>
+      </tr>
+      </tbody>
+      </table>
+    </div>
+    <script>
+      (function(){
+        const speakerSelect = document.getElementById('speakerSelect');
+        const talkSelect = document.getElementById('talkSelect');
+        function filterTalks(){
+          const sid = speakerSelect.value;
+          Array.from(talkSelect.options).forEach(opt => {
+            if(!opt.value) return;
+            opt.hidden = sid && opt.dataset.speaker !== sid;
+          });
+          talkSelect.value = '';
+        }
+        speakerSelect.addEventListener('change', filterTalks);
+        filterTalks();
+      })();
+    </script>
+  </section>
+  <section id="breaks" class="admin-card admin-subsection">
+    <h2><span class="icon">☕</span>Breaks</h2>
+    <div class="admin-table-wrapper">
+      <table class="admin-table">
+        <thead><tr><th>ID</th><th>Break</th><th>Acciones</th></tr></thead>
+        <tbody>
+        {#for t in event.agenda}
+        {#if t.break}
+        <tr>
+        <form method="post" action="/private/admin/events/{event.id}/break">
+        <td>{t.id}<input type="hidden" name="breakId" value="{t.id}"></td>
+        <td><input name="name" value="{t.name}"></td>
+        <td>
+          <input name="duration" type="number" min="1" value="{t.durationMinutes}">
+          <select name="location">
+          {#for sc in event.scenarios}
+          <option value="{sc.id}"{#if sc.id == t.location} selected{/if}>{sc.name}</option>
+          {/for}
+          </select>
+          <input name="startTime" type="time" value="{t.startTimeStr}">
+          <select name="day">
+          {#for d in event.dayList}
+          <option value="{d}"{#if t.day == d} selected{/if}>Día {d}</option>
+          {/for}
+          </select>
+          <button type="submit">Guardar</button>
+        </form>
+        <form method="post" action="/private/admin/events/{event.id}/break/{t.id}/delete" style="display:inline" class="needs-confirm">
+          <button type="submit">Eliminar</button>
+        </form>
+        </td>
+        </tr>
+        {/if}
         {/for}
-      </ul>
-      {/if}
+        <tr>
+        <form method="post" action="/private/admin/events/{event.id}/break">
+        <td>Nuevo</td>
+        <td><input name="name"></td>
+        <td>
+          <input name="duration" type="number" min="1">
+          <select name="location">
+          {#for sc in event.scenarios}
+          <option value="{sc.id}">{sc.name}</option>
+          {/for}
+          </select>
+          <input name="startTime" type="time">
+          <select name="day">
+          {#for d in event.dayList}
+          <option value="{d}">Día {d}</option>
+          {/for}
+          </select>
+          <button type="submit">Agregar</button>
+        </td>
+        </form>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+  <section id="agenda" class="admin-card admin-subsection">
+    <h2><span class="icon">🗓️</span>Agenda</h2>
+    {#for d in event.dayList}
+    <div class="agenda-day">
+      <h3>Día {d}</h3>
+      {#for sc in event.scenarios}
+        {#if !event.getAgendaForDayAndScenario(d, sc.id).isEmpty()}
+        <h4>{sc.name}</h4>
+        <ul class="agenda-list">
+          {#for t in event.getAgendaForDayAndScenario(d, sc.id)}
+            <li class="agenda-item"><span class="icon">{#if t.break}☕{#else}🗣️{/if}</span>{t.startTimeStr} - {t.endTimeStr} | {t.name} <span class="badge {app:talkStateClass(t, event)}">{app:talkState(t, event)}</span></li>
+          {/for}
+        </ul>
+        {/if}
+      {/for}
+    </div>
     {/for}
+  </section>
+  {/if}
+  <div class="admin-card">
+    <a href="/private/admin/events" class="btn btn-secondary">Volver a la administración de Eventos</a>
   </div>
-  {/for}
 </section>
-{/if}
-<p><a href="/private/admin/events">Volver a la administración de Eventos</a></p>
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
@@ -2,43 +2,53 @@
 {#title}Eventos{/title}
 {#breadcrumbs}<a href="/private/admin">Admin</a><span class="sep">/</span><span>Eventos</span>{/breadcrumbs}
 {#main}
-<section class="event-list-admin">
-    <h1 class="page-title"><span class="icon">🗓️</span>Eventos</h1>
-  {#if message}
-  <p class="section-subtitle">{message}</p>
-  {/if}
-  <div class="card action-group">
-    <a href="/private/admin/events/new" class="btn">Nuevo evento</a>
-    <form method="post" action="/private/admin/events/import" enctype="multipart/form-data">
-      <input type="file" name="file" accept="application/json">
-      <button type="submit" class="btn btn-secondary">Importar JSON</button>
-    </form>
-  </div>
-  {#if events.isEmpty()}
-  <p class="no-events">No hay eventos registrados.</p>
-  {#else}
-  <div class="card">
-    <table class="table">
-      <thead><tr><th>ID</th><th>Título</th><th>Acciones</th></tr></thead>
-      <tbody>
-      {#for ev in events}
-        <tr>
-          <td>{ev.id}</td>
-          <td>{ev.title}</td>
-          <td class="action-group">
-            <a href="/private/admin/events/{ev.id}/edit" class="btn btn-secondary">Editar</a>
-            <a href="/private/admin/metrics?event={ev.id}&amp;range=all" class="btn btn-secondary">Ver métricas</a>
-            <form method="post" action="/private/admin/events/{ev.id}/delete" style="display:inline" class="needs-confirm">
-              <button type="submit" class="btn btn-secondary">Eliminar</button>
+<section class="admin-page">
+    <div class="admin-header">
+        <div>
+            <h1 class="page-title"><span class="icon">🗓️</span>Eventos</h1>
+            {#if message}
+                <p class="section-subtitle">{message}</p>
+            {/if}
+        </div>
+    </div>
+    <div class="admin-card">
+        <h2 class="card-title">Acciones</h2>
+        <div class="admin-actions">
+            <a href="/private/admin/events/new" class="btn">Nuevo evento</a>
+            <form method="post" action="/private/admin/events/import" enctype="multipart/form-data" class="admin-form">
+                <label for="importFile">Importar JSON</label>
+                <input id="importFile" type="file" name="file" accept="application/json">
+                <button type="submit" class="btn btn-secondary">Importar</button>
             </form>
-          </td>
-        </tr>
-      {/for}
-      </tbody>
-    </table>
-  </div>
-  {/if}
-  <a href="/private/admin" class="btn btn-secondary">Volver</a>
+        </div>
+    </div>
+    {#if events.isEmpty()}
+        <div class="admin-card">
+            <p class="no-events">No hay eventos registrados.</p>
+        </div>
+    {#else}
+        <div class="admin-card admin-table-wrapper">
+            <table class="table admin-table">
+                <thead><tr><th>ID</th><th>Título</th><th>Acciones</th></tr></thead>
+                <tbody>
+                {#for ev in events}
+                    <tr>
+                        <td>{ev.id}</td>
+                        <td>{ev.title}</td>
+                        <td class="action-group">
+                            <a href="/private/admin/events/{ev.id}/edit" class="btn btn-secondary">Editar</a>
+                            <a href="/private/admin/metrics?event={ev.id}&amp;range=all" class="btn btn-secondary">Ver métricas</a>
+                            <form method="post" action="/private/admin/events/{ev.id}/delete" style="display:inline" class="needs-confirm">
+                                <button type="submit" class="btn btn-secondary">Eliminar</button>
+                            </form>
+                        </td>
+                    </tr>
+                {/for}
+                </tbody>
+            </table>
+        </div>
+    {/if}
+    <a href="/private/admin" class="btn btn-secondary">Volver</a>
 </section>
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/AdminResource/admin.html
+++ b/quarkus-app/src/main/resources/templates/AdminResource/admin.html
@@ -2,20 +2,28 @@
 {#title}Panel de administraci\u00f3n{/title}
 {#breadcrumbs}<a href="/private/profile">Perfil</a><span class="sep">/</span><span>Admin</span>{/breadcrumbs}
 {#main}
-<section class="admin-overview">
-    <h1 class="page-title">Admin Panel</h1>
-    <p class="section-subtitle">Bienvenido {name}. Gestiona los eventos aquí.</p>
-    <div class="card action-group">
-        <a href="/private/admin/events" class="btn">Administrar eventos</a>
-        <a href="/private/admin/speakers" class="btn">Administrar oradores</a>
-        <a href="/private/admin/metrics" class="btn">Métricas</a>
-        <a href="/private/admin/capacity" class="btn">Capacidad</a>
-        <a href="/private/admin/backup" class="btn">Respaldo de datos</a>
-        <a href="/admin/notifications" class="btn">Notificaciones</a>
-        <a href="/private/admin/guide" class="btn">Guía</a>
-        <a href="/admin/notifications" class="btn">Broadcast de notificaciones</a>
-        <a href="/admin/notifications/sim" class="btn">Simulación de notificaciones</a>
-        <a href="/private/profile" class="btn btn-secondary">Volver a perfil</a>
+<section class="admin-page">
+    <div class="admin-header">
+        <div>
+            <p class="section-subtitle">Bienvenido {name}</p>
+            <h1 class="page-title">Panel de administración</h1>
+            <p class="section-subtitle">Gestiona eventos, oradores y métricas desde un solo lugar.</p>
+        </div>
+    </div>
+    <div class="admin-card">
+        <h2 class="card-title">Acciones rápidas</h2>
+        <div class="admin-actions">
+            <a href="/private/admin/events" class="btn">Administrar eventos</a>
+            <a href="/private/admin/speakers" class="btn">Administrar oradores</a>
+            <a href="/private/admin/metrics" class="btn">Métricas</a>
+            <a href="/private/admin/capacity" class="btn">Capacidad</a>
+            <a href="/private/admin/backup" class="btn">Respaldo de datos</a>
+            <a href="/admin/notifications" class="btn">Notificaciones</a>
+            <a href="/private/admin/guide" class="btn">Guía</a>
+            <a href="/admin/notifications" class="btn">Broadcast de notificaciones</a>
+            <a href="/admin/notifications/sim" class="btn">Simulación de notificaciones</a>
+            <a href="/private/profile" class="btn btn-secondary">Volver a perfil</a>
+        </div>
     </div>
 </section>
 {/main}

--- a/quarkus-app/src/main/resources/templates/AdminSpeakerResource/list.html
+++ b/quarkus-app/src/main/resources/templates/AdminSpeakerResource/list.html
@@ -2,10 +2,17 @@
 {#title}Oradores{/title}
 {#breadcrumbs}<a href="/private/admin">Admin</a><span class="sep">/</span><span>Oradores</span>{/breadcrumbs}
 {#main}
-<h1>Oradores</h1>
-<p><a href="#new-speaker" class="btn">Agregar Orador</a></p>
-{#if message}<p class="section-subtitle">{message}</p>{/if}
-<ul class="speaker-list">
+<section class="admin-page">
+  <div class="admin-header">
+    <div>
+      <h1 class="page-title">Oradores</h1>
+      {#if message}<p class="section-subtitle">{message}</p>{/if}
+    </div>
+    <div>
+      <a href="#new-speaker" class="btn">Agregar Orador</a>
+    </div>
+  </div>
+  <ul class="speaker-list">
   {#for s in speakers}
   <li class="card speaker-card">
     <form method="post" action="/private/admin/speakers" class="speaker-form">
@@ -110,7 +117,10 @@
     </form>
   </li>
 </ul>
-<p><a href="/private/admin">Volver al panel</a></p>
+  <div class="admin-card">
+    <a href="/private/admin" class="btn btn-secondary">Volver al panel</a>
+  </div>
+</section>
 <script>
 (function(){
   document.querySelectorAll('.cospeaker-toggle').forEach(cb => {
@@ -123,4 +133,3 @@
 </script>
 {/main}
 {/include}
-


### PR DESCRIPTION
## Summary
- add admin layout styles and cards for consistent spacing/actions
- refresh admin home, events list/edit, and speakers pages to reuse the shared admin shell
- keep existing flows while improving table readability and form grouping

## Testing
- ./scripts/test-fast.sh