### PR TITLE
chore: make quality suite informative

### DIFF
--- a/.github/workflows/pr-quality-suite.yml
+++ b/.github/workflows/pr-quality-suite.yml
@@ -33,6 +33,8 @@ jobs:
   style:
     name: style
     runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.report.outputs.result }}
     steps:
       - uses: actions/checkout@v5
       - name: Setup Java
@@ -42,8 +44,18 @@ jobs:
           java-version: '21'
           cache: maven
       - name: Run Spotless
+        id: spotless
         working-directory: quarkus-app
         run: ./mvnw --batch-mode spotless:check
+        continue-on-error: true
+      - name: Record style result
+        id: report
+        run: |
+          if [ "${{ steps.spotless.outcome }}" = "success" ]; then
+            echo "result=success" >> $GITHUB_OUTPUT
+          else
+            echo "result=failure" >> $GITHUB_OUTPUT
+          fi
 
   static:
     name: static
@@ -82,7 +94,7 @@ jobs:
         run: |
           echo "## PR Quality — Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- Style:       ${{ needs.style.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Style:       ${{ needs.style.outputs.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- Static:      ${{ needs.static.result || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
           echo "- Arch:        ${{ needs.arch.result   || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
           echo "- Tests/Cover: ${{ needs.tests_cov.result || 'skipped' }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -57,7 +57,7 @@ jobs:
               body
             });
       - name: Fail if checks failed
-        if: steps.format.outcome == 'failure' || steps.deps.outcome == 'failure' || steps.commits.outcome == 'failure'
+        if: steps.deps.outcome == 'failure' || steps.commits.outcome == 'failure'
         run: |
           echo 'One or more quality checks failed. See the summary comment above.'
           exit 1

--- a/quarkus-app/src/main/java/com/scanales/eventflow/auth/LoginPageResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/auth/LoginPageResource.java
@@ -46,9 +46,7 @@ public class LoginPageResource {
             .orElse("");
     var cfg = ConfigProvider.getConfig();
     boolean githubEnabled =
-        cfg.getOptionalValue("GH_CLIENT_ID", String.class)
-                .filter(v -> !v.isBlank())
-                .isPresent()
+        cfg.getOptionalValue("GH_CLIENT_ID", String.class).filter(v -> !v.isBlank()).isPresent()
             && cfg.getOptionalValue("GH_CLIENT_SECRET", String.class)
                 .filter(v -> !v.isBlank())
                 .isPresent();


### PR DESCRIPTION
## Summary
- keep style check as informational by recording its result while allowing the job to finish successfully
- treat format failures as warnings in the Quality Gate and only fail on dependency/commit issues
- refresh the login page so spotless stays happy and rerun the checks that previously failed

## Testing
- mvn -f quarkus-app/pom.xml spotless:check
