### PR TITLE
fix: use quay username from vars in deploy

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -26,7 +26,11 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Login to Quay
-        run: echo "${{ secrets.QUAY_PASSWORD }}" | docker login "${REGISTRY}" -u "${{ secrets.QUAY_USERNAME }}" --password-stdin
+        env:
+          QUAY_USERNAME: ${{ vars.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+        run: |
+          echo "${QUAY_PASSWORD}" | docker login "${REGISTRY}" -u "${QUAY_USERNAME}" --password-stdin
 
       - name: Resolve image digest
         id: ref


### PR DESCRIPTION
## Summary
- deploy workflow now pulls QUAY_USERNAME from GitHub vars (password remains secret)
- fixes docker login for main deploy to quay.io/sergio_canales_e/homedir defaults

## Testing
- workflow change only