### PR TITLE
fix: ensure deploy replaces named container

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -112,20 +112,21 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
 
       - name: Deploy via Podman on VPS
-        env:
-          VPS_HOST: ${{ env.VPS_HOST }}
-          VPS_USER: ${{ env.VPS_USER }}
-          VPS_PORT: ${{ env.VPS_PORT }}
-          APP_PORT: ${{ env.APP_PORT }}
-          DATA_DIR: ${{ vars.DATA_DIR || '/opt/homedir/data' }}
-          FALLBACK_IMAGE_REF: ${{ vars.IMAGE_REF }}
-          OIDC_CLIENT_ID: ${{ secrets.OIDC_CLIENT_ID }}
-          OIDC_CLIENT_SECRET: ${{ secrets.OIDC_CLIENT_SECRET }}
-          GH_CLIENT_ID: ${{ vars.GH_CLIENT_ID || secrets.GH_CLIENT_ID }}
-          GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
-          SESSION_KEY: ${{ secrets.SESSION_KEY }}
-          NOTIFICATIONS_USER_HASH_SALT: ${{ secrets.NOTIFICATIONS_USER_HASH_SALT }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      env:
+        VPS_HOST: ${{ env.VPS_HOST }}
+        VPS_USER: ${{ env.VPS_USER }}
+        VPS_PORT: ${{ env.VPS_PORT }}
+        APP_PORT: ${{ env.APP_PORT }}
+        IMAGE_NAME: ${{ vars.IMAGE_NAME || 'homedir' }}
+        DATA_DIR: ${{ vars.DATA_DIR || '/opt/homedir/data' }}
+        FALLBACK_IMAGE_REF: ${{ vars.IMAGE_REF }}
+        OIDC_CLIENT_ID: ${{ secrets.OIDC_CLIENT_ID }}
+        OIDC_CLIENT_SECRET: ${{ secrets.OIDC_CLIENT_SECRET }}
+        GH_CLIENT_ID: ${{ vars.GH_CLIENT_ID || secrets.GH_CLIENT_ID }}
+        GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
+        SESSION_KEY: ${{ secrets.SESSION_KEY }}
+        NOTIFICATIONS_USER_HASH_SALT: ${{ secrets.NOTIFICATIONS_USER_HASH_SALT }}
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           if [ -z "${VPS_HOST}" ] || [ -z "${VPS_USER}" ]; then
             echo "VPS_HOST and VPS_USER must be set as repository variables"; exit 1; fi
@@ -143,6 +144,10 @@ jobs:
           mkdir -p "${DATA_DIR}"
           chown -R 1001:1001 "${DATA_DIR}" || true
           podman pull "$IMAGE"
+          if podman ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}\$"; then
+            podman stop "${CONTAINER_NAME}" || true
+            podman rm -f "${CONTAINER_NAME}" || true
+          fi
           # Stop any container currently bound to the target port to avoid EADDRINUSE
           for c in $(podman ps -a --format '{{.Names}} {{.Ports}}' | awk "/${APP_PORT:-8080}/ {print \$1}"); do
             podman stop "$c" || true


### PR DESCRIPTION
## Summary\n- stop and remove the default named container before running the new image\n- enforce the IMAGE_NAME variable so the VPS always runs the same container that nginx expects\n\n## Testing\n- not run (workflow-only change)