### PR TITLE
Add UI v2 feature flag and frontend contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,3 +134,46 @@ The dependency check summarizes additions, updates and removals plus any violati
 - Mantén **≥ 70 %** de líneas y ramas en el diff de tu PR. El gating es progresivo: primera semana `warn`, luego `enforcing`.
 - Opcional: `mvn -f quarkus-app/pom.xml org.pitest:pitest-maven:1.16.1:mutationCoverage -DtargetClasses='io.eventflow.*'`.
 - Si falla el gate de cobertura, agrega o ajusta tests de las clases tocadas y vuelve a ejecutar.
+
+## Contribuir a la UI (frontend)
+
+La UI de Homedir está construida con:
+
+- Quarkus + Qute para el renderizado de vistas.
+- Templates en `quarkus-app/src/main/resources/templates`.
+- Estilos centralizados en `quarkus-app/src/main/resources/META-INF/resources/css/homedir.css`.
+
+### Cómo levantar la app para trabajar en la UI
+
+1. Ir al módulo `quarkus-app`:
+
+   ```bash
+   cd quarkus-app
+   ```
+
+2. Ejecutar en modo dev:
+
+   ```bash
+   mvn quarkus:dev
+   ```
+
+3. Abrir el navegador en http://localhost:8080.
+
+### Convenciones de diseño
+
+- Usa siempre el layout principal: `{#extends layout/main}` o `{#include layout/main}`.
+- Evita duplicar `<html>`, `<head>`, `<body>` en templates individuales.
+- Usa clases `hd-*` ya existentes siempre que sea posible.
+- No agregues estilos inline; extiende `homedir.css`.
+- Si necesitas nuevos componentes o variantes, documenta las clases en `docs/ui/architecture.md`.
+
+### Feature flag de UI
+
+La UI v2 está controlada por la propiedad `homedir.ui.v2.enabled` en `application.properties`.
+
+En caso de introducir una nueva versión futura, considera usar esta propiedad para hacer el cambio gradual o preparar un fallback.
+
+### Alineación con la maqueta
+
+- Los textos, colores y espaciados deben alinearse con la maqueta oficial de Homedir en Canva.
+- Donde veas comentarios `TODO: alinear con maqueta Canva`, reemplaza el contenido con los valores correctos y elimina el comentario.

