### PR TITLE
chore: release 2.2.3

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -10,7 +10,7 @@
 
 Plataforma inteligente de gestión de eventos: espacios, actividades, ponentes, asistentes y planificación personalizada.
 
-Versión estable más reciente: **v2.2.2**.
+Versión estable más reciente: **v2.2.3**.
 
 ## Funciones
 - Gestiona eventos, ponentes, escenarios y charlas

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ La estrategia de persistencia de EventFlow está documentada en:
  - [ADR 2025-09-07: Persistencia centralizada](docs/es/architecture/ADR-2025-09-07-persistence-service-centralized.md)
 
 
-Latest stable release: **v2.2.2**.
+Latest stable release: **v2.2.3**.
 
 ## Features
 - Manage events, speakers, scenarios, and talks

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,20 @@
-# EventFlow 2.2.2
+# EventFlow 2.2.3
+
+**Resumen**
+- Canonicaliza el `redirect_uri` de GitHub para que siempre apunte a `/auth/post-login` y mueve la lógica a `GithubLinkService`, evitando diferencias entre entornos y el callback registrado.
+- Añade la propiedad `app.public-url` a la documentación y ajustes de despliegue para que el valor público real se propague en el contenedor; el workflow obtiene el digest correcto más limpio.
+- Actualiza los recursos públicos y los artefactos de build/deploy para que reflejen la nueva versión y los contenedores se publiquen con `2.2.3`.
+
+**Detalles**
+- La interacción con GitHub ya no reconstruye URIs manualmente; el nuevo servicio gestiona cookies y respuestas coherentes con el OAuth app configurado.
+- Las instrucciones de tagging/release se actualizaron a `2.2.3` y los Dockerfiles comentados muestran el tag actual para referencia.
+- Deploy workflow (tag `fix/deploy-logging`) publica el digest, loguea el estado de podman y usa las variables de entorno requeridas sin tocar `URI`s desde el recurso.
+
+**Container**
+- `quay.io/sergio_canales_e/eventflow:2.2.3` (alias)
+- Despliegue por digest siempre que sea posible; el pipeline lo registra en el artefacto `pr-image-ref`.
+
+## EventFlow 2.2.2
 
 **Resumen**
 - Correcciones menores y mejoras de documentación.
@@ -11,4 +27,3 @@
 **Container**
 - `quay.io/sergio_canales_e/eventflow:2.2.2` (alias)
 - Despliegue por digest recomendado (CD actual lo aplica).
-

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
         - name: homedir
           # Alias tag; production uses immutable digests
-          image: quay.io/sergio_canales_e/homedir:2.2.2
+          image: quay.io/sergio_canales_e/homedir:2.2.3
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/docs/en/ci-cd.md
+++ b/docs/en/ci-cd.md
@@ -31,11 +31,11 @@ After merging to `main`:
 
 ```bash
 git fetch origin && git checkout main && git pull
-git tag -a v2.2.2 -m "EventFlow 2.2.2"
-git push origin v2.2.2
+git tag -a v2.2.3 -m "EventFlow 2.2.3"
+git push origin v2.2.3
 
 # Optional GitHub Release
-gh release create v2.2.2 -F RELEASE_NOTES.md -t "EventFlow 2.2.2"
+gh release create v2.2.3 -F RELEASE_NOTES.md -t "EventFlow 2.2.3"
 ```
 
 

