### PR TITLE
Add standalone Homedir mockup JS and wire up home interactions

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/homedir.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/homedir.js
@@ -1,0 +1,462 @@
+let currentUser = null;
+let allUsers = [];
+
+// Equipment/Collectibles System
+const COLLECTIBLES = [
+  { id: 'laptop', icon: '💻', name: 'DEVELOPER LAPTOP', rarity: 'common', description: '+5 Coding Power' },
+  { id: 'keyboard', icon: '⌨️', name: 'MECHANICAL KEYBOARD', rarity: 'rare', description: '+10 Typing Speed' },
+  { id: 'coffee', icon: '☕', name: 'ENERGY COFFEE', rarity: 'common', description: '+3 Focus' },
+  { id: 'badge', icon: '🏅', name: 'CONTRIBUTOR BADGE', rarity: 'epic', description: '+15 Reputation' },
+  { id: 'trophy', icon: '🏆', name: 'CHAMPION TROPHY', rarity: 'legendary', description: '+25 Achievement' },
+  { id: 'book', icon: '📚', name: 'CODE MANUAL', rarity: 'rare', description: '+8 Knowledge' },
+  { id: 'rocket', icon: '🚀', name: 'LAUNCH ROCKET', rarity: 'epic', description: '+20 Deployment' },
+  { id: 'gem', icon: '💎', name: 'RARE GEM', rarity: 'legendary', description: '+30 Value' },
+  { id: 'shield', icon: '🛡️', name: 'SECURITY SHIELD', rarity: 'epic', description: '+18 Protection' },
+  { id: 'wand', icon: '🪄', name: 'DEBUG WAND', rarity: 'rare', description: '+12 Bug Fix' },
+  { id: 'crown', icon: '👑', name: 'LEADER CROWN', rarity: 'legendary', description: '+35 Leadership' },
+  { id: 'glasses', icon: '👓', name: 'CODE GLASSES', rarity: 'common', description: '+4 Vision' }
+];
+
+function generateEquipment(level, experience) {
+  const equipment = [];
+  const itemCount = Math.min(6, Math.floor(level / 2) + Math.floor(experience / 200));
+  const shuffled = [...COLLECTIBLES].sort(() => Math.random() - 0.5);
+
+  for (let i = 0; i < itemCount; i++) {
+    equipment.push(shuffled[i].id);
+  }
+
+  return equipment;
+}
+
+function updateEquipmentDisplay(equipment = []) {
+  const slots = document.querySelectorAll('.equipment-slot');
+  if (!slots.length) return;
+
+  let filledCount = 0;
+
+  slots.forEach((slot, index) => {
+    if (equipment[index]) {
+      const collectible = COLLECTIBLES.find((c) => c.id === equipment[index]);
+      if (collectible) {
+        slot.classList.remove('empty');
+        slot.classList.add('filled');
+        slot.innerHTML = `
+              ${collectible.icon}
+              <div class="equipment-rarity rarity-${collectible.rarity}"></div>
+              <div class="equipment-tooltip">
+                ${collectible.name}<br>
+                <span style="color: #FFD700;">${collectible.description}</span>
+              </div>
+            `;
+        filledCount++;
+      }
+    } else {
+      slot.classList.add('empty');
+      slot.classList.remove('filled');
+      slot.innerHTML = `
+            <div class="equipment-tooltip">EMPTY SLOT</div>
+          `;
+    }
+  });
+
+  const equipmentCount = document.querySelector('.equipment-count');
+  if (equipmentCount) {
+    equipmentCount.textContent = `${filledCount} / 6 ITEMS`;
+  }
+}
+
+const defaultConfig = {
+  platform_name: 'HomeDir',
+  tagline: 'by OpenSourceSantiago',
+  community_title: 'Community',
+  community_description: 'Modern toolbox for community building and opensource technology innovation',
+  events_title: 'Events',
+  events_description: 'Scale your teams with collaborative meetups and tech conferences',
+  projects_title: 'Projects',
+  projects_description: 'Innovation hub for your opensource technology projects',
+  background_start: '#667eea',
+  background_end: '#764ba2',
+  card_background: '#ffffff',
+  text_color: '#ffffff',
+  accent_color: '#FFD700'
+};
+
+let config = defaultConfig;
+
+function onConfigChange(newConfig) {
+  config = newConfig || config;
+
+  const platformName = config.platform_name || defaultConfig.platform_name;
+  const tagline = config.tagline || defaultConfig.tagline;
+
+  const navPlatformName = document.getElementById('navPlatformName');
+  const navTagline = document.getElementById('navTagline');
+  const mainTitle = document.getElementById('mainTitle');
+  const mainTagline = document.getElementById('mainTagline');
+
+  if (navPlatformName) navPlatformName.textContent = platformName;
+  if (navTagline) navTagline.textContent = tagline;
+  if (mainTitle) mainTitle.textContent = platformName;
+  if (mainTagline) {
+    mainTagline.textContent = `${tagline} - The community platform to scale your teams and projects`;
+  }
+
+  document.body.style.background = `linear-gradient(135deg, ${config.background_start || defaultConfig.background_start} 0%, ${config.background_end || defaultConfig.background_end} 100%)`;
+  document.body.style.color = config.text_color || defaultConfig.text_color;
+}
+
+function showToast(message) {
+  const toast = document.getElementById('toast');
+  if (!toast) return;
+
+  toast.textContent = message;
+  toast.classList.add('show');
+  setTimeout(() => {
+    toast.classList.remove('show');
+  }, 3000);
+}
+
+function openLoginModal() {
+  const modal = document.getElementById('loginModal');
+  if (modal) {
+    modal.classList.add('show');
+  }
+}
+
+function closeLoginModal() {
+  const modal = document.getElementById('loginModal');
+  if (modal) {
+    modal.classList.remove('show');
+  }
+}
+
+function updateNavigation() {
+  const loginBtn = document.getElementById('openLoginBtn');
+  const userMenu = document.getElementById('userMenuNav');
+  const navAvatar = document.getElementById('navAvatar');
+  const navUserName = document.getElementById('navUserName');
+
+  if (currentUser) {
+    const emoji = currentUser.display_name?.charAt(0) || 'H';
+    if (loginBtn) loginBtn.style.display = 'none';
+    if (userMenu) userMenu.classList.add('active');
+    if (navAvatar) navAvatar.textContent = emoji;
+    if (navUserName) navUserName.textContent = currentUser.display_name;
+  } else {
+    if (loginBtn) loginBtn.style.display = 'block';
+    if (userMenu) userMenu.classList.remove('active');
+  }
+}
+
+function updateCharacterSheet() {
+  const characterName = document.getElementById('characterName');
+  const characterClass = document.getElementById('characterClass');
+  const characterLevel = document.getElementById('characterLevel');
+  const noviceWarning = document.getElementById('noviceWarning');
+  const hpValue = document.getElementById('hpValue');
+  const hpBar = document.getElementById('hpBar');
+  const spValue = document.getElementById('spValue');
+  const spBar = document.getElementById('spBar');
+  const xpValue = document.getElementById('xpValue');
+  const xpBar = document.getElementById('xpBar');
+  const contributionsStat = document.getElementById('contributionsStat');
+  const questsStat = document.getElementById('questsStat');
+  const eventsStat = document.getElementById('eventsStat');
+  const projectsStat = document.getElementById('projectsStat');
+  const connectionsStat = document.getElementById('connectionsStat');
+  const experienceStat = document.getElementById('experienceStat');
+  const loginCharacterBtn = document.getElementById('loginCharacterBtn');
+  const logoutCharacterBtn = document.getElementById('logoutCharacterBtn');
+
+  if (!characterName || !characterClass || !characterLevel) return;
+
+  if (currentUser) {
+    if (noviceWarning) noviceWarning.style.display = 'none';
+
+    characterName.textContent = currentUser.display_name.toUpperCase();
+    characterClass.textContent = 'DEVELOPER';
+    characterLevel.textContent = `LEVEL ${currentUser.level}`;
+
+    const maxHP = 100;
+    const maxSP = 100;
+    const maxXPForLevel = currentUser.level * 100;
+
+    const currentHP = Math.min(100, 10 + currentUser.level * 10 + currentUser.contributions);
+    const currentSP = Math.min(100, 5 + currentUser.level * 8 + currentUser.quests_completed * 5);
+    const currentXP = currentUser.experience % maxXPForLevel;
+
+    if (hpValue) hpValue.textContent = `${currentHP} / ${maxHP}`;
+    if (hpBar) hpBar.style.width = `${currentHP}%`;
+
+    if (spValue) spValue.textContent = `${currentSP} / ${maxSP}`;
+    if (spBar) spBar.style.width = `${currentSP}%`;
+
+    if (xpValue) xpValue.textContent = `${currentXP} / ${maxXPForLevel}`;
+    if (xpBar) xpBar.style.width = `${(currentXP / maxXPForLevel) * 100}%`;
+
+    if (contributionsStat) contributionsStat.textContent = currentUser.contributions;
+    if (questsStat) questsStat.textContent = currentUser.quests_completed;
+    if (eventsStat) eventsStat.textContent = currentUser.events_attended;
+    if (projectsStat) projectsStat.textContent = currentUser.projects_hosted;
+    if (connectionsStat) connectionsStat.textContent = currentUser.connections;
+    if (experienceStat) experienceStat.textContent = currentUser.experience;
+
+    const equipment = generateEquipment(currentUser.level, currentUser.experience);
+    updateEquipmentDisplay(equipment);
+
+    if (loginCharacterBtn) loginCharacterBtn.style.display = 'none';
+    if (logoutCharacterBtn) logoutCharacterBtn.style.display = 'block';
+  } else {
+    if (noviceWarning) noviceWarning.style.display = 'block';
+
+    characterName.textContent = 'NOVICE GUEST';
+    characterClass.textContent = 'VISITOR';
+    characterLevel.textContent = 'LEVEL 1';
+
+    if (hpValue) hpValue.textContent = '10 / 100';
+    if (hpBar) hpBar.style.width = '10%';
+
+    if (spValue) spValue.textContent = '5 / 100';
+    if (spBar) spBar.style.width = '5%';
+
+    if (xpValue) xpValue.textContent = '0 / 100';
+    if (xpBar) xpBar.style.width = '0%';
+
+    if (contributionsStat) contributionsStat.textContent = '0';
+    if (questsStat) questsStat.textContent = '0';
+    if (eventsStat) eventsStat.textContent = '0';
+    if (projectsStat) projectsStat.textContent = '0';
+    if (connectionsStat) connectionsStat.textContent = '0';
+    if (experienceStat) experienceStat.textContent = '0';
+
+    updateEquipmentDisplay([]);
+
+    if (loginCharacterBtn) loginCharacterBtn.style.display = 'block';
+    if (logoutCharacterBtn) logoutCharacterBtn.style.display = 'none';
+  }
+}
+
+// TODO: Reemplazar este login demo por integración real con backend/OIDC de Homedir
+async function handleLogin(provider) {
+  const btn = provider === 'google' ? document.getElementById('googleLogin') : document.getElementById('githubLogin');
+  if (!btn) return;
+
+  btn.classList.add('loading');
+  btn.disabled = true;
+
+  const demoNames = ['Alex Chen', 'Maria Garcia', 'Jamal Johnson', 'Sofia Rodriguez', 'Kai Nakamura'];
+  const randomName = demoNames[Math.floor(Math.random() * demoNames.length)];
+  const userId = `user_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
+  const demoLevel = Math.floor(Math.random() * 5) + 1;
+  const demoExperience = Math.floor(Math.random() * 500);
+
+  const newUser = {
+    user_id: userId,
+    display_name: randomName,
+    avatar_url: '',
+    level: demoLevel,
+    experience: demoExperience,
+    contributions: Math.floor(Math.random() * 30),
+    quests_completed: Math.floor(Math.random() * 10),
+    events_attended: Math.floor(Math.random() * 5),
+    projects_hosted: Math.floor(Math.random() * 3),
+    connections: Math.floor(Math.random() * 20),
+    login_provider: provider,
+    created_at: new Date().toISOString()
+  };
+
+  // DEMO: guardamos en memoria nada más
+  allUsers.push(newUser);
+  currentUser = newUser;
+
+  closeLoginModal();
+  updateNavigation();
+  updateCharacterSheet();
+  showToast(`Welcome, ${randomName}! 🎉 Your character has been created!`);
+
+  btn.classList.remove('loading');
+  btn.disabled = false;
+}
+
+function handleLogout() {
+  currentUser = null;
+  updateNavigation();
+  updateCharacterSheet();
+  showToast('Logged out successfully - Character data saved!');
+}
+
+const TECH_AVATARS = ['👨‍💻', '👩‍💻', '🧑‍💻', '👨‍🎨', '👩‍🎨', '🧑‍🎨', '👨‍🔬', '👩‍🔬', '🧑‍🔬', '🦸‍♂️', '🦸‍♀️', '🧙‍♂️', '🧙‍♀️', '🤖', '👾', '🚀'];
+
+const TECH_ROLES = [
+  { emoji: '⚛️', name: 'FRONTEND' },
+  { emoji: '⚙️', name: 'BACKEND' },
+  { emoji: '🎨', name: 'DESIGNER' },
+  { emoji: '📊', name: 'DATA SCI' },
+  { emoji: '🏗️', name: 'PLATFORM' },
+  { emoji: '🔐', name: 'DEVOPS' },
+  { emoji: '📱', name: 'MOBILE' },
+  { emoji: '🧪', name: 'QA' },
+  { emoji: '📈', name: 'PRODUCT' }
+];
+
+const STATUS_TYPES = ['online', 'busy', 'away'];
+
+function generateVillageInhabitants() {
+  const inhabitantsLayer = document.getElementById('inhabitantsLayer');
+  if (!inhabitantsLayer) return;
+
+  inhabitantsLayer.innerHTML = '';
+
+  const members = allUsers.length > 0 ? allUsers : generateDemoInhabitants();
+
+  members.forEach((user, index) => {
+    const member = document.createElement('div');
+    member.className = 'team-member';
+
+    const left = 12 + Math.random() * 76;
+    const bottom = 18 + Math.random() * 35;
+
+    member.style.left = `${left}%`;
+    member.style.bottom = `${bottom}%`;
+    member.style.animationDelay = `${Math.random() * 4}s`;
+
+    const avatar = user.display_name
+      ? TECH_AVATARS[user.display_name.charCodeAt(0) % TECH_AVATARS.length]
+      : TECH_AVATARS[index % TECH_AVATARS.length];
+    const role = TECH_ROLES[index % TECH_ROLES.length];
+    const status = STATUS_TYPES[Math.floor(Math.random() * STATUS_TYPES.length)];
+
+    member.innerHTML = `
+          <div class="member-level">${user.level || 1}</div>
+          <div class="member-avatar">
+            ${avatar}
+            <div class="member-status status-${status}"></div>
+          </div>
+          <div class="member-badge">${user.display_name || 'Guest'}</div>
+          <div class="member-role">${role.emoji}</div>
+        `;
+
+    inhabitantsLayer.appendChild(member);
+  });
+
+  updateCommunityStats(members);
+}
+
+function generateDemoInhabitants() {
+  const demoMembers = [
+    { name: 'Alex Chen', role: 'Senior Frontend Dev' },
+    { name: 'Maria Garcia', role: 'Backend Architect' },
+    { name: 'Jamal Johnson', role: 'UX Designer' },
+    { name: 'Sofia Rodriguez', role: 'Data Scientist' },
+    { name: 'Kai Nakamura', role: 'DevOps Engineer' },
+    { name: 'Emma Wilson', role: 'Full Stack Dev' },
+    { name: 'Lucas Silva', role: 'Mobile Developer' },
+    { name: 'Aisha Patel', role: 'UI Designer' },
+    { name: 'Oliver Kim', role: 'QA Engineer' },
+    { name: 'Isabella Brown', role: 'Product Manager' },
+    { name: 'Noah Zhang', role: 'Tech Lead' },
+    { name: 'Mia Ivanov', role: 'Frontend Dev' },
+    { name: 'Ethan Okafor', role: 'ML Engineer' },
+    { name: 'Ava Müller', role: 'Brand Designer' },
+    { name: "Liam O'Brien", role: 'Security Expert' }
+  ];
+
+  return demoMembers.map((member, index) => ({
+    user_id: `demo_${index}`,
+    display_name: member.name,
+    level: Math.floor(Math.random() * 10) + 1,
+    experience: Math.floor(Math.random() * 1200),
+    contributions: Math.floor(Math.random() * 80),
+    quests_completed: Math.floor(Math.random() * 30),
+    projects_hosted: Math.floor(Math.random() * 8),
+    connections: Math.floor(Math.random() * 20)
+  }));
+}
+
+function updateCommunityStats(inhabitants) {
+  const totalMembers = inhabitants.length;
+  const totalXP = inhabitants.reduce((sum, user) => sum + (user.experience || 0), 0);
+  const totalQuests = inhabitants.reduce((sum, user) => sum + (user.quests_completed || 0), 0);
+  const totalProjects = inhabitants.reduce((sum, user) => sum + (user.projects_hosted || 0), 0);
+
+  const totalMembersEl = document.getElementById('totalMembers');
+  const totalXPEl = document.getElementById('totalXP');
+  const totalQuestsEl = document.getElementById('totalQuests');
+  const totalProjectsEl = document.getElementById('totalProjects');
+
+  if (totalMembersEl) totalMembersEl.textContent = totalMembers;
+  if (totalXPEl) totalXPEl.textContent = totalXP.toLocaleString();
+  if (totalQuestsEl) totalQuestsEl.textContent = totalQuests;
+  if (totalProjectsEl) totalProjectsEl.textContent = totalProjects;
+}
+
+function showCommunityView() {
+  const publicContent = document.getElementById('publicContent') || document.querySelector('.public-content');
+  const communityView = document.getElementById('communityView');
+
+  if (publicContent) publicContent.style.display = 'none';
+  if (communityView) communityView.style.display = 'block';
+
+  generateVillageInhabitants();
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+function hideCommunityView() {
+  const publicContent = document.getElementById('publicContent') || document.querySelector('.public-content');
+  const communityView = document.getElementById('communityView');
+
+  if (publicContent) publicContent.style.display = 'block';
+  if (communityView) communityView.style.display = 'none';
+
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+function updateProfileDisplay() {
+  const communityView = document.getElementById('communityView');
+  if (communityView && communityView.style.display === 'block') {
+    generateVillageInhabitants();
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const openLoginBtn = document.getElementById('openLoginBtn');
+  if (openLoginBtn) openLoginBtn.addEventListener('click', openLoginModal);
+
+  const closeLoginBtn = document.getElementById('closeLoginBtn');
+  if (closeLoginBtn) closeLoginBtn.addEventListener('click', closeLoginModal);
+
+  const googleLogin = document.getElementById('googleLogin');
+  if (googleLogin) googleLogin.addEventListener('click', () => handleLogin('google'));
+
+  const githubLogin = document.getElementById('githubLogin');
+  if (githubLogin) githubLogin.addEventListener('click', () => handleLogin('github'));
+
+  const logoutBtn = document.getElementById('logoutBtn');
+  if (logoutBtn) logoutBtn.addEventListener('click', handleLogout);
+
+  const loginCharacterBtn = document.getElementById('loginCharacterBtn');
+  if (loginCharacterBtn) loginCharacterBtn.addEventListener('click', openLoginModal);
+
+  const logoutCharacterBtn = document.getElementById('logoutCharacterBtn');
+  if (logoutCharacterBtn) logoutCharacterBtn.addEventListener('click', handleLogout);
+
+  const communityCard = document.getElementById('communityCard');
+  if (communityCard) communityCard.addEventListener('click', showCommunityView);
+
+  const backButton = document.getElementById('backButton');
+  if (backButton) backButton.addEventListener('click', hideCommunityView);
+
+  const loginModal = document.getElementById('loginModal');
+  if (loginModal) {
+    loginModal.addEventListener('click', (e) => {
+      if (e.target.id === 'loginModal') {
+        closeLoginModal();
+      }
+    });
+  }
+
+  updateCharacterSheet();
+  onConfigChange(defaultConfig);
+});

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -63,12 +63,12 @@
       <!-- TODO: integrar estado real de login Qute con esta nav -->
       <button class="login-btn-nav" id="openLoginBtn">Login</button>
       <div class="user-menu" id="userMenuNav">
-        <div class="user-avatar" aria-hidden="true">HD</div>
+        <div class="user-avatar" id="navAvatar" aria-hidden="true">HD</div>
         <div class="user-dropdown">
-          <div class="user-name">Logged in</div>
+          <div class="user-name" id="navUserName">Logged in</div>
           <div class="user-actions">
             <a href="/profile" class="btn">Profile</a>
-            <a href="/logout" class="btn">Logout</a>
+            <a href="/logout" class="btn" id="logoutBtn">Logout</a>
           </div>
         </div>
       </div>
@@ -77,7 +77,7 @@
 </nav>
 
 <div class="app-container">
-  <div class="public-content">
+  <div class="public-content" id="publicContent">
     <header class="public-header">
       <div class="content">
         <h1 id="mainTitle">HomeDir</h1>
@@ -200,73 +200,170 @@
           <div class="building lab">Builder Lab</div>
           <div class="building arcade">Arcade</div>
         </div>
+        <div class="inhabitants-layer" id="inhabitantsLayer"></div>
       </div>
       <aside class="community-stats">
         <h3>Community stats</h3>
-        <ul class="list">
-          <li class="item">Connected squads</li>
-          <li class="item">Live workshops</li>
-          <li class="item">Mentor hours</li>
-          <li class="item">Daily quests</li>
-        </ul>
+        <div class="stat-grid">
+          <div class="stat-item">
+            <div class="stat-icon">👥</div>
+            <div class="stat-info">
+              <div class="stat-value" id="totalMembers">0</div>
+              <div class="stat-label">Members online</div>
+            </div>
+          </div>
+          <div class="stat-item">
+            <div class="stat-icon">⭐</div>
+            <div class="stat-info">
+              <div class="stat-value" id="totalXP">0</div>
+              <div class="stat-label">Total XP</div>
+            </div>
+          </div>
+          <div class="stat-item">
+            <div class="stat-icon">🏆</div>
+            <div class="stat-info">
+              <div class="stat-value" id="totalQuests">0</div>
+              <div class="stat-label">Quests Completed</div>
+            </div>
+          </div>
+          <div class="stat-item">
+            <div class="stat-icon">🚀</div>
+            <div class="stat-info">
+              <div class="stat-value" id="totalProjects">0</div>
+              <div class="stat-label">Active Projects</div>
+            </div>
+          </div>
+        </div>
       </aside>
     </div>
   </div>
 </div>
 
 <footer class="character-sheet">
-  <div class="novice-warning">New to HomeDir? Start your character sheet and unlock perks.</div>
-  <div class="avatar">
-    <img src="/images/default-avatar.png" alt="Player avatar" />
-    <div>
-      <p class="label">Player</p>
-      <p class="value">Community Builder</p>
+  <div class="character-container">
+    <div class="novice-warning" id="noviceWarning">
+      You're playing as a NOVICE guest! Login to save your progress and unlock your full character potential!
     </div>
-  </div>
-  <div class="stats">
-    <div class="stat">
-      <p class="label">XP</p>
-      <p class="value">1200</p>
+    <div class="character-header">
+      <div class="character-title">
+        <h3 id="characterName">NOVICE GUEST</h3>
+        <span class="character-class" id="characterClass">VISITOR</span>
+      </div>
+      <div class="character-level" id="characterLevel">LEVEL 1</div>
     </div>
-    <div class="stat">
-      <p class="label">Allies</p>
-      <p class="value">24</p>
+    <div class="character-main">
+      <div class="character-vitals">
+        <div class="vital-bar">
+          <div class="vital-label"><span class="vital-name">❤️ HP (HEALTH)</span> <span class="vital-value" id="hpValue">10 / 100</span></div>
+          <div class="vital-progress">
+            <div class="vital-fill hp-fill" id="hpBar" style="width: 10%"></div>
+          </div>
+        </div>
+        <div class="vital-bar">
+          <div class="vital-label"><span class="vital-name">⚡ SP (SKILL)</span> <span class="vital-value" id="spValue">5 / 100</span></div>
+          <div class="vital-progress">
+            <div class="vital-fill sp-fill" id="spBar" style="width: 5%"></div>
+          </div>
+        </div>
+        <div class="vital-bar">
+          <div class="vital-label"><span class="vital-name">⭐ XP (EXPERIENCE)</span> <span class="vital-value" id="xpValue">0 / 100</span></div>
+          <div class="vital-progress">
+            <div class="vital-fill xp-fill" id="xpBar" style="width: 0%"></div>
+          </div>
+        </div>
+      </div>
+      <div class="character-stats">
+        <div class="stat-box">
+          <div class="stat-icon">🎯</div>
+          <div class="stat-value" id="contributionsStat">0</div>
+          <div class="stat-label">Contributions</div>
+        </div>
+        <div class="stat-box">
+          <div class="stat-icon">🏆</div>
+          <div class="stat-value" id="questsStat">0</div>
+          <div class="stat-label">Quests</div>
+        </div>
+        <div class="stat-box">
+          <div class="stat-icon">📅</div>
+          <div class="stat-value" id="eventsStat">0</div>
+          <div class="stat-label">Events</div>
+        </div>
+        <div class="stat-box">
+          <div class="stat-icon">🚀</div>
+          <div class="stat-value" id="projectsStat">0</div>
+          <div class="stat-label">Projects</div>
+        </div>
+        <div class="stat-box">
+          <div class="stat-icon">🤝</div>
+          <div class="stat-value" id="connectionsStat">0</div>
+          <div class="stat-label">Connections</div>
+        </div>
+        <div class="stat-box">
+          <div class="stat-icon">💎</div>
+          <div class="stat-value" id="experienceStat">0</div>
+          <div class="stat-label">Total XP</div>
+        </div>
+      </div>
+      <div class="character-equipment">
+        <div class="equipment-header">
+          <h4>🎒 EQUIPMENT</h4>
+        </div>
+        <div class="equipment-grid" id="equipmentGrid">
+          <div class="equipment-slot empty" data-slot="0">
+            <div class="equipment-tooltip">EMPTY SLOT</div>
+          </div>
+          <div class="equipment-slot empty" data-slot="1">
+            <div class="equipment-tooltip">EMPTY SLOT</div>
+          </div>
+          <div class="equipment-slot empty" data-slot="2">
+            <div class="equipment-tooltip">EMPTY SLOT</div>
+          </div>
+          <div class="equipment-slot empty" data-slot="3">
+            <div class="equipment-tooltip">EMPTY SLOT</div>
+          </div>
+          <div class="equipment-slot empty" data-slot="4">
+            <div class="equipment-tooltip">EMPTY SLOT</div>
+          </div>
+          <div class="equipment-slot empty" data-slot="5">
+            <div class="equipment-tooltip">EMPTY SLOT</div>
+          </div>
+        </div>
+        <div class="equipment-count">0 / 6 ITEMS</div>
+      </div>
     </div>
-    <div class="stat">
-      <p class="label">Quests</p>
-      <p class="value">8 active</p>
+    <div class="character-actions" id="characterActions">
+      <button class="character-action-btn" id="loginCharacterBtn"><span>🎮 LOGIN TO SAVE CHARACTER</span></button>
+      <button class="character-action-btn" id="logoutCharacterBtn" style="display: none;"><span>🚪 LOGOUT</span></button>
     </div>
-    <div class="stat">
-      <p class="label">Artifacts</p>
-      <p class="value">5</p>
-    </div>
-  </div>
-  <div class="actions">
-    <button class="pixel-button">Edit sheet</button>
-    <button class="pixel-button">Save loadout</button>
   </div>
 </footer>
 
 <div class="login-modal" id="loginModal" role="dialog" aria-modal="true" aria-labelledby="loginTitle">
-  <div class="modal-content">
-    <button class="close-modal" id="closeLoginBtn" aria-label="Close login modal">×</button>
-    <h2 id="loginTitle">Login to HomeDir</h2>
-    <p class="modal-subtitle">Jump back into your community quests.</p>
-    <div class="input-group">
-      <label for="emailInput">Email</label>
-      <input type="email" id="emailInput" placeholder="you@example.com" />
-    </div>
-    <div class="input-group">
-      <label for="passwordInput">Password</label>
-      <input type="password" id="passwordInput" placeholder="••••••••" />
-    </div>
-    <div class="modal-actions">
-      <button class="pixel-button" id="loginSubmit">Login</button>
-      <button class="btn" id="forgotPassword">Forgot password?</button>
+  <div class="login-card">
+    <button class="close-modal" id="closeLoginBtn" aria-label="Close login">×</button>
+    <h2 id="loginTitle">Welcome to HomeDir</h2>
+    <p class="modal-subtitle">Login to manage your profile and data</p>
+    <div class="login-buttons">
+      <button class="login-btn" id="googleLogin">
+        <svg viewbox="0 0 24 24" fill="currentColor">
+          <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
+          <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+          <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+          <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+        </svg>
+        Continue with Google
+      </button>
+      <button class="login-btn" id="githubLogin">
+        <svg viewbox="0 0 24 24" fill="currentColor">
+          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+        </svg>
+        Continue with GitHub
+      </button>
     </div>
   </div>
 </div>
 
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
+<script src="/js/homedir.js"></script>
 {/body}
 {/include}


### PR DESCRIPTION
## Summary
- add standalone `homedir.js` with mock campus, login, character sheet, and styling config logic without Canva SDKs
- wire home template elements and IDs to support interactive campus, stats, and demo login UI
- include static script on the home page and expand modal/character sheet structure for dynamic updates

## Testing
- ⚠️ `./mvnw quarkus:dev -DskipTests` *(failed: Maven wrapper could not download dependencies because the network is unreachable in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ec9680e4c8333b322b1b3e4adc763)