### PR TITLE
Add landing stats API and hook up frontend

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/LandingStatsResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/LandingStatsResource.java
@@ -1,0 +1,42 @@
+package com.scanales.eventflow.public_;
+
+import com.scanales.eventflow.service.CommunityService;
+import jakarta.annotation.security.PermitAll;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/api/landing/stats")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@PermitAll
+public class LandingStatsResource {
+
+  @Inject CommunityService communityService;
+
+  @GET
+  public LandingStats getStats() {
+    LandingStats stats = new LandingStats();
+
+    stats.totalMembers = communityService.countMembers();
+
+    // NOTE: valores dummy por ahora.
+    // Cuando exista un servicio de dominio para miembros/proyectos/quests,
+    // reemplazar por consultas reales.
+    stats.totalXP = 1337L; // TODO: reemplazar por suma real de XP
+    stats.totalQuests = 7L; // TODO: reemplazar por quests reales completadas
+    stats.totalProjects = 3L; // TODO: reemplazar por proyectos activos reales
+
+    return stats;
+  }
+
+  public static class LandingStats {
+    public long totalMembers;
+    public long totalXP;
+    public long totalQuests;
+    public long totalProjects;
+  }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/js/homedir.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/homedir.js
@@ -392,6 +392,32 @@ function updateCommunityStats(inhabitants) {
   if (totalProjectsEl) totalProjectsEl.textContent = totalProjects;
 }
 
+// Fuente de verdad para las estadísticas mostradas en la landing.
+// En el futuro debe alinearse con los datos reales de Homedir.
+async function fetchLandingStats() {
+  try {
+    const response = await fetch('/api/landing/stats');
+    if (!response.ok) {
+      console.error('Failed to fetch landing stats', response.status);
+      return;
+    }
+
+    const stats = await response.json();
+
+    const membersEl = document.getElementById('totalMembers');
+    const xpEl = document.getElementById('totalXP');
+    const questsEl = document.getElementById('totalQuests');
+    const projectsEl = document.getElementById('totalProjects');
+
+    if (membersEl) membersEl.textContent = stats.totalMembers ?? 0;
+    if (xpEl) xpEl.textContent = (stats.totalXP ?? 0).toLocaleString();
+    if (questsEl) questsEl.textContent = stats.totalQuests ?? 0;
+    if (projectsEl) projectsEl.textContent = stats.totalProjects ?? 0;
+  } catch (e) {
+    console.error('Error loading landing stats', e);
+  }
+}
+
 function showCommunityView() {
   const publicContent = document.getElementById('publicContent') || document.querySelector('.public-content');
   const communityView = document.getElementById('communityView');
@@ -459,4 +485,5 @@ document.addEventListener('DOMContentLoaded', () => {
 
   updateCharacterSheet();
   onConfigChange(defaultConfig);
+  fetchLandingStats();
 });


### PR DESCRIPTION
## Summary
- add a public `/api/landing/stats` endpoint that returns landing metrics with a real community member count and TODOs for other values
- wire the landing page JavaScript to fetch the backend stats and populate the community metric counters on load

## Testing
- mvn -f pom.xml clean verify


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ecfdbc8248333a8ed5385b58367c5)