### PR TITLE
Improve responsiveness and accessibility polish

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -1,11 +1,12 @@
 :root {
-  --hd-color-bg: var(--color-bg);
-  --hd-color-surface: var(--color-surface-2);
-  --hd-color-border: var(--color-border);
-  --hd-color-primary: var(--color-primary);
-  --hd-color-text: var(--color-text);
-  --hd-color-muted: var(--color-muted);
-  --hd-color-text-primary: #ffffff;
+  --hd-color-bg: #070c1b; /* TODO: confirmar con maqueta */
+  --hd-color-surface: #0f172a; /* TODO: confirmar con maqueta */
+  --hd-color-border: #1f2937; /* TODO: confirmar con maqueta */
+  --hd-color-primary: #2563eb;
+  --hd-color-accent: #22d3ee;
+  --hd-color-text: #e2e8f0;
+  --hd-color-muted: #94a3b8;
+  --hd-color-text-primary: #e8edf7;
   --hd-color-text-secondary: #cbd5e1;
 }
 
@@ -13,11 +14,14 @@
   margin: 0;
   background: var(--hd-color-bg);
   color: var(--hd-color-text);
-  font-family: 'Inter', 'Space Grotesk', 'Helvetica Neue', Arial, sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  /* TODO: reemplazar por fuente de la maqueta (por ejemplo, "Inter", "Poppins", etc.) */
+  font-size: 16px;
+  line-height: 1.5;
 }
 
 .hd-section {
-  padding: clamp(2rem, 4vw, 3rem) 0;
+  padding-block: 4rem;
 }
 
 .hd-page {
@@ -27,6 +31,7 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  padding-inline: clamp(1rem, 4vw, 2rem);
 }
 
 .hd-page-narrow {
@@ -60,6 +65,13 @@
   border-radius: 999px;
 }
 
