### PR TITLE
chore: default quay registry for homedir

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,10 +26,13 @@ jobs:
           VPS_USER: ${{ vars.VPS_USER }}
           VPS_PORT: ${{ vars.VPS_PORT || '22' }}
           APP_PORT: ${{ vars.APP_PORT || '8080' }}
+          REGISTRY: ${{ vars.REGISTRY || 'quay.io/sergio_canales_e' }}
+          IMAGE_NAME: ${{ vars.IMAGE_NAME || 'homedir' }}
           REF: ${{ vars.IMAGE_REF }}
         run: |
           if [ -z "${VPS_HOST}" ] || [ -z "${VPS_USER}" ] || [ -z "${REF}" ]; then
             echo "VPS_HOST, VPS_USER, and IMAGE_REF vars are required"; exit 1; fi
+          echo "Using registry: ${REGISTRY:-unset}, image: ${IMAGE_NAME:-unset}"
           ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -p "${VPS_PORT:-22}" "${VPS_USER}@${VPS_HOST}" <<EOF
           set -euo pipefail
           IMAGE="${REF}"

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -6,8 +6,8 @@ on:
     branches: [main]
 
 env:
-  REGISTRY: ${{ vars.REGISTRY }}
-  IMAGE_NAME: ${{ vars.IMAGE_NAME }}
+  REGISTRY: ${{ vars.REGISTRY || 'quay.io/sergio_canales_e' }}
+  IMAGE_NAME: ${{ vars.IMAGE_NAME || 'homedir' }}
   VPS_HOST: ${{ vars.VPS_HOST }}
   VPS_USER: ${{ vars.VPS_USER }}
   VPS_PORT: ${{ vars.VPS_PORT || '22' }}


### PR DESCRIPTION
## Summary
- set registry/image defaults to quay.io/sergio_canales_e/homedir when vars not provided
- keep VPS podman deploy flow; logs registry used for traceability

## Testing
- workflow-only change (not executed here)