### PR TITLE
fix: enforce container lifecycle

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -1,4 +1,3 @@
----
 name: Promote by Digest
 
 on:
@@ -112,21 +111,21 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
 
       - name: Deploy via Podman on VPS
-      env:
-        VPS_HOST: ${{ env.VPS_HOST }}
-        VPS_USER: ${{ env.VPS_USER }}
-        VPS_PORT: ${{ env.VPS_PORT }}
-        APP_PORT: ${{ env.APP_PORT }}
-        IMAGE_NAME: ${{ vars.IMAGE_NAME || 'homedir' }}
-        DATA_DIR: ${{ vars.DATA_DIR || '/opt/homedir/data' }}
-        FALLBACK_IMAGE_REF: ${{ vars.IMAGE_REF }}
-        OIDC_CLIENT_ID: ${{ secrets.OIDC_CLIENT_ID }}
-        OIDC_CLIENT_SECRET: ${{ secrets.OIDC_CLIENT_SECRET }}
-        GH_CLIENT_ID: ${{ vars.GH_CLIENT_ID || secrets.GH_CLIENT_ID }}
-        GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
-        SESSION_KEY: ${{ secrets.SESSION_KEY }}
-        NOTIFICATIONS_USER_HASH_SALT: ${{ secrets.NOTIFICATIONS_USER_HASH_SALT }}
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        env:
+          VPS_HOST: ${{ env.VPS_HOST }}
+          VPS_USER: ${{ env.VPS_USER }}
+          VPS_PORT: ${{ env.VPS_PORT }}
+          APP_PORT: ${{ env.APP_PORT }}
+          IMAGE_NAME: ${{ vars.IMAGE_NAME || 'homedir' }}
+          DATA_DIR: ${{ vars.DATA_DIR || '/opt/homedir/data' }}
+          FALLBACK_IMAGE_REF: ${{ vars.IMAGE_REF }}
+          OIDC_CLIENT_ID: ${{ secrets.OIDC_CLIENT_ID }}
+          OIDC_CLIENT_SECRET: ${{ secrets.OIDC_CLIENT_SECRET }}
+          GH_CLIENT_ID: ${{ vars.GH_CLIENT_ID || secrets.GH_CLIENT_ID }}
+          GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
+          SESSION_KEY: ${{ secrets.SESSION_KEY }}
+          NOTIFICATIONS_USER_HASH_SALT: ${{ secrets.NOTIFICATIONS_USER_HASH_SALT }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           if [ -z "${VPS_HOST}" ] || [ -z "${VPS_USER}" ]; then
             echo "VPS_HOST and VPS_USER must be set as repository variables"; exit 1; fi
@@ -135,19 +134,22 @@ jobs:
           IMAGE="${IMAGE#docker:}"
           if [ -z "$IMAGE" ]; then echo "Empty image ref" >&2; exit 1; fi
           echo "Using image: ${IMAGE}"
-          ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -p "${VPS_PORT:-22}" "${VPS_USER}@${VPS_HOST}" <<EOF
+          ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -p "${VPS_PORT:-22}" "${VPS_USER}@${VPS_HOST}" <<'EOF'
           set -euo pipefail
           IMAGE="${IMAGE}"
           CONTAINER_NAME="${IMAGE_NAME:-homedir}"
           APP_PORT="${APP_PORT:-8080}"
           DATA_DIR="${DATA_DIR:-/opt/homedir/data}"
+          stop_named_container() {
+            if podman ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}\$"; then
+              podman stop "${CONTAINER_NAME}" || true
+              podman rm -f "${CONTAINER_NAME}" || true
+            fi
+          }
           mkdir -p "${DATA_DIR}"
           chown -R 1001:1001 "${DATA_DIR}" || true
           podman pull "$IMAGE"
-          if podman ps -a --format '{{.Names}}' | grep -q "^\${CONTAINER_NAME}\$"; then
-            podman stop "\${CONTAINER_NAME}" || true
-            podman rm -f "\${CONTAINER_NAME}" || true
-          fi
+          stop_named_container
           # Stop any container currently bound to the target port to avoid EADDRINUSE
           for c in $(podman ps -a --format '{{.Names}} {{.Ports}}' | awk "/${APP_PORT:-8080}/ {print \$1}"); do
             podman stop "$c" || true
@@ -157,10 +159,8 @@ jobs:
           if command -v fuser >/dev/null 2>&1; then
             fuser -k "${APP_PORT}/tcp" || true
           fi
-          if podman ps -a --format '{{.Names}}' | grep -q "^\${CONTAINER_NAME}\$"; then
-            podman rm -f "\${CONTAINER_NAME}" || true
-          fi
-          podman run -d --name "\${CONTAINER_NAME}" --restart=always \
+          stop_named_container
+          podman run -d --name "${CONTAINER_NAME}" --restart=always \
             -p "\${APP_PORT}:8080" \
             -e eventflow.data.dir=/work/data \
             -e OIDC_CLIENT_ID="${OIDC_CLIENT_ID}" \


### PR DESCRIPTION
## Summary\n- ensure the deploy step keeps the heredoc literal so the VPS script can access the vars\n- stop/remove the named container before cleaning ports and again before running so only the latest image remains\n\n## Testing\n- not run (workflow-only change)