+a:focus-visible,
+button:focus-visible,
+.hd-form-input:focus-visible {
+  outline: 2px solid var(--hd-color-accent);
+  outline-offset: 2px;
+}
+
 .hd-visually-hidden {
   position: absolute;
   width: 1px;
@@ -75,12 +87,13 @@
 .hd-nav {
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 50;
   backdrop-filter: blur(10px);
-  background: rgba(11, 16, 33, 0.9);
+  background: var(--hd-color-bg);
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
+.hd-nav-inner,
 .hd-nav-bar {
   display: flex;
   align-items: center;
@@ -92,7 +105,7 @@
 }
 
 .hd-nav-brand {
-  color: #fff;
+  color: var(--hd-color-text-primary);
   font-weight: 700;
   letter-spacing: 0.01em;
   text-decoration: none;
@@ -102,10 +115,11 @@
   display: flex;
   gap: 1rem;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 .hd-nav-link {
-  color: var(--hd-color-text);
+  color: var(--hd-color-text-primary);
   text-decoration: none;
   font-weight: 600;
   padding: 0.5rem 0.75rem;
@@ -122,6 +136,7 @@
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .hd-btn {
@@ -129,34 +144,44 @@
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  padding: 0.75rem 1rem;
-  border-radius: 0.8rem;
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
   background: rgba(255, 255, 255, 0.04);
   color: var(--hd-color-text-primary);
-  font-weight: 700;
+  font-weight: 600;
   text-decoration: none;
-  transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
+  transition: transform 0.1s ease, box-shadow 0.1s ease, background-color 0.1s ease, border-color 0.1s ease;
   cursor: pointer;
 }
 
 .hd-btn:hover,
 .hd-btn:focus-visible {
-  border-color: rgba(255, 255, 255, 0.25);
   transform: translateY(-1px);
   text-decoration: none;
 }
 
 .hd-btn-primary {
-  background: linear-gradient(135deg, var(--hd-color-primary), #6c63ff);
-  border-color: rgba(255, 255, 255, 0.25);
-  color: #0b1021;
-  box-shadow: 0 12px 24px rgba(108, 99, 255, 0.35);
+  background: var(--hd-color-primary);
+  color: var(--hd-color-text-primary);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+}
+
+.hd-btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 35px rgba(0, 0, 0, 0.4);
+  background: color-mix(in srgb, var(--hd-color-primary) 90%, white 10%);
 }
 
 .hd-btn-secondary {
-  background: rgba(255, 255, 255, 0.08);
+  background: transparent;
   color: var(--hd-color-text-primary);
+  border-color: var(--hd-color-text-secondary);
+}
+
+.hd-btn-secondary:hover {
+  border-color: var(--hd-color-accent);
+  color: var(--hd-color-accent);
 }
 
 .hd-btn-ghost {
@@ -167,7 +192,7 @@
 .hd-nav-toggle {
   display: none;
   background: transparent;
-  color: #fff;
+  color: var(--hd-color-text-primary);
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 10px;
   padding: 0.5rem 0.75rem;
@@ -204,7 +229,60 @@
 }
 
 .hd-page-grid {
+  display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.hd-section-grid,
+.hd-about-grid,
+.hd-for-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.hd-hero {
+  padding-top: clamp(3rem, 5vw, 4.5rem);
+}
+
+.hd-hero-inner {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+  gap: 2rem;
+}
+
+.hd-hero-title {
+  font-size: clamp(2.25rem, 3vw + 1.25rem, 3.25rem);
+  margin: 0 0 0.75rem;
+  color: var(--hd-color-text-primary);
+}
+
+.hd-hero-subtitle {
+  margin: 0 0 1.25rem;
+  color: var(--hd-color-text-secondary);
+  max-width: 640px;
+}
+
+.hd-hero-actions,
+.hd-hero-stats,
+.hd-hero-visual {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.hd-section-title {
+  font-size: clamp(1.75rem, 2vw + 1rem, 2.25rem);
+  color: var(--hd-color-text-primary);
+  margin: 0 0 0.75rem;
+}
+
+.hd-section-intro {
+  color: var(--hd-color-text-secondary);
+  margin: 0 0 1.5rem;
+  max-width: 760px;
 }
 
 .hd-link-list {
@@ -278,7 +356,7 @@
 }
 
 .hd-form-input:focus-visible {
-  outline: 2px solid rgba(37, 99, 235, 0.6);
+  outline: 2px solid var(--hd-color-accent);
 }
 
 .hd-form-actions {
@@ -376,6 +454,14 @@
 
 .hd-login-local {
   margin-top: 2rem;
+}
+
+.hd-card {
+  background: var(--hd-color-surface);
+  border: 1px solid var(--hd-color-border);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
 }
 
 .hd-card-surface {
@@ -486,27 +572,25 @@
 .hd-table {
   width: 100%;
   border-collapse: collapse;
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 0.75rem;
-  overflow: hidden;
+  margin-top: 1.5rem;
+  font-size: 0.95rem;
 }
 
 .hd-table-head {
   text-align: left;
-  font-weight: 700;
-  padding: 0.9rem 1rem;
-  background: rgba(255, 255, 255, 0.03);
-  color: var(--hd-color-text-primary);
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  color: var(--hd-color-text-secondary);
+  font-weight: 500;
 }
 
-.hd-table-row:nth-child(every) {
-  background: rgba(255, 255, 255, 0.02);
+.hd-table-row:nth-child(even) .hd-table-cell {
+  background: rgba(15, 23, 42, 0.5);
 }
 
 .hd-table-cell {
-  padding: 0.9rem 1rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.8);
   color: var(--hd-color-text-secondary);
 }
 
@@ -620,17 +704,19 @@
 }
 
 @media (max-width: 768px) {
-  .hd-login-panel {
-    margin: 0 1rem;
-    padding: 1.75rem;
+  .hd-main {
+    padding: 0 1rem 3rem;
   }
 
-  .hd-dashboard-header {
-    flex-direction: column;
+  .hd-section {
+    padding-block: 3rem;
   }
-}
 
-@media (max-width: 768px) {
+  .hd-page {
+    padding-inline: 1rem;
+  }
+
+  .hd-nav-inner,
   .hd-nav-bar {
     flex-wrap: wrap;
   }
@@ -641,8 +727,9 @@
 
   .hd-nav-menu {
     width: 100%;
-    flex-direction: column;
-    align-items: flex-start;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    flex-direction: row;
   }
 
   .hd-nav-actions {
@@ -650,7 +737,31 @@
     justify-content: flex-start;
   }
 
+  .hd-hero {
+    padding-top: 2.5rem;
+  }
+
+  .hd-hero-inner {
+    grid-template-columns: 1fr;
+  }
+
+  .hd-hero-title {
+    margin-bottom: 0.5rem;
+  }
+
+  .hd-section-grid,
+  .hd-about-grid,
+  .hd-for-grid,
   .hd-page-grid {
     grid-template-columns: 1fr;
+  }
+
+  .hd-login-panel {
+    margin: 0 1rem;
+    padding: 1.75rem;
+  }
+
+  .hd-dashboard-header {
+    flex-direction: column;
   }
 }

--- a/quarkus-app/src/main/resources/templates/AdminMetricsResource/registrants.html
+++ b/quarkus-app/src/main/resources/templates/AdminMetricsResource/registrants.html
@@ -4,34 +4,55 @@
 {#main}
 <section class="admin-metrics">
   <h1 class="page-title">{talk.name} - {event.title}</h1>
-  <form method="get" class="filter">
+  <form method="get" class="filter hd-form">
     <input type="hidden" name="talk" value="{talk.id}">
-    <input type="search" name="name" placeholder="Nombre" value="{name}">
-    <input type="search" name="email" placeholder="Email" value="{email}">
-    <select name="size">
-      <option value="20"{#if size == 20} selected{/if}>20</option>
-      <option value="50"{#if size == 50} selected{/if}>50</option>
-      <option value="100"{#if size == 100} selected{/if}>100</option>
-    </select>
-    <button type="submit" class="btn btn-secondary">Filtrar</button>
+    <div class="hd-form-grid">
+      <div class="hd-form-field">
+        <label for="filter-name" class="hd-form-label">Nombre</label>
+        <input id="filter-name" type="search" name="name" value="{name}" class="hd-form-input">
+      </div>
+      <div class="hd-form-field">
+        <label for="filter-email" class="hd-form-label">Email</label>
+        <input id="filter-email" type="search" name="email" value="{email}" class="hd-form-input">
+      </div>
+      <div class="hd-form-field">
+        <label for="filter-size" class="hd-form-label">Resultados</label>
+        <select id="filter-size" name="size" class="hd-form-input">
+          <option value="20"{#if size == 20} selected{/if}>20</option>
+          <option value="50"{#if size == 50} selected{/if}>50</option>
+          <option value="100"{#if size == 100} selected{/if}>100</option>
+        </select>
+      </div>
+    </div>
+    <div class="hd-form-actions">
+      <button type="submit" class="hd-btn hd-btn-secondary">Filtrar</button>
+    </div>
   </form>
-  <table class="table registrants-table">
-    <thead><tr><th>Nombre</th><th>Email</th></tr></thead>
+  <table class="hd-table registrants-table">
+    <thead>
+      <tr>
+        <th class="hd-table-head">Nombre</th>
+        <th class="hd-table-head">Email</th>
+      </tr>
+    </thead>
     <tbody>
     {#for u in users}
-      <tr><td>{u.name}</td><td>{u.email}</td></tr>
+      <tr class="hd-table-row">
+        <td class="hd-table-cell">{u.name}</td>
+        <td class="hd-table-cell">{u.email}</td>
+      </tr>
     {/for}
     </tbody>
   </table>
   <div class="pagination">
     {#if hasPrev}
-      <a href="?talk={talk.id}&name={name}&email={email}&size={size}&page={prev}" class="btn btn-secondary">Anterior</a>
+      <a href="?talk={talk.id}&name={name}&email={email}&size={size}&page={prev}" class="hd-btn hd-btn-secondary">Anterior</a>
     {/if}
     {#if hasNext}
-      <a href="?talk={talk.id}&name={name}&email={email}&size={size}&page={next}" class="btn btn-secondary">Siguiente</a>
+      <a href="?talk={talk.id}&name={name}&email={email}&size={size}&page={next}" class="hd-btn hd-btn-secondary">Siguiente</a>
     {/if}
   </div>
-  <a href="/private/admin/metrics/registrations" class="btn btn-secondary">Volver</a>
+  <a href="/private/admin/metrics/registrations" class="hd-btn hd-btn-secondary">Volver</a>
 </section>
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/AdminMetricsResource/registrations.html
+++ b/quarkus-app/src/main/resources/templates/AdminMetricsResource/registrations.html
@@ -6,16 +6,24 @@
   <h1 class="page-title">Registros por charla</h1>
   {#for ev in events}
     <h2>{ev.event.title}</h2>
-    <table>
-      <thead><tr><th>Charla</th><th>Registros</th></tr></thead>
+    <table class="hd-table">
+      <thead>
+        <tr>
+          <th class="hd-table-head">Charla</th>
+          <th class="hd-table-head">Registros</th>
+        </tr>
+      </thead>
       <tbody>
       {#for row in ev.rows}
-        <tr><td><a href="/private/admin/metrics/registrants?talk={row.id}">{row.name}</a></td><td>{row.registrations}</td></tr>
+        <tr class="hd-table-row">
+          <td class="hd-table-cell"><a href="/private/admin/metrics/registrants?talk={row.id}">{row.name}</a></td>
+          <td class="hd-table-cell">{row.registrations}</td>
+        </tr>
       {/for}
       </tbody>
     </table>
   {/for}
-  <a href="/private/admin/metrics" class="btn btn-secondary">Volver</a>
+  <a href="/private/admin/metrics" class="hd-btn hd-btn-secondary">Volver</a>
 </section>
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/AdminMetricsResource/talks.html
+++ b/quarkus-app/src/main/resources/templates/AdminMetricsResource/talks.html
@@ -4,15 +4,23 @@
 {#main}
 <section class="admin-metrics">
   <h1 class="page-title">Charlas registradas - {event.title}</h1>
-  <table>
-    <thead><tr><th>Charla</th><th>Registros</th></tr></thead>
+  <table class="hd-table">
+    <thead>
+      <tr>
+        <th class="hd-table-head">Charla</th>
+        <th class="hd-table-head">Registros</th>
+      </tr>
+    </thead>
     <tbody>
     {#for row in rows}
-      <tr><td><a href="/private/admin/metrics/registrants?talk={row.id}">{row.name}</a></td><td>{row.registrations}</td></tr>
+      <tr class="hd-table-row">
+        <td class="hd-table-cell"><a href="/private/admin/metrics/registrants?talk={row.id}">{row.name}</a></td>
+        <td class="hd-table-cell">{row.registrations}</td>
+      </tr>
     {/for}
     </tbody>
   </table>
-  <a href="/private/admin/metrics?event={event.id}&amp;range=all" class="btn btn-secondary">Volver</a>
+  <a href="/private/admin/metrics?event={event.id}&amp;range=all" class="hd-btn hd-btn-secondary">Volver</a>
 </section>
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -84,7 +84,7 @@ Evento
     <details class="agenda-day" open>
       <summary>Día {d}</summary>
       <div id="agenda-seq-{d}" class="agenda-view agenda-seq" data-agenda-seq>
-        <table class="table agenda-table">
+        <table class="hd-table agenda-table">
           <colgroup>
             <col style="width: 12%;">
             <col style="width: 60%;">
@@ -93,17 +93,17 @@ Evento
           </colgroup>
           <thead>
             <tr>
-              <th>Horario</th>
-              <th>Actividad</th>
-              <th>Ponentes</th>
-              <th>Escenario</th>
+              <th class="hd-table-head">Horario</th>
+              <th class="hd-table-head">Actividad</th>
+              <th class="hd-table-head">Ponentes</th>
+              <th class="hd-table-head">Escenario</th>
             </tr>
           </thead>
           <tbody>
             {#for t in event.getAgendaForDay(d)}
-            <tr>
-              <td class="agenda-time">{t.startTimeStr} - {t.endTimeStr}</td>
-              <td class="agenda-title">
+            <tr class="hd-table-row">
+              <td class="agenda-time hd-table-cell">{t.startTimeStr} - {t.endTimeStr}</td>
+              <td class="agenda-title hd-table-cell">
                 <span class="icon">{#if t.break}☕{#else}🗣️{/if}</span>
                 {#if t.break}
                 <span class="agenda-title-text">{t.name}</span>
@@ -111,7 +111,7 @@ Evento
                 <a href="/event/{event.id}/talk/{t.id}" class="agenda-title-text">{t.name}</a>
                 {/if}
               </td>
-              <td class="agenda-speakers">
+              <td class="agenda-speakers hd-table-cell">
                 {#if !t.break && !t.speakers.isEmpty()}
                 <span class="speaker-avatars">
                   {#for s in t.speakers}
@@ -126,28 +126,28 @@ Evento
                 </span>
                 {/if}
               </td>
-              <td class="agenda-location"><a href="/event/{event.id}/scenario/{t.location}">{event.getScenarioName(t.location)}</a></td>
+              <td class="agenda-location hd-table-cell"><a href="/event/{event.id}/scenario/{t.location}">{event.getScenarioName(t.location)}</a></td>
             </tr>
             {/for}
           </tbody>
         </table>
       </div>
       <div id="agenda-grid-{d}" class="agenda-view agenda-grid hidden" data-agenda-grid>
-        <table class="table agenda-grid-table">
+        <table class="hd-table agenda-grid-table">
           <thead>
             <tr>
-              <th>Horario</th>
+              <th class="hd-table-head">Horario</th>
               {#for sc in event.scenarios}
-              <th>{sc.name}</th>
+              <th class="hd-table-head">{sc.name}</th>
               {/for}
             </tr>
           </thead>
           <tbody>
             {#for e in event.getAgendaGroupedByTimeSlot(d).entrySet()}
-            <tr>
-              <td class="agenda-time">{e.key}</td>
+            <tr class="hd-table-row">
+              <td class="agenda-time hd-table-cell">{e.key}</td>
               {#for sc in event.scenarios}
-              <td>
+              <td class="hd-table-cell">
                 {#for t in e.value}
                 {#if t.location == sc.id}
                 <div class="agenda-slot">

--- a/quarkus-app/src/main/resources/templates/fragments/nav.html
+++ b/quarkus-app/src/main/resources/templates/fragments/nav.html
@@ -1,10 +1,15 @@
 <nav class="hd-nav" aria-label="Principal">
-  <div class="hd-nav-bar">
+  <div class="hd-nav-inner hd-nav-bar">
     <a href="/" class="hd-nav-brand">Homedir</a>
-    <button class="hd-nav-toggle" aria-label="Abrir menú" aria-expanded="false" data-hd-nav-toggle>
-      ☰
+    <button
+      class="hd-nav-toggle"
+      aria-label="Abrir menú"
+      aria-expanded="false"
+      aria-controls="primary-nav"
+      data-hd-nav-toggle>
+      <span aria-hidden="true">☰</span>
     </button>
-    <div class="hd-nav-menu" data-hd-nav-menu>
+    <div class="hd-nav-menu" id="primary-nav" data-hd-nav-menu>
       <a href="/" class="hd-nav-link">Inicio</a>
       <a href="/eventos" class="hd-nav-link">Eventos</a>
       <a href="/comunidad" class="hd-nav-link">Comunidad</a>

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{#insert title}Homedir{/}</title>
     <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="/css/homedir.css">
     <link rel="stylesheet" href="/css/notifications.css">
     <script>window.__EF_NOTIFICATIONS_MODE__='global';</script>
     <script src="/js/notifications-adapter.js" defer></script>

--- a/quarkus-app/src/main/resources/templates/layout/main.html
+++ b/quarkus-app/src/main/resources/templates/layout/main.html
@@ -3,7 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Homedir es una plataforma open-source para organizar eventos, espacios y experiencias de comunidad." />
+  <!-- TODO: ajustar texto según maqueta y mensaje final -->
   <title>{#insert title}Homedir{/}</title>
+  <link rel="icon" href="/favicon.ico" />
+  <!-- TODO: reemplazar por íconos alineados a la marca Homedir -->
   <link rel="stylesheet" href="/styles.css" />
   <link rel="stylesheet" href="/css/homedir.css" />
   <link rel="stylesheet" href="/css/notifications.css" />
@@ -11,7 +15,7 @@
 <body class="hd-body">
   <a class="hd-skip-link" href="#main-content">Saltar al contenido principal</a>
   {#include fragments/nav.html/}
-  <main id="main-content" class="hd-main">
+  <main id="main-content" class="hd-main" role="main">
     {#insert body}
     {/}
   </main>


### PR DESCRIPTION
## Summary
- enhance layout metadata and navigation structure for accessibility and responsive behavior
- apply homedir design system styles to legacy admin layouts and metrics tables
- update CSS with improved contrast, focus states, responsive grids, and refreshed button/table components

## Testing
- mvn -f pom.xml test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de1e8597c83339f5d2d56cc1af4c6)