### PR TITLE
Fix: limit form session timeout to dev

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -38,7 +38,6 @@ quarkus.jackson.serialization-inclusion=non-null
 quarkus.http.proxy.proxy-address-forwarding=true
 quarkus.http.proxy.allow-forwarded=true
 quarkus.http.auth.session.encryption-key=${SESSION_KEY}
-quarkus.http.auth.session.timeout=PT15M
 quarkus.http.auth.permission.private.paths=/private/*
 quarkus.http.auth.permission.private.policy=authenticated
 
@@ -58,6 +57,7 @@ quarkus.http.auth.permission.private.policy=authenticated
 %dev.quarkus.http.auth.form.username-parameter=username
 %dev.quarkus.http.auth.form.password-parameter=password
 %dev.quarkus.http.auth.form.landing-page=/profile
+%dev.quarkus.http.auth.session.timeout=PT15M
 %dev.ADMIN_LIST=admin@example.org,sergio.canales.e@gmail.com
 %dev.app.auth.local-enabled=true
 %dev.app.auth.local-users=usuario: user@example.com / userpass; admin: admin@example.org / adminpass


### PR DESCRIPTION
## Summary
- move quarkus.http.auth.session.timeout to the dev profile to silence config warnings in prod builds

## Testing
- ./scripts/test-all.sh