### PR TITLE
chore: pass oidc secrets to vps podman run

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -83,6 +83,8 @@ jobs:
           VPS_PORT: ${{ env.VPS_PORT }}
           APP_PORT: ${{ env.APP_PORT }}
           REF: ${{ env.REF }}
+          OIDC_CLIENT_ID: ${{ secrets.OIDC_CLIENT_ID }}
+          OIDC_CLIENT_SECRET: ${{ secrets.OIDC_CLIENT_SECRET }}
         run: |
           if [ -z "${VPS_HOST}" ] || [ -z "${VPS_USER}" ]; then
             echo "VPS_HOST and VPS_USER must be set as repository variables"; exit 1; fi
@@ -102,6 +104,8 @@ jobs:
           podman run -d --name "${CONTAINER_NAME}" --restart=always \
             -p "\${APP_PORT}:8080" \
             -e eventflow.data.dir=/work/data \
+            -e OIDC_CLIENT_ID="${OIDC_CLIENT_ID}" \
+            -e OIDC_CLIENT_SECRET="${OIDC_CLIENT_SECRET}" \
             -v "\${DATA_DIR}:/work/data:Z" \
             "$IMAGE"
           EOF


### PR DESCRIPTION
## Summary
- inject OIDC_CLIENT_ID and OIDC_CLIENT_SECRET from GitHub secrets into the podman run on VPS
- keeps existing volume/port settings and restart policy

## Testing
- workflow change only