### PR TITLE
chore: deploy main to vps via podman

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to GKE
+name: Deploy to VPS (Podman)
 
 on:
   workflow_call:
@@ -6,59 +6,39 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    container:
-      image: google/cloud-sdk:latest
-    env:
-      PROJECT_ID: scanales-191111
-      SERVICE_ACCOUNT_NAME: github-actions-deployer
-      GKE_CLUSTER_NAME: eventflow-cluster
-      GKE_ZONE: us-central1
-      GKE_NAMESPACE: eventflow
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Write GCP credentials
+      - name: Prepare SSH key
         env:
-          GCP_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY_JSON }}
-        run: echo "$GCP_SERVICE_ACCOUNT_KEY_JSON" | base64 -d > "$HOME/key.json"
-
-      - name: Authenticate to Google Cloud
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
         run: |
-          gcloud auth activate-service-account --key-file="$HOME/key.json"
-          gcloud config set project "$PROJECT_ID"
-          gcloud config set compute/zone "$GKE_ZONE"
+          if [ -z "${VPS_SSH_KEY:-}" ]; then
+            echo "VPS_SSH_KEY secret is required"; exit 1; fi
+          install -m 700 -d ~/.ssh
+          echo "${VPS_SSH_KEY}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
 
-      - name: Configure kubectl
-        run: |
-          gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --zone "$GKE_ZONE" --project "$PROJECT_ID"
-
-      - name: Update OAuth secret
+      - name: Deploy via Podman on VPS
         env:
-          OIDC_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-          OIDC_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-          OIDC_AUTH_SERVER_URL: ${{ secrets.OIDC_AUTH_SERVER_URL }}
-          OIDC_AUTH_URI: ${{ secrets.OIDC_AUTH_URI }}
-          OIDC_TOKEN_URI: ${{ secrets.OIDC_TOKEN_URI }}
-          OIDC_JWKS_URI: ${{ secrets.OIDC_JWKS_URI }}
-          OIDC_REDIRECT_URI: ${{ secrets.OIDC_REDIRECT_URI }}
+          VPS_HOST: ${{ vars.VPS_HOST }}
+          VPS_USER: ${{ vars.VPS_USER }}
+          VPS_PORT: ${{ vars.VPS_PORT || '22' }}
+          APP_PORT: ${{ vars.APP_PORT || '8080' }}
+          REF: ${{ vars.IMAGE_REF }}
         run: |
-          kubectl -n "$GKE_NAMESPACE" create secret generic google-oauth \
-            --from-literal=client-id="$OIDC_CLIENT_ID" \
-            --from-literal=client-secret="$OIDC_CLIENT_SECRET" \
-            --from-literal=auth-server-url="$OIDC_AUTH_SERVER_URL" \
-            --from-literal=auth-uri="$OIDC_AUTH_URI" \
-            --from-literal=token-uri="$OIDC_TOKEN_URI" \
-            --from-literal=jwks-uri="$OIDC_JWKS_URI" \
-            --from-literal=redirect-uri="$OIDC_REDIRECT_URI" \
-            --dry-run=client -o yaml | kubectl apply -f -
-
-      - name: Apply Kubernetes manifests
-        run: |
-          kubectl apply -n "$GKE_NAMESPACE" -f deployment/namespace.yaml
-          kubectl apply -n "$GKE_NAMESPACE" -f deployment/managed-cert.yaml
-          kubectl apply -n "$GKE_NAMESPACE" -f deployment/service.yaml
-          kubectl apply -n "$GKE_NAMESPACE" -f deployment/deployment.yaml
-          kubectl apply -n "$GKE_NAMESPACE" -f deployment/ingress.yaml
-          kubectl apply -n "$GKE_NAMESPACE" -f deployment/pvc.yaml
-          kubectl rollout restart deployment eventflow -n "$GKE_NAMESPACE"
+          if [ -z "${VPS_HOST}" ] || [ -z "${VPS_USER}" ] || [ -z "${REF}" ]; then
+            echo "VPS_HOST, VPS_USER, and IMAGE_REF vars are required"; exit 1; fi
+          ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -p "${VPS_PORT:-22}" "${VPS_USER}@${VPS_HOST}" <<EOF
+          set -euo pipefail
+          IMAGE="${REF}"
+          CONTAINER_NAME=homedir
+          APP_PORT="${APP_PORT:-8080}"
+          podman pull "$IMAGE"
+          if podman ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}\$"; then
+            podman stop "${CONTAINER_NAME}" || true
+            podman rm "${CONTAINER_NAME}" || true
+          fi
+          podman run -d --name "${CONTAINER_NAME}" --restart=always -p "\${APP_PORT}:8080" "$IMAGE"
+          EOF

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -8,10 +8,10 @@ on:
 env:
   REGISTRY: ${{ vars.REGISTRY }}
   IMAGE_NAME: ${{ vars.IMAGE_NAME }}
