### PR TITLE
chore: bump version references to 2.2.2

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -10,7 +10,7 @@
 
 Plataforma inteligente de gestión de eventos: espacios, actividades, ponentes, asistentes y planificación personalizada.
 
-Versión estable más reciente: **v2.2.1**.
+Versión estable más reciente: **v2.2.2**.
 
 ## Funciones
 - Gestiona eventos, ponentes, escenarios y charlas
@@ -72,4 +72,5 @@ Para divulgación coordinada de vulnerabilidades, consulta [SECURITY.es.md](SECU
 
 ## Integración Navia × ElevenLabs
 Para ejecutar el MVP local que valida cache + RAG consulta [docs/es/navia-elevenlabs-mvp.md](docs/es/navia-elevenlabs-mvp.md).
+
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ La estrategia de persistencia de EventFlow está documentada en:
  - [ADR 2025-09-07: Persistencia centralizada](docs/es/architecture/ADR-2025-09-07-persistence-service-centralized.md)
 
 
-Latest stable release: **v2.2.1**.
+Latest stable release: **v2.2.2**.
 
 ## Features
 - Manage events, speakers, scenarios, and talks
@@ -91,3 +91,4 @@ The build produces SBOMs for dependencies and container images and scans images 
 Project supported by the OpenSource Santiago community. Join our [Discord server](https://discord.gg/3eawzc9ybc).
 
 For coordinated vulnerability disclosure, see [SECURITY.md](SECURITY.md).
+

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,14 @@
-# EventFlow 2.2.1
+# EventFlow 2.2.2
 
 **Resumen**
 - Correcciones menores y mejoras de documentación.
 - Calidad: pipelines ajustados y verificación actualizada.
-- Supply chain: imagen `:2.2.1` firmada + SBOM; deploy por digest.
+- Supply chain: imagen `:2.2.2` firmada + SBOM; deploy por digest.
 
 **Detalles**
 - Ver CHANGELOG para lista completa.
 
 **Container**
-- `quay.io/sergio_canales_e/eventflow:2.2.1` (alias)
+- `quay.io/sergio_canales_e/eventflow:2.2.2` (alias)
 - Despliegue por digest recomendado (CD actual lo aplica).
+

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -2,15 +2,15 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: eventflow
-  namespace: eventflow
+  name: homedir
+  namespace: homedir
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: eventflow
+      app: homedir
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -19,12 +19,12 @@ spec:
   template:
     metadata:
       labels:
-        app: eventflow
+        app: homedir
     spec:
       containers:
-        - name: eventflow
+        - name: homedir
           # Alias tag; production uses immutable digests
-          image: quay.io/sergio_canales_e/eventflow:2.2.1
+          image: quay.io/sergio_canales_e/homedir:2.2.2
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -45,7 +45,7 @@ spec:
             failureThreshold: 3
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-XX:+UseContainerSupport -Deventflow.data.dir=/work/data -Dvertx.disableFileCaching=true -Dvertx.disableFileCPResolving=true"
+              value: "-XX:+UseContainerSupport -Dhomedir.data.dir=/work/data -Dvertx.disableFileCaching=true -Dvertx.disableFileCPResolving=true"
             - name: OIDC_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -108,7 +108,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: eventflow-data
+            claimName: homedir-data
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -117,3 +117,4 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       terminationGracePeriodSeconds: 30
+

--- a/docs/en/ci-cd.md
+++ b/docs/en/ci-cd.md
@@ -31,9 +31,11 @@ After merging to `main`:
 
 ```bash
 git fetch origin && git checkout main && git pull
-git tag -a v2.2.1 -m "EventFlow 2.2.1"
-git push origin v2.2.1
+git tag -a v2.2.2 -m "EventFlow 2.2.2"
+git push origin v2.2.2
 
 # Optional GitHub Release
-gh release create v2.2.1 -F RELEASE_NOTES.md -t "EventFlow 2.2.1"
+gh release create v2.2.2 -F RELEASE_NOTES.md -t "EventFlow 2.2.2"
 ```
+
+

--- a/docs/es/ci-cd.md
+++ b/docs/es/ci-cd.md
@@ -31,9 +31,10 @@ Después de fusionarse con 'Main`:
 
 `` `Bash
 Git Fetch Origin && Git Checkout Main && Git Pull
-git etiqueta -a v2.2.1 -m "eventflow 2.2.1"
-Git Push Origin v2.2.1
+git etiqueta -a v2.2.2 -m "eventflow 2.2.2"
+Git Push Origin v2.2.2
 
 # Lanzamiento opcional de GitHub
-GH Release Create v2.2.1 -f libe_notes.md -t "Eventflow 2.2.1"
+GH Release Create v2.2.2 -f libe_notes.md -t "eventflow 2.2.2"
 `` `` ``
+

--- a/quarkus-app/README.md
+++ b/quarkus-app/README.md
@@ -71,7 +71,7 @@ native executable:
 
 After getting a cup of coffee, you'll be able to run this executable directly:
 
-> ./target/eventflow-2.2.1-runner
+> ./target/eventflow-2.2.2-runner
 
 
 ## Google Login Demo
@@ -100,4 +100,5 @@ Configure SmallRye JWT to validate Google ID tokens against Google's public keys
 Set the `GOOGLE_CLIENT_ID` environment variable to your OAuth client ID so that
 tokens with a matching `aud` claim are accepted. Adjust the `issuer` value if
 your tokens use `accounts.google.com` without the `https` scheme.
+
 

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.scanales</groupId>
     <artifactId>eventflow</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2</version>
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/quarkus-app/src/main/docker/Dockerfile.jvm
+++ b/quarkus-app/src/main/docker/Dockerfile.jvm
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t eventflow:2.2.1 .
+# docker build -f src/main/docker/Dockerfile.jvm -t eventflow:2.2.2 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow:2.2.1
+# docker run -i --rm -p 8080:8080 eventflow:2.2.2
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
@@ -20,7 +20,7 @@
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 eventflow:2.2.1
+# docker run -i --rm -p 8080:8080 eventflow:2.2.2
 #
 # This image uses the `run-java.sh` script to run the application.
 # This scripts computes the command line to execute your Java application, and
@@ -95,4 +95,5 @@ ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=or
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
 ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]
+
 

--- a/quarkus-app/src/main/docker/Dockerfile.legacy-jar
+++ b/quarkus-app/src/main/docker/Dockerfile.legacy-jar
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.legacy-jar -t eventflow:2.2.1 .
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t eventflow:2.2.2 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow:2.2.1
+# docker run -i --rm -p 8080:8080 eventflow:2.2.2
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
@@ -20,7 +20,7 @@
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 eventflow:2.2.1
+# docker run -i --rm -p 8080:8080 eventflow:2.2.2
 #
 # This image uses the `run-java.sh` script to run the application.
 # This scripts computes the command line to execute your Java application, and
@@ -92,3 +92,4 @@ ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=or
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
 ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]
+

--- a/quarkus-app/src/main/docker/Dockerfile.native
+++ b/quarkus-app/src/main/docker/Dockerfile.native
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native -t eventflow-native:2.2.1 .
+# docker build -f src/main/docker/Dockerfile.native -t eventflow-native:2.2.2 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow-native:2.2.1
+# docker run -i --rm -p 8080:8080 eventflow-native:2.2.2
 #
 # The base image has been switched to a distroless variant to reduce the attack surface
 ###
@@ -21,3 +21,4 @@ COPY --chown=1001:1001 --chmod=500 target/*-runner /work/application
 USER 1001
 EXPOSE 8080
 ENTRYPOINT ["./application"]
+

--- a/quarkus-app/src/main/docker/Dockerfile.native-micro
+++ b/quarkus-app/src/main/docker/Dockerfile.native-micro
@@ -10,11 +10,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native-micro -t eventflow-native:2.2.1 .
+# docker build -f src/main/docker/Dockerfile.native-micro -t eventflow-native:2.2.2 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow-native:2.2.1
+# docker run -i --rm -p 8080:8080 eventflow-native:2.2.2
 #
 # The `quay.io/quarkus/ubi9-quarkus-micro-image:2.0` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/quarkus/quarkus-micro-image:2.0`.
@@ -30,3 +30,4 @@ EXPOSE 8080
 USER 1001
 
 ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]
+

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -89,7 +89,7 @@ public class HomeResource {
             "issuesUrl", "https://github.com/scanalesespinoza/eventflow/issues",
             "donateUrl", "https://ko-fi.com/sergiocanales");
     var nowBox = nowBoxService.build();
-    return Templates.home(upcoming, past, today, "2.2.1", stats, links, nowBox);
+    return Templates.home(upcoming, past, today, "2.2.2", stats, links, nowBox);
   }
 
   @GET
@@ -99,3 +99,4 @@ public class HomeResource {
     return Response.status(Response.Status.MOVED_PERMANENTLY).location(URI.create("/")).build();
   }
 }
+

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -19,7 +19,7 @@ quarkus.oidc.token.principal-claim=id_token
 %prod.mp.jwt.verify.audiences=${GOOGLE_CLIENT_ID}
 %prod.smallrye.jwt.verify.algorithm=RS256
 # Application version
-quarkus.application.version=2.2.1
+quarkus.application.version=2.2.2
 # Store Vert.x cache on a writable volume
 quarkus.vertx.cache-directory=${eventflow.data.dir:./data}/vertx-cache
 # Store HTTP file uploads on a writable volume


### PR DESCRIPTION
## Summary
- bump project version to 2.2.2 in pom, application.properties, home template version string
- update docs/README/deployment image tags and Dockerfile comments to 2.2.2 (quay.io/sergio_canales_e/homedir)
- adjust release notes/ci-cd docs to reference v2.2.2

## Testing
- ./scripts/test-fast.sh