--- a/docs/ui/architecture.md
+++ b/docs/ui/architecture.md
@@ -1,0 +1,80 @@
+# Arquitectura de la UI de Homedir (v2)
+
+Este documento describe cómo está organizada la interfaz de usuario de Homedir en su versión v2 (layout Qute + estilos `hd-*`).
+
+## 1. Estructura de templates
+
+- **Layout principal**
+  - `quarkus-app/src/main/resources/templates/layout/main.html`
+  - Define `<head>`, `<body>`, navegación, `<main>` y `<footer>`.
+  - Expone los bloques `{#insert title}` y `{#insert body}` para cada página.
+
+- **Fragmentos compartidos**
+  - Navegación: `quarkus-app/src/main/resources/templates/fragments/nav.html`
+  - Footer: `quarkus-app/src/main/resources/templates/fragments/footer.html`
+
+- **Páginas públicas (v2)**
+  - Home: `quarkus-app/src/main/resources/templates/HomeResource/home.html` (ruta `/`).
+  - Eventos: `quarkus-app/src/main/resources/templates/pages/eventos.html` (ruta `/eventos`).
+  - Comunidad: `quarkus-app/src/main/resources/templates/pages/comunidad.html` (ruta `/comunidad`, v2 en construcción). El recurso actual usa `templates/CommunityResource/community.html` mientras se completa la migración.
+  - Documentación: `quarkus-app/src/main/resources/templates/pages/docs.html` (ruta `/docs`).
+  - Contacto: `quarkus-app/src/main/resources/templates/pages/contacto.html` (ruta `/contacto`).
+
+- **Vistas privadas**
+  - Paneles y herramientas administrativas viven bajo `quarkus-app/src/main/resources/templates/admin/**` y los templates específicos por recurso (`Admin*Resource`).
+  - Secciones privadas generales usan `quarkus-app/src/main/resources/templates/PrivateResource/privatePage.html`.
+  - Otros recursos privados siguen la convención `templates/<Recurso>/<vista>.html` (por ejemplo, `templates/ProfileResource/profile.html`).
+
+Todas las páginas públicas de la UI v2 deben extender el layout principal mediante `{#include layout/main}` o `{#extends layout/main}`:
+
+```html
+{#extends layout/main}
+
+{#title}Título · Homedir{/title}
+
+{#body}
+  <!-- contenido específico de cada vista -->
+{/body}
+```
+
+Los fragmentos se incluyen con `{#include fragments/nav /}` y `{#include fragments/footer /}` desde el layout.
+
+## 2. Estilos y design tokens
+
+- **CSS principal**: `quarkus-app/src/main/resources/META-INF/resources/css/homedir.css`.
+- **Variables CSS**: definidas en `:root` como `--hd-color-primary`, `--hd-color-secondary`, `--hd-color-bg`, `--hd-color-surface`, `--hd-color-text-primary`, `--hd-color-text-secondary`, `--hd-color-accent` (ver `docs/ui/design-tokens.md`).
+- **Clases y componentes `hd-*`**:
+  - Layout y contenedores: `.hd-body`, `.hd-main`, `.hd-page`, `.hd-section`, `.hd-hero`, `.hd-section-title`.
+  - Navegación y footer: `.hd-nav`, `.hd-nav-menu`, `.hd-nav-link`, `.hd-footer`.
+  - Tarjetas y grids: `.hd-card`, `.hd-section-grid`, `.hd-card-title`, `.hd-card-text`.
+  - Formularios: `.hd-form`, `.hd-form-field`, `.hd-form-label`, `.hd-form-input`, `.hd-form-actions`.
+  - Tablas y listados: `.hd-table`, `.hd-table-row`, `.hd-table-cell`.
+  - Variantes auxiliares: `.hd-btn`, `.hd-btn-primary`, `.hd-btn-secondary`, badges y pills específicas por sección.
+- **TODO**: los valores exactos de colores, tipografías y espaciados deben alinearse con la maqueta de Canva (ver `docs/ui/design-tokens.md`).
+
+## 3. Feature flag de UI
+
+- Propiedad: `homedir.ui.v2.enabled` en `quarkus-app/src/main/resources/application.properties`.
+- Propósito: habilitar/deshabilitar la UI v2 sin cambiar rutas. Actualmente el valor `false` usa los mismos templates porque no existe una versión mínima, pero queda listo para introducir un fallback futuro.
+- Ejemplo de uso en controladores (Home):
+
+```java
+@ConfigProperty(name = "homedir.ui.v2.enabled", defaultValue = "true")
+boolean uiV2Enabled;
+
+if (uiV2Enabled) {
+  return Templates.home(...);
+}
+// TODO: definir template de fallback si en el futuro se desea una versión mínima
+return Templates.home(...);
+```
+
+Aplica el mismo patrón a otras rutas públicas (`/eventos`, `/docs`, `/contacto`, etc.) cuando se requiera alternar entre versiones.
+
+## 4. Convenciones para nuevas vistas
+
+- Extiende siempre `layout/main` y reutiliza los fragmentos de navegación y footer.
+- Usa clases `hd-*` existentes; si creas variantes nuevas, documenta el uso en `docs/ui/architecture.md` y en los estilos.
+- Mantén los textos en español hasta definir una estrategia de i18n.
+- Evita estilos inline: centraliza los cambios en `homedir.css` y respeta los tokens definidos.
+- Marca con `TODO` los textos o imágenes que deban alinearse con la maqueta de Canva antes de un release.

