### PR TITLE
Free app port before podman run in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,10 +81,14 @@ jobs:
           chown -R 1001:1001 "${DATA_DIR}" || true
           podman pull "$IMAGE"
           # Stop any container currently bound to the target port to avoid EADDRINUSE
-          for c in $(podman ps -a --format '{{.Names}} {{.Ports}}' | awk '/8080/ {print $1}'); do
+          for c in $(podman ps -a --format '{{.Names}} {{.Ports}}' | awk "/${APP_PORT:-8080}/ {print \$1}"); do
             podman stop "$c" || true
             podman rm "$c" || true
           done
+          # Kill any other process still holding the port (defensive)
+          if command -v fuser >/dev/null 2>&1; then
+            fuser -k "${APP_PORT}/tcp" || true
+          fi
           if podman ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}\$"; then
             podman stop "${CONTAINER_NAME}" || true
             podman rm "${CONTAINER_NAME}" || true

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -141,10 +141,14 @@ jobs:
           chown -R 1001:1001 "${DATA_DIR}" || true
           podman pull "$IMAGE"
           # Stop any container currently bound to the target port to avoid EADDRINUSE
-          for c in $(podman ps -a --format '{{.Names}} {{.Ports}}' | awk '/8080/ {print $1}'); do
+          for c in $(podman ps -a --format '{{.Names}} {{.Ports}}' | awk "/${APP_PORT:-8080}/ {print \$1}"); do
             podman stop "$c" || true
             podman rm "$c" || true
           done
+          # Kill any other process still holding the port (defensive)
+          if command -v fuser >/dev/null 2>&1; then
+            fuser -k "${APP_PORT}/tcp" || true
+          fi
           if podman ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}\$"; then
             podman stop "${CONTAINER_NAME}" || true
             podman rm "${CONTAINER_NAME}" || true


### PR DESCRIPTION
## Summary
- stop any podman container publishing the app port using the configured APP_PORT
- aggressively free the port with fuser to avoid EADDRINUSE before launching the new container

## Testing
- not run (workflow change only)