--- a/docs/es/ci-cd.md
+++ b/docs/es/ci-cd.md
@@ -31,10 +31,10 @@ Después de fusionarse con 'Main`:
 
 `` `Bash
 Git Fetch Origin && Git Checkout Main && Git Pull
-git etiqueta -a v2.2.2 -m "eventflow 2.2.2"
-Git Push Origin v2.2.2
+git etiqueta -a v2.2.3 -m "eventflow 2.2.3"
+Git Push Origin v2.2.3
 
 # Lanzamiento opcional de GitHub
-GH Release Create v2.2.2 -f libe_notes.md -t "eventflow 2.2.2"
+GH Release Create v2.2.3 -f libe_notes.md -t "eventflow 2.2.3"
 `` `` ``
 

--- a/quarkus-app/README.md
+++ b/quarkus-app/README.md
@@ -71,7 +71,7 @@ native executable:
 
 After getting a cup of coffee, you'll be able to run this executable directly:
 
-> ./target/eventflow-2.2.2-runner
+> ./target/eventflow-2.2.3-runner
 
 
 ## Google Login Demo

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.scanales</groupId>
     <artifactId>eventflow</artifactId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/quarkus-app/src/main/docker/Dockerfile.jvm
+++ b/quarkus-app/src/main/docker/Dockerfile.jvm
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t eventflow:2.2.2 .
+# docker build -f src/main/docker/Dockerfile.jvm -t eventflow:2.2.3 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow:2.2.2
+# docker run -i --rm -p 8080:8080 eventflow:2.2.3
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
@@ -20,7 +20,7 @@
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 eventflow:2.2.2
+# docker run -i --rm -p 8080:8080 eventflow:2.2.3
 #
 # This image uses the `run-java.sh` script to run the application.
 # This scripts computes the command line to execute your Java application, and

--- a/quarkus-app/src/main/docker/Dockerfile.legacy-jar
+++ b/quarkus-app/src/main/docker/Dockerfile.legacy-jar
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.legacy-jar -t eventflow:2.2.2 .
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t eventflow:2.2.3 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow:2.2.2
+# docker run -i --rm -p 8080:8080 eventflow:2.2.3
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
@@ -20,7 +20,7 @@
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 eventflow:2.2.2
+# docker run -i --rm -p 8080:8080 eventflow:2.2.3
 #
 # This image uses the `run-java.sh` script to run the application.
 # This scripts computes the command line to execute your Java application, and

--- a/quarkus-app/src/main/docker/Dockerfile.native
+++ b/quarkus-app/src/main/docker/Dockerfile.native
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native -t eventflow-native:2.2.2 .
+# docker build -f src/main/docker/Dockerfile.native -t eventflow-native:2.2.3 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow-native:2.2.2
+# docker run -i --rm -p 8080:8080 eventflow-native:2.2.3
 #
 # The base image has been switched to a distroless variant to reduce the attack surface
 ###

--- a/quarkus-app/src/main/docker/Dockerfile.native-micro
+++ b/quarkus-app/src/main/docker/Dockerfile.native-micro
@@ -10,11 +10,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native-micro -t eventflow-native:2.2.2 .
+# docker build -f src/main/docker/Dockerfile.native-micro -t eventflow-native:2.2.3 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow-native:2.2.2
+# docker run -i --rm -p 8080:8080 eventflow-native:2.2.3
 #
 # The `quay.io/quarkus/ubi9-quarkus-micro-image:2.0` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/quarkus/quarkus-micro-image:2.0`.

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -89,7 +89,7 @@ public class HomeResource {
             "issuesUrl", "https://github.com/os-santiago/homedir/issues",
             "donateUrl", "https://ko-fi.com/sergiocanales");
     var nowBox = nowBoxService.build();
-    return Templates.home(upcoming, past, today, "2.2.2", stats, links, nowBox);
+    return Templates.home(upcoming, past, today, "2.2.3", stats, links, nowBox);
   }
 
   @GET

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -25,7 +25,7 @@ community.github.default-branch=main
 %prod.mp.jwt.verify.audiences=${GOOGLE_CLIENT_ID}
 %prod.smallrye.jwt.verify.algorithm=RS256
 # Application version
-quarkus.application.version=2.2.2
+quarkus.application.version=2.2.3
 # Store Vert.x cache on a writable volume
 quarkus.vertx.cache-directory=${eventflow.data.dir:./data}/vertx-cache
 # Store HTTP file uploads on a writable volume


### PR DESCRIPTION
## Summary
- Bump every version reference and documentation to 2.2.3 so the next release is aligned across README/deployment docs and Maven artifacts.
- Add the 2.2.3 section to `RELEASE_NOTES.md` that highlights the GitHub OAuth callback fix, `app.public-url` guidance, and the updated deploy workflow.

## Testing
- Not run (metadata/docs only)