-  GKE_PROJECT: ${{ vars.GKE_PROJECT }}
-  GKE_CLUSTER: ${{ vars.GKE_CLUSTER }}
-  GKE_LOCATION: ${{ vars.GKE_LOCATION }}
-  GKE_NAMESPACE: ${{ vars.GKE_NAMESPACE || 'prod' }}
+  VPS_HOST: ${{ vars.VPS_HOST }}
+  VPS_USER: ${{ vars.VPS_USER }}
+  VPS_PORT: ${{ vars.VPS_PORT || '22' }}
+  APP_PORT: ${{ vars.APP_PORT || '8080' }}
   GH_TOKEN: ${{ github.token }}
 
 jobs:
@@ -62,31 +62,35 @@ jobs:
         run: |
           cosign verify --key <(printf "%s" "${COSIGN_PUBLIC_KEY}") "$REF" || exit 1
 
-      - name: Auth to GCP
-        uses: google-github-actions/auth@v3
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Get GKE credentials
-        uses: google-github-actions/get-gke-credentials@v3
-        with:
-          cluster_name: ${{ env.GKE_CLUSTER }}
-          location: ${{ env.GKE_LOCATION }}
-          project_id: ${{ env.GKE_PROJECT }}
-
-      - name: Apply manifests & rollout (by digest)
+      - name: Prepare SSH key
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
         run: |
-          kubectl apply -n "$GKE_NAMESPACE" -f deployment/namespace.yaml
-          kubectl apply -n "$GKE_NAMESPACE" -f deployment/managed-cert.yaml
-          kubectl apply -n "$GKE_NAMESPACE" -f deployment/service.yaml
-          kubectl apply -n "$GKE_NAMESPACE" -f deployment/deployment.yaml
-          kubectl apply -n "$GKE_NAMESPACE" -f deployment/ingress.yaml
-          kubectl apply -n "$GKE_NAMESPACE" -f deployment/pvc.yaml
-          kubectl -n "$GKE_NAMESPACE" set image deployment/eventflow eventflow="$REF"
-          kubectl rollout status deployment/eventflow -n "$GKE_NAMESPACE"
+          if [ -z "${VPS_SSH_KEY:-}" ]; then
+            echo "VPS_SSH_KEY secret is required"; exit 1; fi
+          install -m 700 -d ~/.ssh
+          echo "${VPS_SSH_KEY}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
 
-      - name: Add traceability tag (main-<shortsha>)
-        if: steps.ref.outcome == 'success'
+      - name: Deploy via Podman on VPS
+        env:
+          VPS_HOST: ${{ env.VPS_HOST }}
+          VPS_USER: ${{ env.VPS_USER }}
+          VPS_PORT: ${{ env.VPS_PORT }}
+          APP_PORT: ${{ env.APP_PORT }}
+          REF: ${{ env.REF }}
         run: |
-          SHORT=$(echo "${{ github.sha }}" | cut -c1-12)
-          skopeo copy docker://$REF docker://${REGISTRY}/${IMAGE_NAME}:main-${SHORT}
+          if [ -z "${VPS_HOST}" ] || [ -z "${VPS_USER}" ]; then
+            echo "VPS_HOST and VPS_USER must be set as repository variables"; exit 1; fi
+          ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -p "${VPS_PORT:-22}" "${VPS_USER}@${VPS_HOST}" <<EOF
+          set -euo pipefail
+          IMAGE="${REF}"
+          CONTAINER_NAME=homedir
+          APP_PORT="${APP_PORT:-8080}"
+          podman pull "$IMAGE"
+          if podman ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}\$"; then
+            podman stop "${CONTAINER_NAME}" || true
+            podman rm "${CONTAINER_NAME}" || true
+          fi
+          podman run -d --name "${CONTAINER_NAME}" --restart=always -p "\${APP_PORT}:8080" "$IMAGE"
+          EOF


### PR DESCRIPTION
## Summary
- replace GKE deployment with SSH-based podman rollout to VPS
- expect repo vars VPS_HOST, VPS_USER, optional VPS_PORT/APP_PORT, and secret VPS_SSH_KEY
- stop existing container, pull image digest, and run homedir with restart=always

## Testing
- config-only change; no code/tests