### PR TITLE
chore: use quay username from vars

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -83,7 +83,7 @@ jobs:
         env:
           IMAGE: ${{ env.IMAGE }}
           PRTAG: ${{ env.PRTAG }}
-          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_USERNAME: ${{ vars.QUAY_USERNAME }}
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
         run: |
           if [ -z "${REGISTRY:-}" ]; then


### PR DESCRIPTION
## Summary
- read QUAY_USERNAME from GitHub vars (QUAY_PASSWORD remains a secret)
- keeps build-native aligned with deployment defaults

## Testing
- workflow change only