### PR TITLE
Add event type enum with hackathon support

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
@@ -23,6 +23,7 @@ public class Event {
   @NotBlank private String id;
   @NotBlank private String title;
   @NotBlank private String description;
+  private EventType type = EventType.OTHER;
   private List<Scenario> scenarios = new ArrayList<>();
 
   /** Number of days the event lasts. */
@@ -121,6 +122,14 @@ public class Event {
 
   public void setDescription(String description) {
     this.description = description;
+  }
+
+  public EventType getType() {
+    return type == null ? EventType.OTHER : type;
+  }
+
+  public void setType(EventType type) {
+    this.type = type == null ? EventType.OTHER : type;
   }
 
   public List<Scenario> getScenarios() {
@@ -253,6 +262,14 @@ public class Event {
     } else {
       this.date = null;
     }
+  }
+
+  public String getTypeLabel() {
+    return getType().getLabel();
+  }
+
+  public String getTypeCss() {
+    return getType().getCssClass();
   }
 
   /** Returns the event date formatted for display, e.g. "5 de septiembre de 2025". */

--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/EventType.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/EventType.java
@@ -1,0 +1,36 @@
+package com.scanales.eventflow.model;
+
+import java.util.Arrays;
+
+/** Classifies events by type without relying on database enums. */
+public enum EventType {
+  CONFERENCE("Conferencia"),
+  MEETUP("Meetup"),
+  WORKSHOP("Workshop"),
+  HACKATHON("Hackatón"),
+  OTHER("General");
+
+  private final String label;
+
+  EventType(String label) {
+    this.label = label;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public String getCssClass() {
+    return "event-type-" + name().toLowerCase();
+  }
+
+  public static EventType fromNullable(String value) {
+    if (value == null || value.isBlank()) {
+      return OTHER;
+    }
+    return Arrays.stream(values())
+        .filter(t -> t.name().equalsIgnoreCase(value))
+        .findFirst()
+        .orElse(OTHER);
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -1,6 +1,7 @@
 package com.scanales.eventflow.service;
 
 import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.EventType;
 import com.scanales.eventflow.model.Scenario;
 import com.scanales.eventflow.model.Talk;
 import com.scanales.eventflow.model.TalkInfo;
@@ -32,6 +33,7 @@ public class EventService {
   @PostConstruct
   void init() {
     events.putAll(persistence.loadEvents());
+    events.values().forEach(this::ensureDefaults);
     LOG.infof("Loaded %d events into memory", events.size());
   }
 
@@ -253,5 +255,12 @@ public class EventService {
   public void reload() {
     events.clear();
     events.putAll(persistence.loadEvents());
+    events.values().forEach(this::ensureDefaults);
+  }
+
+  private void ensureDefaults(Event event) {
+    if (event.getType() == null) {
+      event.setType(EventType.OTHER);
+    }
   }
 }

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -1357,6 +1357,44 @@ footer {
 .badge.warning { background: #ff9800; color: #fff; }
 .badge.info { background: #2196f3; color: #fff; }
 .badge.past { background: #9e9e9e; color: #fff; }
+.badge.event-type {
+    background: #e8f4ff;
+    color: #0d47a1;
+    border: 1px solid #bbdefb;
+    margin-bottom: 0;
+}
+.badge.event-type.event-type-hackathon {
+    background: #f3e5f5;
+    color: #6a1b9a;
+    border-color: #ce93d8;
+}
+.badge.event-type.event-type-meetup {
+    background: #fff3e0;
+    color: #e65100;
+    border-color: #ffcc80;
+}
+.badge.event-type.event-type-workshop {
+    background: #e8f5e9;
+    color: #2e7d32;
+    border-color: #a5d6a7;
+}
+.badge.event-type.event-type-conference {
+    background: #e3f2fd;
+    color: #0d47a1;
+    border-color: #90caf9;
+}
+.badge.event-type.event-type-other {
+    background: #eceff1;
+    color: #37474f;
+    border-color: #cfd8dc;
+}
+.event-tags {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+    align-items: center;
+    margin: 0.25rem 0;
+}
 
 @keyframes spin {
     from { transform: rotate(0deg); }

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -41,6 +41,13 @@ Nuevo Evento
         <label for="title">Titulo
           <input id="title" name="title" type="text" value="{event.title}">
         </label>
+        <label for="type">Tipo de evento
+          <select id="type" name="type">
+            {#for t in types}
+            <option value="{t.name()}"{#if event.type?? && event.type.name() == t.name()} selected{/if}>{t.label}</option>
+            {/for}
+          </select>
+        </label>
         <label for="date">Fecha de realización
           <input id="date" name="date" type="date" value="{event.dateStr}">
         </label>

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
@@ -29,12 +29,13 @@
     {#else}
         <div class="admin-card admin-table-wrapper">
             <table class="table admin-table">
-                <thead><tr><th>ID</th><th>Título</th><th>Acciones</th></tr></thead>
+                <thead><tr><th>ID</th><th>Título</th><th>Tipo</th><th>Acciones</th></tr></thead>
                 <tbody>
                 {#for ev in events}
                     <tr>
                         <td>{ev.id}</td>
                         <td>{ev.title}</td>
+                        <td><span class="badge event-type {ev.typeCss}">{ev.typeLabel}</span></td>
                         <td class="action-group">
                             <a href="/private/admin/events/{ev.id}/edit" class="btn btn-secondary">Editar</a>
                             <a href="/private/admin/metrics?event={ev.id}&amp;range=all" class="btn btn-secondary">Ver métricas</a>

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -21,6 +21,12 @@ Evento
       {/if}
       <div class="event-info">
         <h1 class="page-title">{event.title}</h1>
+        <div class="event-tags">
+          <span class="badge event-type {event.typeCss}">{event.typeLabel}</span>
+          {#if event.isOngoing()}
+          <span class="badge info">En curso</span>
+          {/if}
+        </div>
         {#if event.formattedDate}
         <p class="event-datetime">{event.formattedDate} | {event.startTimeStr} – {event.endTimeStr} hrs{#if event.timezone} ({event.timezone}){/if}.</p>
         {/if}

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -23,9 +23,12 @@
                     </div>
                     <div class="event-main">
                         <h2 class="event-name"><a href="/event/{e.id}" title="Ver detalles del evento">{e.title}</a></h2>
-                        {#if e.isOngoing()}
-                        <span class="badge info">En curso</span>
-                        {/if}
+                        <div class="event-tags">
+                            <span class="badge event-type {e.typeCss}">{e.typeLabel}</span>
+                            {#if e.isOngoing()}
+                            <span class="badge info">En curso</span>
+                            {/if}
+                        </div>
                         {#if e.descriptionSummary}
                         <p class="event-description">{e.descriptionSummary}</p>
                         {/if}
@@ -72,10 +75,13 @@
                         </div>
                         <div class="event-main">
                             <h2 class="event-name"><a href="/event/{e.id}" title="Ver detalles del evento">{e.title}</a></h2>
+                            <div class="event-tags">
+                                <span class="badge event-type {e.typeCss}">{e.typeLabel}</span>
+                                <span class="badge past">Finalizado</span>
+                            </div>
                             {#if e.descriptionSummary}
                             <p class="event-description">{e.descriptionSummary}</p>
                             {/if}
-                            <span class="badge past">Finalizado</span>
                         </div>
                         <div class="event-countdown">
                             {#if e.formattedDate}
@@ -90,4 +96,3 @@
     </section>
 {/main}
 {/include}
-


### PR DESCRIPTION
## Summary
- introduce EventType with new Hackatón option and defaults for existing events
- expose type selection in admin forms and show badges on home/admin/event detail views
- normalize loaded events and add styling for event type badges

## Testing
- ./scripts/test-fast.sh