### PR TITLE
Connect landing cards to real Homedir routes

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -183,6 +183,22 @@ textarea:focus-visible {
   background: rgba(255, 255, 255, 0.04);
 }
 
+.nav-link {
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  margin-right: 1rem;
+  text-decoration: none;
+  color: #ffffff;
+  opacity: 0.9;
+  font-family: 'Courier New', monospace;
+}
+
+.nav-link:hover {
+  opacity: 1;
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.7);
+}
+
 .top-nav .nav-actions {
   display: flex;
   align-items: center;

--- a/quarkus-app/src/main/resources/META-INF/resources/js/homedir.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/homedir.js
@@ -537,12 +537,38 @@ document.addEventListener('DOMContentLoaded', () => {
   if (logoutCharacterBtn) logoutCharacterBtn.addEventListener('click', handleLogout);
 
   const communityCard = document.getElementById('communityCard');
+  const eventsCard = document.getElementById('eventsCard');
+  const projectsCard = document.getElementById('projectsCard');
+
   if (communityCard) {
     communityCard.addEventListener('click', (event) => {
       if (event.target.closest('a') || event.target.closest('button')) {
         return;
       }
+      event.preventDefault();
       showCommunityView();
+      // TODO: si en el futuro existe una sección /community completa,
+      // evaluar si esta card debe navegar ahí en vez de usar solo showCommunityView().
+    });
+  }
+
+  if (eventsCard) {
+    eventsCard.addEventListener('click', (event) => {
+      if (event.target.closest('a') || event.target.closest('button')) {
+        return;
+      }
+      event.preventDefault();
+      window.location.href = '/eventos';
+    });
+  }
+
+  if (projectsCard) {
+    projectsCard.addEventListener('click', (event) => {
+      if (event.target.closest('a') || event.target.closest('button')) {
+        return;
+      }
+      event.preventDefault();
+      window.location.href = '/proyectos';
     });
   }
 

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -52,10 +52,10 @@
       </div>
     </div>
     <div class="links">
-      <a href="#communityCard">Community</a>
-      <a href="#eventsSection">Events</a>
-      <a href="#projectsSection">Projects</a>
-      <a href="/notifications/center">Notifications</a>
+      <a href="/comunidad" class="nav-link">Community</a>
+      <a href="/eventos" class="nav-link">Events</a>
+      <a href="/proyectos" class="nav-link">Projects</a>
+      <a href="/notifications/center" class="nav-link">Notifications</a>
     </div>
     <div class="nav-actions">
       <!-- TODO: integrar estado real de login Qute con esta nav -->
@@ -135,7 +135,7 @@
         </div>
       </article>
 
-      <article class="section-card" id="eventsSection">
+      <article class="section-card" id="eventsCard">
         <div>
           <p class="eyebrow">Events</p>
           <h2 id="eventsTitle">Events & Experiences</h2>
@@ -147,7 +147,7 @@
             <span class="activity-text">{past.size ?: 0} archived</span>
           </div>
           <div class="actions">
-            <a href="/event" class="btn primary">View events</a>
+            <a href="/eventos" class="btn primary">View events</a>
             <a href="/ingresar" class="btn">Create new</a>
           </div>
         </div>
@@ -157,7 +157,7 @@
         </div>
       </article>
 
-      <article class="section-card" id="projectsSection">
+      <article class="section-card" id="projectsCard">
         <div>
           <p class="eyebrow">Projects</p>
           <h2 id="projectsTitle">Open Projects</h2>
@@ -169,7 +169,7 @@
             <span class="activity-text">New squads forming</span>
           </div>
           <div class="actions">
-            <a href="/projects" class="btn primary">Browse projects</a>
+            <a href="/proyectos" class="btn primary">Browse projects</a>
             <a href="/docs" class="btn">Contribute guide</a>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add navigation links and landing card identifiers that align with the community, events, and projects sections
- point landing actions to the existing eventos/proyectos routes and apply retro-styled nav link styling
- wire card click handlers to navigate to live routes while keeping the Community Campus inline view

## Testing
- `./mvnw test` *(fails: network is unreachable when downloading Maven wrapper dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eeaf9d3148333a386449808b8875e)