### PR TITLE
test: isolate profile security

### DIFF
--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
@@ -159,6 +159,11 @@ public class ProfileResourceTest {
     assertTrue(details.attended);
   }
 
+  @Test
+  public void currentUserEmailDefaultsToPrincipalName() {
+    assertEquals(securityIdentity.getPrincipal().getName(), currentUserEmail());
+  }
+
   private String currentUserEmail() {
     Object emailAttr = securityIdentity.getAttribute("email");
     if (emailAttr != null && !emailAttr.toString().isBlank()) {


### PR DESCRIPTION
## Summary\n- add a regression test that proves currentUserEmail falls back to the SecurityIdentity principal when the email attribute is missing\n- rely on the injected identity during the existing profile flow tests so they never need to hit real Google/GitHub claims\n\n## Testing\n- mvn -B -f quarkus-app/pom.xml -Dtest=ProfileResourceTest test