### PR TITLE
test: cover rate limiting and notifications

### DIFF
--- a/quarkus-app/src/test/java/com/scanales/eventflow/metrics/ServerErrorMetricsMapperTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/metrics/ServerErrorMetricsMapperTest.java
@@ -1,0 +1,27 @@
+package com.scanales.eventflow.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import com.scanales.eventflow.service.UsageMetricsService;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.Test;
+
+class ServerErrorMetricsMapperTest {
+
+  @Test
+  void recordsServerErrorAndReturns500() {
+    UsageMetricsService metrics = mock(UsageMetricsService.class);
+    UriInfo uri = mock(UriInfo.class);
+    when(uri.getPath()).thenReturn("api/test");
+
+    ServerErrorMetricsMapper mapper = new ServerErrorMetricsMapper();
+    mapper.metrics = metrics;
+
+    Response r = mapper.map(new RuntimeException("boom"), uri);
+
+    verify(metrics).recordServerError("/api/test");
+    assertEquals(500, r.getStatus());
+  }
+}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/security/RateLimitingFilterTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/security/RateLimitingFilterTest.java
@@ -1,0 +1,65 @@
+package com.scanales.eventflow.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class RateLimitingFilterTest {
+
+  private RateLimitingFilter filter;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    filter = new RateLimitingFilter();
+    setField("enabled", true);
+    setField("windowSeconds", 60);
+    setField("authLimit", 2);
+    setField("logoutLimit", 1);
+    setField("apiLimit", 2);
+  }
+
+  @Test
+  void throttlesAuthBucketAfterLimit() {
+    ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+    UriInfo uri = mock(UriInfo.class);
+    when(uri.getPath()).thenReturn("login");
+    when(ctx.getUriInfo()).thenReturn(uri);
+    when(ctx.getHeaderString("X-Forwarded-For")).thenReturn("1.1.1.1");
+
+    // First two pass
+    filter.filter(ctx);
+    filter.filter(ctx);
+
+    ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+    filter.filter(ctx);
+
+    verify(ctx, times(1)).abortWith(captor.capture());
+    assertEquals(429, captor.getValue().getStatus());
+  }
+
+  @Test
+  void skipsStaticAssets() {
+    ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+    UriInfo uri = mock(UriInfo.class);
+    when(uri.getPath()).thenReturn("css/app.css");
+    when(ctx.getUriInfo()).thenReturn(uri);
+
+    filter.filter(ctx);
+
+    verify(ctx, never()).abortWith(any());
+  }
+
+  private void setField(String name, Object value) throws Exception {
+    Field f = RateLimitingFilter.class.getDeclaredField(name);
+    f.setAccessible(true);
+    f.set(filter, value);
+  }
+}

--- a/quarkus-app/src/test/java/io/eventflow/notifications/rest/NotificationResourceTest.java
+++ b/quarkus-app/src/test/java/io/eventflow/notifications/rest/NotificationResourceTest.java
@@ -1,23 +1,29 @@
 package io.eventflow.notifications.rest;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-public class NotificationResourceTest {
+class NotificationResourceTest {
 
   @Test
-  public void legacyEndpointReturnsGone() {
+  void returnsGoneForAllOperations() {
     given()
         .when()
         .get("/api/notifications")
         .then()
         .statusCode(410)
-        .body("error", is("notifications-now-global"))
-        .body("hint", containsString("/ws/global-notifications"));
+        .body("error", equalTo("notifications-now-global"))
+        .body("hint", containsString("global"));
+
+    given()
+        .when()
+        .post("/api/notifications/anything")
+        .then()
+        .statusCode(410)
+        .body("error", equalTo("notifications-now-global"));
   }
 }


### PR DESCRIPTION
## Summary
- add unit test for RateLimitingFilter covering auth throttling and static skips
- add REST test asserting /api/notifications now returns 410 with hint
- add server error mapper test to ensure metrics record and 500 response

## Testing
- ./scripts/test-fast.sh
- ./scripts/test-all.sh