### PR TITLE
Fix homepage links and container name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
           ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -p "${VPS_PORT:-22}" "${VPS_USER}@${VPS_HOST}" <<EOF
           set -euo pipefail
           IMAGE="${IMAGE}"
-          CONTAINER_NAME=homedir
+          CONTAINER_NAME="${IMAGE_NAME:-homedir}"
           APP_PORT="${APP_PORT:-8080}"
           DATA_DIR="${DATA_DIR:-/opt/homedir/data}"
           mkdir -p "${DATA_DIR}"

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -134,7 +134,7 @@ jobs:
           ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -p "${VPS_PORT:-22}" "${VPS_USER}@${VPS_HOST}" <<EOF
           set -euo pipefail
           IMAGE="${IMAGE}"
-          CONTAINER_NAME=homedir
+          CONTAINER_NAME="${IMAGE_NAME:-homedir}"
           APP_PORT="${APP_PORT:-8080}"
           DATA_DIR="${DATA_DIR:-/opt/homedir/data}"
           mkdir -p "${DATA_DIR}"

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -85,8 +85,8 @@ public class HomeResource {
             today.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")));
     var links =
         Map.of(
-            "releasesUrl", "https://github.com/scanalesespinoza/eventflow/releases",
-            "issuesUrl", "https://github.com/scanalesespinoza/eventflow/issues",
+            "releasesUrl", "https://github.com/os-santiago/homedir/releases",
+            "issuesUrl", "https://github.com/os-santiago/homedir/issues",
             "donateUrl", "https://ko-fi.com/sergiocanales");
     var nowBox = nowBoxService.build();
     return Templates.home(upcoming, past, today, "2.2.2", stats, links, nowBox);
@@ -99,4 +99,3 @@ public class HomeResource {
     return Response.status(Response.Status.MOVED_PERMANENTLY).location(URI.create("/")).build();
   }
 }
-


### PR DESCRIPTION
## Summary
- point homepage Releases/Issues buttons to os-santiago/homedir instead of the old repo
- let deploy workflows name the podman container using IMAGE_NAME (defaults to homedir)

## Testing
- not run (config/docs change only)