### PR TITLE
Doc scaffold for hackathon module

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Latest stable release: **v2.2.1**.
 - In-app notifications for talk status changes
 - Supply chain security with SBOM generation, image signing and vulnerability scanning
 
+## Módulos
+- Hackathon (sin SQL, reutiliza persistencia JSON): `modules/hackathon/README.md`
+- aExperience (experimental): `modules/aexperience/README.md`
+
 ## Quick start
 Run the application in dev mode:
 

--- a/modules/hackathon/README.md
+++ b/modules/hackathon/README.md
@@ -1,0 +1,25 @@
+# Módulo Hackathon
+
+## Propósito
+- Preparar funcionalidades enfocadas en hackatones sin añadir una base de datos nueva.
+- Reutilizar el motor de persistencia actual (JSON + `PersistenceService`) para eventos, speakers y agendas.
+- Apoyarse en `EventType.HACKATHON` para diferenciar flujos y vistas sin romper eventos existentes.
+
+## Alcance inicial (MVP)
+- Plantillas y endpoints mínimos sobre el modelo actual para publicar agenda y resultados del hackatón.
+- Soporte de registro y seguimiento rápido (equipos/proyectos) usando el storage existente.
+- UI: mostrar badges de tipo Hackatón y permitir selección desde el panel Admin (ya habilitado en #62).
+
+## Enfoque técnico
+- Persistencia: misma carpeta `data/` y archivos JSON utilizados por `PersistenceService` (sin SQL ni migraciones).
+- Dominio: reutilizar `Event`, `Talk` y `Scenario`; extender con modelos livianos para `Team`/`Project` si se necesitan.
+- Feature flag sugerido: `feature.hackathon.enabled=true|false` para aislar el módulo.
+- Integración: rutas bajo `/hackathon` (público) y `/private/hackathon` (admin), apoyándose en la seguridad ya disponible.
+
+## Pendientes sugeridos
+- Definir DTOs/base de datos en memoria para equipos y proyectos.
+- Página pública de proyectos + tablero de resultados.
+- Exportar estado a JSON para juzgado y premiación.
+- Documentar comandos rápidos de build/test específicos del módulo (cuando existan).
+
+> Objetivo: entregar valor rápido para eventos de hackatón reutilizando al máximo la infraestructura existente.


### PR DESCRIPTION
## Summary
- add hackathon module scaffold under modules/hackathon with purpose, scope and persistence plan
- document reuse of existing JSON persistence and the new EventType.HACKATHON flows
- link module docs from README for easy discovery

## Testing
- not run (docs only)