### PR TITLE
Fix deploy workflows image ref resolution and envs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      DATA_DIR: ${{ vars.DATA_DIR || '/opt/homedir/data' }}
+      FALLBACK_IMAGE_REF: ${{ vars.IMAGE_REF }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -53,22 +56,38 @@ jobs:
           APP_PORT: ${{ vars.APP_PORT || '8080' }}
           REGISTRY: ${{ vars.REGISTRY || 'quay.io/sergio_canales_e' }}
           IMAGE_NAME: ${{ vars.IMAGE_NAME || 'homedir' }}
-          IMAGE_REF: ${{ env.IMAGE_REF || vars.IMAGE_REF }}
+          OIDC_CLIENT_ID: ${{ secrets.OIDC_CLIENT_ID }}
+          OIDC_CLIENT_SECRET: ${{ secrets.OIDC_CLIENT_SECRET }}
+          SESSION_KEY: ${{ secrets.SESSION_KEY }}
+          NOTIFICATIONS_USER_HASH_SALT: ${{ secrets.NOTIFICATIONS_USER_HASH_SALT }}
         run: |
           if [ -z "${VPS_HOST}" ] || [ -z "${VPS_USER}" ]; then
             echo "VPS_HOST and VPS_USER must be set as repository variables"; exit 1; fi
-          if [ -z "${IMAGE_REF:-}" ]; then
-            echo "IMAGE_REF must be provided via artifact or vars"; exit 1; fi
           echo "Using registry: ${REGISTRY:-unset}, image: ${IMAGE_NAME:-unset}"
           ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -p "${VPS_PORT:-22}" "${VPS_USER}@${VPS_HOST}" <<EOF
           set -euo pipefail
-          IMAGE="${IMAGE_REF}"
+          IMAGE="${IMAGE_REF:-${FALLBACK_IMAGE_REF:-}}"
+          if [ -z "$IMAGE" ]; then
+            echo "IMAGE_REF must be provided via artifact or vars" >&2
+            exit 1
+          fi
           CONTAINER_NAME=homedir
           APP_PORT="${APP_PORT:-8080}"
+          DATA_DIR="${DATA_DIR:-/opt/homedir/data}"
+          mkdir -p "${DATA_DIR}"
+          chown -R 1001:1001 "${DATA_DIR}" || true
           podman pull "$IMAGE"
           if podman ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}\$"; then
             podman stop "${CONTAINER_NAME}" || true
             podman rm "${CONTAINER_NAME}" || true
           fi
-          podman run -d --name "${CONTAINER_NAME}" --restart=always -p "\${APP_PORT}:8080" "$IMAGE"
+          podman run -d --name "${CONTAINER_NAME}" --restart=always \
+            -p "\${APP_PORT}:8080" \
+            -e eventflow.data.dir=/work/data \
+            -e OIDC_CLIENT_ID="${OIDC_CLIENT_ID}" \
+            -e OIDC_CLIENT_SECRET="${OIDC_CLIENT_SECRET}" \
+            -e SESSION_KEY="${SESSION_KEY}" \
+            -e NOTIFICATIONS_USER_HASH_SALT="${NOTIFICATIONS_USER_HASH_SALT}" \
+            -v "\${DATA_DIR}:/work/data:Z" \
+            "$IMAGE"
           EOF

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -118,7 +118,7 @@ jobs:
           VPS_PORT: ${{ env.VPS_PORT }}
           APP_PORT: ${{ env.APP_PORT }}
           DATA_DIR: ${{ vars.DATA_DIR || '/opt/homedir/data' }}
-          IMAGE_REF: ${{ env.REF }}
+          FALLBACK_IMAGE_REF: ${{ vars.IMAGE_REF }}
           OIDC_CLIENT_ID: ${{ secrets.OIDC_CLIENT_ID }}
           OIDC_CLIENT_SECRET: ${{ secrets.OIDC_CLIENT_SECRET }}
           SESSION_KEY: ${{ secrets.SESSION_KEY }}
@@ -128,7 +128,7 @@ jobs:
             echo "VPS_HOST and VPS_USER must be set as repository variables"; exit 1; fi
           ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -p "${VPS_PORT:-22}" "${VPS_USER}@${VPS_HOST}" <<EOF
           set -euo pipefail
-          IMAGE="${IMAGE_REF}"
+          IMAGE="${IMAGE_REF:-${REF:-${FALLBACK_IMAGE_REF:-}}}"
           if [ -z "$IMAGE" ]; then echo "Empty image ref" >&2; exit 1; fi
           CONTAINER_NAME=homedir
           APP_PORT="${APP_PORT:-8080}"


### PR DESCRIPTION
## Summary
- read image ref from build artifact first, fall back to vars for reusable deploy
- ensure data dir is created/mounted with correct ownership and eventflow.data.dir set
- pass OIDC/SESSION/notifications envs into podman container so Quarkus boots

## Testing
- not run (workflow change only)