--- a/docs/ui/regression-checklist.md
+++ b/docs/ui/regression-checklist.md
@@ -1,0 +1,16 @@
+# Checklist de regresión UI
+
+Revisar visual y funcionalmente después de cambios relevantes en la UI:
+
+- [ ] `/` (home)
+  - [ ] Hero
+  - [ ] Sección "Qué es"
+  - [ ] "Cómo funciona"
+  - [ ] "Para quién es"
+  - [ ] CTA final
+- [ ] `/eventos`
+- [ ] `/comunidad`
+- [ ] `/docs`
+- [ ] `/contacto`
+- [ ] `/ingresar` (login)
+- [ ] Ruta principal de panel privado (`/private` u otra equivalente)

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventsDirectoryResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventsDirectoryResource.java
@@ -5,6 +5,7 @@ import com.scanales.eventflow.service.EventService;
 import com.scanales.eventflow.service.UsageMetricsService;
 import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -23,6 +24,9 @@ public class EventsDirectoryResource {
   @Inject EventService eventService;
 
   @Inject UsageMetricsService metrics;
+
+  @ConfigProperty(name = "homedir.ui.v2.enabled", defaultValue = "true")
+  boolean uiV2Enabled;
 
   @CheckedTemplate
   static class Templates {
@@ -66,6 +70,10 @@ public class EventsDirectoryResource {
         Map.of(
             "upcoming", Integer.toString(upcoming.size()),
             "past", Integer.toString(past.size()));
+    if (uiV2Enabled) {
+      return Templates.eventos(upcoming, past, today, stats);
+    }
+    // TODO: definir template de fallback si en el futuro se desea una versión mínima
     return Templates.eventos(upcoming, past, today, stats);
   }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -7,6 +7,7 @@ import io.eventflow.home.now.NowBoxService;
 import io.eventflow.home.now.NowBoxView;
 import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -30,6 +31,9 @@ public class HomeResource {
   @Inject UsageMetricsService metrics;
 
   @Inject NowBoxService nowBoxService;
+
+  @ConfigProperty(name = "homedir.ui.v2.enabled", defaultValue = "true")
+  boolean uiV2Enabled;
 
   @CheckedTemplate
   static class Templates {
@@ -89,6 +93,10 @@ public class HomeResource {
             "issuesUrl", "https://github.com/os-santiago/homedir/issues",
             "donateUrl", "https://ko-fi.com/sergiocanales");
     var nowBox = nowBoxService.build();
+    if (uiV2Enabled) {
+      return Templates.home(upcoming, past, today, "2.2.3", stats, links, nowBox);
+    }
+    // TODO: definir template de fallback si en el futuro se desea una versión mínima
     return Templates.home(upcoming, past, today, "2.2.3", stats, links, nowBox);
   }
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/MarketingPagesResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/MarketingPagesResource.java
@@ -4,6 +4,7 @@ import com.scanales.eventflow.service.UsageMetricsService;
 import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
 import io.vertx.ext.web.RoutingContext;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -20,6 +21,9 @@ public class MarketingPagesResource {
 
   @Inject UsageMetricsService metrics;
 
+  @ConfigProperty(name = "homedir.ui.v2.enabled", defaultValue = "true")
+  boolean uiV2Enabled;
+
   @CheckedTemplate(basePath = "pages")
   static class Templates {
     public static native TemplateInstance docs();
@@ -32,6 +36,10 @@ public class MarketingPagesResource {
   public TemplateInstance docs(
       @Context HttpHeaders headers, @Context RoutingContext context) {
     metrics.recordPageView("/docs", headers, context);
+    if (uiV2Enabled) {
+      return Templates.docs();
+    }
+    // TODO: definir template de fallback si en el futuro se desea una versión mínima
     return Templates.docs();
   }
 
@@ -40,6 +48,10 @@ public class MarketingPagesResource {
   public TemplateInstance contacto(
       @Context HttpHeaders headers, @Context RoutingContext context) {
     metrics.recordPageView("/contacto", headers, context);
+    if (uiV2Enabled) {
+      return Templates.contacto();
+    }
+    // TODO: definir template de fallback si en el futuro se desea una versión mínima
     return Templates.contacto();
   }
 }

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -47,6 +47,11 @@ quarkus.http.auth.session.encryption-key=${SESSION_KEY}
 quarkus.http.auth.permission.private.paths=/private/*
 quarkus.http.auth.permission.private.policy=authenticated
 
+# Controla el uso de la nueva UI (layout + templates v2).
+# true  -> usa la nueva UI basada en layout/main + clases hd-*
+# false -> fallback (si se implementa) a templates anteriores / minimal
+homedir.ui.v2.enabled=true
+
 # Local development authentication (disabled outside the dev profile)
 %dev.quarkus.oidc.enabled=false
 %dev.quarkus.security.users.embedded.enabled=true

--- a/quarkus-app/src/main/resources/templates/LoginPage/ingresar.html
+++ b/quarkus-app/src/main/resources/templates/LoginPage/ingresar.html
@@ -8,6 +8,7 @@
       <div class="hd-login-panel">
         <h1 class="hd-page-title">Ingresar a Homedir</h1>
         <p class="hd-page-intro">
+          <!-- TODO: ajustar copy según la maqueta Canva -->
           Usa tu cuenta para administrar eventos y experiencias.
         </p>
         {#if loginError}


### PR DESCRIPTION
## Summary
- add `homedir.ui.v2.enabled` configuration and wire it into public controllers with fallback placeholders
- document the UI v2 architecture, regression checklist, and frontend contribution guidance
- mark Canva-alignment TODOs on login copy

## Testing
- mvn -f quarkus-app/pom.xml test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dee639acc83339daa0a5a11f420aa)