### PR TITLE
Add pixel layout and homepage template

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -1,101 +1,37 @@
 package com.scanales.eventflow.public_;
 
-import com.scanales.eventflow.model.Event;
-import com.scanales.eventflow.service.EventService;
 import com.scanales.eventflow.service.UsageMetricsService;
-import io.eventflow.home.now.NowBoxService;
-import io.eventflow.home.now.NowBoxView;
 import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import io.vertx.ext.web.RoutingContext;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
-import java.time.LocalDate;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
 
 @Path("/")
 public class HomeResource {
 
-  @Inject EventService eventService;
-
   @Inject UsageMetricsService metrics;
 
-  @Inject NowBoxService nowBoxService;
-
-  @ConfigProperty(name = "homedir.ui.v2.enabled", defaultValue = "true")
-  boolean uiV2Enabled;
-
-  @CheckedTemplate
+  @CheckedTemplate(basePath = "")
   static class Templates {
-    static native TemplateInstance home(
-        java.util.List<com.scanales.eventflow.model.Event> upcoming,
-        java.util.List<com.scanales.eventflow.model.Event> past,
-        LocalDate today,
-        String version,
-        Map<String, String> stats,
-        Map<String, String> links,
-        NowBoxView nowBox);
+    static native TemplateInstance index();
   }
 
   @GET
   @PermitAll
   @Produces(MediaType.TEXT_HTML)
   public TemplateInstance home(
-      @jakarta.ws.rs.core.Context jakarta.ws.rs.core.HttpHeaders headers,
-      @jakarta.ws.rs.core.Context io.vertx.ext.web.RoutingContext context) {
+      @jakarta.ws.rs.core.Context HttpHeaders headers,
+      @jakarta.ws.rs.core.Context RoutingContext context) {
     metrics.recordPageView("/", headers, context);
-    var allEvents = eventService.listEvents();
-    LocalDate today = LocalDate.now();
-    List<Event> upcoming =
-        allEvents.stream()
-            .filter(
-                e -> {
-                  ZonedDateTime end = e.getEndDateTime();
-                  LocalDate endDate = end == null ? null : end.toLocalDate();
-                  return endDate == null || !endDate.isBefore(today);
-                })
-            .sorted(
-                Comparator.comparing(
-                    Event::getDate, Comparator.nullsLast(Comparator.naturalOrder())))
-            .toList();
-    List<Event> past =
-        allEvents.stream()
-            .filter(
-                e -> {
-                  ZonedDateTime end = e.getEndDateTime();
-                  LocalDate endDate = end == null ? null : end.toLocalDate();
-                  return endDate != null && endDate.isBefore(today);
-                })
-            .sorted(
-                Comparator.comparing(
-                        Event::getEndDateTime, Comparator.nullsLast(Comparator.naturalOrder()))
-                    .reversed())
-            .toList();
-    var stats =
-        Map.of(
-            "status",
-            "En desarrollo",
-            "lastUpdated",
-            today.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")));
-    var links =
-        Map.of(
-            "releasesUrl", "https://github.com/os-santiago/homedir/releases",
-            "issuesUrl", "https://github.com/os-santiago/homedir/issues",
-            "donateUrl", "https://ko-fi.com/sergiocanales");
-    var nowBox = nowBoxService.build();
-    var template = Templates.home(upcoming, past, today, "2.2.3", stats, links, nowBox);
-    // TODO: definir template de fallback si en el futuro se desea una versión mínima
-    return template.data("noNav", true).data("noFooter", true);
+    return Templates.index();
   }
 
   @GET

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir-pixel.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir-pixel.css
@@ -1,0 +1,988 @@
+:root {
+  --hd-bg-start: #10002b;
+  --hd-bg-end: #2d0a60;
+  --hd-surface: rgba(21, 12, 40, 0.92);
+  --hd-surface-strong: rgba(35, 20, 64, 0.95);
+  --hd-surface-soft: rgba(255, 255, 255, 0.04);
+  --hd-border: rgba(255, 255, 255, 0.12);
+  --hd-primary: #ff8bd1;
+  --hd-primary-strong: #ff63c3;
+  --hd-secondary: #7bd7ff;
+  --hd-accent: #caffbf;
+  --hd-text: #f8f4ff;
+  --hd-text-muted: #c5b5ff;
+  --hd-shadow: 0 18px 50px rgba(0, 0, 0, 0.45);
+  --hd-radius: 20px;
+  --hd-spacing: 18px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+body,
+.hd-body {
+  background: radial-gradient(circle at 20% 20%, rgba(255, 99, 195, 0.08), transparent 35%),
+    radial-gradient(circle at 80% 0%, rgba(123, 215, 255, 0.12), transparent 30%),
+    linear-gradient(135deg, var(--hd-bg-start), var(--hd-bg-end));
+  color: var(--hd-text);
+  font-family: 'Courier Prime', system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  letter-spacing: 0.01em;
+  line-height: 1.6;
+  position: relative;
+  overflow-x: hidden;
+}
+
+main,
+.hd-main {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+a {
+  color: var(--hd-secondary);
+  text-decoration: none;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+a:hover {
+  color: var(--hd-accent);
+  transform: translateY(-1px);
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--hd-secondary);
+  outline-offset: 4px;
+}
+
+.floating-shapes {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  overflow: hidden;
+}
+
+.shape {
+  position: absolute;
+  opacity: 0.35;
+  filter: blur(1px);
+  animation: float 10s ease-in-out infinite;
+}
+
+.shape svg {
+  width: 220px;
+  height: 220px;
+}
+
+.shape-1 {
+  top: 12%;
+  left: 6%;
+}
+
+.shape-2 {
+  top: 8%;
+  right: 12%;
+  animation-delay: 1.2s;
+}
+
+.shape-3 {
+  bottom: 14%;
+  left: 10%;
+  animation-delay: 2.3s;
+}
+
+.shape-4 {
+  bottom: 6%;
+  right: 6%;
+  animation-delay: 3s;
+}
+
+.top-nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(16px);
+  background: linear-gradient(90deg, rgba(16, 0, 43, 0.85), rgba(45, 10, 96, 0.92));
+  border-bottom: 1px solid var(--hd-border);
+  box-shadow: var(--hd-shadow);
+}
+
+.top-nav .inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px clamp(16px, 3vw, 40px);
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.top-nav .logo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 13px;
+  color: var(--hd-text);
+}
+
+.top-nav .logo-icon {
+  width: 46px;
+  height: 46px;
+  display: grid;
+  place-items: center;
+  background: var(--hd-surface);
+  border-radius: 14px;
+  border: 1px solid var(--hd-border);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+
+.top-nav .logo-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-family: 'Press Start 2P', 'Courier Prime', monospace;
+  letter-spacing: 0.05em;
+}
+
+.top-nav .logo-subtitle {
+  font-size: 10px;
+  color: var(--hd-text-muted);
+}
+
+.top-nav .links {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.top-nav .links a {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  color: var(--hd-text-muted);
+}
+
+.top-nav .links a:hover {
+  color: var(--hd-text);
+  border-color: var(--hd-border);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.nav-link {
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  margin-right: 1rem;
+  text-decoration: none;
+  color: #ffffff;
+  opacity: 0.9;
+  font-family: 'Courier New', monospace;
+}
+
+.nav-link:hover {
+  opacity: 1;
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.7);
+}
+
+.top-nav .nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.login-btn-nav {
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--hd-border);
+  background: linear-gradient(120deg, var(--hd-primary), var(--hd-secondary));
+  color: #0d071b;
+  box-shadow: 0 10px 30px rgba(255, 99, 195, 0.25);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.user-menu {
+  position: relative;
+  display: none;
+  align-items: center;
+  gap: 10px;
+}
+
+.user-menu.active {
+  display: flex;
+}
+
+.user-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--hd-surface);
+  border: 1px solid var(--hd-border);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+}
+
+.user-dropdown {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: var(--hd-surface-strong);
+  border: 1px solid var(--hd-border);
+  border-radius: 12px;
+  padding: 10px 12px;
+  box-shadow: var(--hd-shadow);
+}
+
+.user-dropdown .btn {
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--hd-border);
+  background: var(--hd-surface);
+  color: var(--hd-text);
+}
+
+.app-container {
+  position: relative;
+  z-index: 1;
+  padding: 30px clamp(16px, 4vw, 44px) 80px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.public-content {
+  background: linear-gradient(135deg, rgba(255, 99, 195, 0.12), rgba(123, 215, 255, 0.08));
+  border: 1px solid var(--hd-border);
+  border-radius: 28px;
+  box-shadow: var(--hd-shadow);
+  padding: 32px clamp(18px, 4vw, 48px);
+}
+
+.public-header {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 28px;
+  align-items: center;
+}
+
+.public-header h1 {
+  margin: 0 0 16px;
+  font-size: clamp(22px, 3vw, 30px);
+  font-family: 'Press Start 2P', 'Courier Prime', monospace;
+  letter-spacing: 0.04em;
+}
+
+.public-header .tagline {
+  margin: 0 0 18px;
+  color: var(--hd-text-muted);
+}
+
+.public-header .meta,
+.section-card .meta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: var(--hd-text-muted);
+}
+
+.public-header .meta span,
+.section-card .meta span {
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--hd-border);
+}
+
+.public-header .actions,
+.section-card .actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.pixel-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 18px;
+  border-radius: 14px;
+  border: 2px solid #000;
+  background: linear-gradient(160deg, var(--hd-primary), var(--hd-secondary));
+  box-shadow: 4px 4px 0 #000;
+  color: #0d071b;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+}
+
+.pixel-button:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 6px 6px 0 #000;
+}
+
+.cta {
+  color: var(--hd-text);
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--hd-border);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 14px;
+}
+
+.stat-card {
+  padding: 16px 18px;
+  border-radius: 14px;
+  background: var(--hd-surface);
+  border: 1px solid var(--hd-border);
+  box-shadow: var(--hd-shadow);
+}
+
+.stat-card .label {
+  display: block;
+  font-size: 11px;
+  color: var(--hd-text-muted);
+  margin-bottom: 8px;
+}
+
+.stat-card .value {
+  font-size: 16px;
+  color: #fff;
+  font-family: 'Press Start 2P', 'Courier Prime', monospace;
+}
+
+.main-sections {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 18px;
+  margin-top: 24px;
+}
+
+.section-card {
+  padding: 22px;
+  border-radius: 20px;
+  background: var(--hd-surface);
+  border: 1px solid var(--hd-border);
+  box-shadow: var(--hd-shadow);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--hd-spacing);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.section-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+}
+
+.section-card h2 {
+  margin: 0 0 14px;
+  font-size: 18px;
+}
+
+.section-card p {
+  margin: 0;
+  color: var(--hd-text-muted);
+}
+
+.icon-wrapper {
+  width: 64px;
+  height: 64px;
+  display: grid;
+  place-items: center;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--hd-border);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.icon-wrapper svg {
+  width: 56px;
+  height: 56px;
+}
+
+.activity-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.activity-dots .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--hd-secondary);
+  box-shadow: 0 0 12px rgba(123, 215, 255, 0.6);
+}
+
+.section-card .actions .btn {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--hd-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: #fff;
+}
+
+.section-card .actions .btn.primary {
+  background: linear-gradient(120deg, var(--hd-primary), var(--hd-secondary));
+  color: #0d071b;
+  border: none;
+  box-shadow: 0 10px 30px rgba(255, 99, 195, 0.25);
+}
+
+.section-card .visual {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--hd-border);
+  font-size: 12px;
+  color: var(--hd-text);
+}
+
+.activity-text {
+  color: var(--hd-text-muted);
+  font-size: 12px;
+}
+
+.community-view {
+  display: grid;
+  grid-template-columns: 2fr 1.2fr;
+  gap: 24px;
+  margin-top: 24px;
+}
+
+.community-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.back-button {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--hd-border);
+  background: var(--hd-surface);
+  color: var(--hd-text);
+  cursor: pointer;
+}
+
+.village-container {
+  background: var(--hd-surface);
+  border: 1px solid var(--hd-border);
+  border-radius: 20px;
+  padding: 16px;
+  box-shadow: var(--hd-shadow);
+}
+
+.village-landscape {
+  position: relative;
+  height: 320px;
+  background: linear-gradient(180deg, rgba(123, 215, 255, 0.16), rgba(16, 0, 43, 0.6));
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid var(--hd-border);
+}
+
+.village-sky {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 80% 20%, rgba(255, 255, 255, 0.18), transparent 40%);
+}
+
+.village-ground {
+  position: absolute;
+  bottom: 0;
+  height: 90px;
+  width: 100%;
+  background: linear-gradient(0deg, rgba(16, 0, 43, 0.95), rgba(16, 0, 43, 0));
+}
+
+.village-buildings {
+  position: absolute;
+  bottom: 90px;
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+  padding: 0 12px;
+  gap: 10px;
+}
+
+.building {
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: var(--hd-surface-strong);
+  border: 1px dashed var(--hd-border);
+  min-width: 90px;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.inhabitants-layer {
+  position: absolute;
+  bottom: 90px;
+  left: 0;
+  right: 0;
+  height: 180px;
+}
+
+.team-member {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  color: var(--hd-text);
+  animation: float 5s ease-in-out infinite;
+}
+
+.team-member .member-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--hd-surface);
+  border: 2px solid var(--hd-secondary);
+  display: grid;
+  place-items: center;
+  font-size: 22px;
+  position: relative;
+}
+
+.member-status {
+  position: absolute;
+  right: -4px;
+  bottom: -2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid var(--hd-surface);
+}
+
+.status-online {
+  background: #4ade80;
+}
+
+.status-busy {
+  background: #f97316;
+}
+
+.status-away {
+  background: #facc15;
+}
+
+.member-level {
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--hd-border);
+  border-radius: 8px;
+  padding: 4px 6px;
+  font-size: 11px;
+}
+
+.member-badge {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--hd-border);
+  border-radius: 10px;
+  padding: 6px 8px;
+  font-size: 12px;
+}
+
+.member-role {
+  font-size: 16px;
+}
+
+.community-stats {
+  background: var(--hd-surface);
+  border: 1px solid var(--hd-border);
+  border-radius: 20px;
+  padding: 18px;
+  box-shadow: var(--hd-shadow);
+}
+
+.community-stats h3 {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.community-stats .stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.community-stats .stat-item {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 12px;
+  border: 1px solid var(--hd-border);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.community-stats .stat-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.character-sheet {
+  margin-top: 28px;
+  background: linear-gradient(145deg, rgba(255, 99, 195, 0.08), rgba(123, 215, 255, 0.08));
+  border: 1px solid var(--hd-border);
+  border-radius: 24px;
+  padding: 22px;
+  box-shadow: var(--hd-shadow);
+}
+
+.character-container {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.novice-warning {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px dashed var(--hd-border);
+  padding: 12px 14px;
+  border-radius: 14px;
+  color: var(--hd-text);
+}
+
+.character-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.character-title h3 {
+  margin: 0;
+  font-family: 'Press Start 2P', 'Courier Prime', monospace;
+}
+
+.character-class {
+  display: inline-block;
+  margin-top: 6px;
+  padding: 6px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--hd-border);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.character-level {
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: linear-gradient(120deg, var(--hd-primary), var(--hd-secondary));
+  color: #0d071b;
+  font-weight: 800;
+}
+
+.character-main {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+.character-vitals .vital-bar {
+  margin-bottom: 12px;
+}
+
+.vital-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  color: var(--hd-text);
+}
+
+.vital-progress {
+  position: relative;
+  height: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--hd-border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.vital-fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+
+.hp-fill {
+  background: linear-gradient(90deg, #ff6b6b, #ff8bd1);
+}
+
+.sp-fill {
+  background: linear-gradient(90deg, #7bd7ff, #3b82f6);
+}
+
+.xp-fill {
+  background: linear-gradient(90deg, #facc15, #f97316);
+}
+
+.character-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+}
+
+.stat-box {
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--hd-border);
+  text-align: center;
+}
+
+.stat-box .stat-icon {
+  font-size: 20px;
+  margin-bottom: 6px;
+}
+
+.character-equipment {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--hd-border);
+  border-radius: 14px;
+  padding: 12px;
+}
+
+.equipment-header h4 {
+  margin: 0 0 10px;
+}
+
+.equipment-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+  gap: 10px;
+}
+
+.equipment-slot {
+  position: relative;
+  min-height: 80px;
+  border: 1px dashed var(--hd-border);
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.25);
+  display: grid;
+  place-items: center;
+  color: var(--hd-text);
+  font-size: 22px;
+}
+
+.equipment-slot .equipment-tooltip {
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 11px;
+  color: var(--hd-text-muted);
+}
+
+.equipment-slot.filled {
+  border-style: solid;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.equipment-rarity {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.rarity-common {
+  background: #9ca3af;
+}
+
+.rarity-rare {
+  background: #3b82f6;
+}
+
+.rarity-epic {
+  background: #a855f7;
+}
+
+.rarity-legendary {
+  background: #f59e0b;
+}
+
+.equipment-count {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--hd-text-muted);
+}
+
+.character-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.character-action-btn {
+  flex: 1;
+  min-width: 220px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--hd-border);
+  background: linear-gradient(120deg, var(--hd-primary), var(--hd-secondary));
+  color: #0d071b;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.login-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  z-index: 30;
+}
+
+.login-modal.show {
+  display: flex;
+}
+
+.login-card {
+  background: var(--hd-surface);
+  border: 1px solid var(--hd-border);
+  border-radius: 16px;
+  padding: 20px;
+  max-width: 420px;
+  width: 100%;
+  position: relative;
+  box-shadow: var(--hd-shadow);
+}
+
+.close-modal {
+  position: absolute;
+  right: 12px;
+  top: 10px;
+  background: transparent;
+  color: var(--hd-text);
+  border: none;
+  font-size: 22px;
+  cursor: pointer;
+}
+
+.login-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.login-btn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--hd-border);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--hd-text);
+  cursor: pointer;
+}
+
+.login-btn svg {
+  width: 22px;
+  height: 22px;
+}
+
+.login-btn.loading {
+  opacity: 0.7;
+}
+
+.toast {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  padding: 12px 14px;
+  background: var(--hd-surface);
+  border: 1px solid var(--hd-border);
+  border-radius: 12px;
+  box-shadow: var(--hd-shadow);
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  z-index: 40;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@keyframes float {
+  0% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@view-transition {
+  navigation: auto;
+}
+
+@media (max-width: 900px) {
+  .top-nav .inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .community-view {
+    grid-template-columns: 1fr;
+  }
+
+  .character-main {
+    grid-template-columns: 1fr;
+  }
+}

--- a/quarkus-app/src/main/resources/templates/index.qute.html
+++ b/quarkus-app/src/main/resources/templates/index.qute.html
@@ -1,0 +1,131 @@
+{#include layouts/main}
+  {#body}
+    <div class="public-content" id="publicContent">
+      <header class="public-header">
+        <h1 id="mainTitle">HomeDir</h1>
+        <p class="tagline" id="mainTagline">
+          by OpenSourceSantiago - The community platform to scale your teams and projects
+        </p>
+      </header>
+
+      <main class="main-sections">
+        <article class="section-card" id="communityCard">
+          <div class="icon-wrapper" aria-hidden="true">
+            <svg viewBox="0 0 64 64" role="img">
+              <rect x="10" y="10" width="44" height="44" rx="10" fill="#0d071b" stroke="#ff8bd1" stroke-width="3" />
+              <path d="M16 40 L16 26 L32 16 L48 26 L48 40" fill="none" stroke="#7bd7ff" stroke-width="3" />
+              <circle cx="32" cy="34" r="6" fill="#ff8bd1" />
+            </svg>
+          </div>
+          <h2 id="communityTitle">Community</h2>
+          <p id="communityDescription">
+            Modern toolbox for community building and opensource technology innovation
+          </p>
+          <div class="activity-dots">
+            <div class="dot"></div>
+            <div class="dot"></div>
+            <div class="dot"></div>
+            <span class="activity-text">2.4k active members</span>
+          </div>
+        </article>
+
+        <article class="section-card" id="eventsCard">
+          <div class="icon-wrapper" aria-hidden="true">
+            <svg viewBox="0 0 64 64" role="img">
+              <rect x="12" y="16" width="40" height="32" rx="6" ry="6" fill="#0d071b" stroke="#7bd7ff" stroke-width="3" />
+              <path d="M18 26 H46" stroke="#ff8bd1" stroke-width="3" />
+              <rect x="22" y="32" width="8" height="8" fill="#7bd7ff" />
+              <rect x="34" y="32" width="8" height="8" fill="#ff8bd1" />
+            </svg>
+          </div>
+          <h2 id="eventsTitle">Events</h2>
+          <p id="eventsDescription">Scale your teams with collaborative meetups and tech conferences</p>
+          <div class="activity-dots">
+            <div class="dot"></div>
+            <div class="dot"></div>
+            <div class="dot"></div>
+            <span class="activity-text">Adaptive agenda for your squads</span>
+          </div>
+        </article>
+
+        <article class="section-card" id="projectsCard">
+          <div class="icon-wrapper" aria-hidden="true">
+            <svg viewBox="0 0 64 64" role="img">
+              <rect x="12" y="14" width="40" height="36" rx="8" ry="8" fill="#0d071b" stroke="#caffbf" stroke-width="3" />
+              <path d="M20 40 L32 22 L44 40 Z" fill="#7bd7ff" opacity="0.8" />
+              <circle cx="32" cy="34" r="4" fill="#ff8bd1" />
+            </svg>
+          </div>
+          <h2 id="projectsTitle">Projects</h2>
+          <p id="projectsDescription">Innovation hub for your opensource technology projects</p>
+          <div class="activity-dots">
+            <div class="dot"></div>
+            <div class="dot"></div>
+            <div class="dot"></div>
+            <span class="activity-text">Fresh collaborations weekly</span>
+          </div>
+        </article>
+      </main>
+    </div>
+
+    <div class="community-view" id="communityView" style="display: none;">
+      <div class="community-header">
+        <button class="back-button" id="backButton">⬅ Back to overview</button>
+        <div class="view-meta">
+          <span class="badge">Community campus</span>
+          <span class="activity-text">Live rooms and quests</span>
+        </div>
+      </div>
+      <div class="village-container">
+        <div class="village-landscape">
+          <div class="village-sky"></div>
+          <div class="village-ground"></div>
+          <div class="village-buildings">
+            <div class="building hall">Hall</div>
+            <div class="building lab">Builder Lab</div>
+            <div class="building arcade">Arcade</div>
+          </div>
+          <div class="village-paths">
+            <div class="path"></div>
+            <div class="path"></div>
+            <div class="path"></div>
+          </div>
+          <div class="inhabitants-layer" id="inhabitantsLayer"></div>
+        </div>
+        <aside class="community-stats">
+          <h3>Community stats</h3>
+          <div class="stat-grid">
+            <div class="stat-item">
+              <div class="stat-icon">👥</div>
+              <div class="stat-info">
+                <div class="stat-value" id="totalMembers">0</div>
+                <div class="stat-label">Members online</div>
+              </div>
+            </div>
+            <div class="stat-item">
+              <div class="stat-icon">⭐</div>
+              <div class="stat-info">
+                <div class="stat-value" id="totalXP">0</div>
+                <div class="stat-label">Total XP</div>
+              </div>
+            </div>
+            <div class="stat-item">
+              <div class="stat-icon">🏆</div>
+              <div class="stat-info">
+                <div class="stat-value" id="totalQuests">0</div>
+                <div class="stat-label">Quests Completed</div>
+              </div>
+            </div>
+            <div class="stat-item">
+              <div class="stat-icon">🚀</div>
+              <div class="stat-info">
+                <div class="stat-value" id="totalProjects">0</div>
+                <div class="stat-label">Active Projects</div>
+              </div>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </div>
+  {/body}
+{/include}

--- a/quarkus-app/src/main/resources/templates/layouts/main.qute.html
+++ b/quarkus-app/src/main/resources/templates/layouts/main.qute.html
@@ -1,0 +1,220 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{#insert title}HomeDir - Community Platform{/insert}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Courier+Prime&display=swap"
+    rel="stylesheet" />
+  <link rel="icon" href="/favicon.ico" />
+  <link rel="stylesheet" href="/css/homedir-pixel.css" />
+</head>
+<body>
+  <div class="floating-shapes">
+    <div class="shape shape-1">
+      <svg viewBox="0 0 120 120" aria-hidden="true">
+        <circle cx="60" cy="60" r="52" fill="url(#grad1)" opacity="0.12" />
+        <defs>
+          <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#ff8bd1" />
+            <stop offset="100%" stop-color="#7bd7ff" />
+          </linearGradient>
+        </defs>
+      </svg>
+    </div>
+    <div class="shape shape-2">
+      <svg viewBox="0 0 160 160" aria-hidden="true">
+        <rect x="18" y="18" width="124" height="124" rx="28" ry="28" fill="#7bd7ff" opacity="0.1" />
+        <rect x="36" y="36" width="88" height="88" rx="22" ry="22" fill="#ff8bd1" opacity="0.16" />
+      </svg>
+    </div>
+    <div class="shape shape-3">
+      <svg viewBox="0 0 140 140" aria-hidden="true">
+        <polygon points="70,8 130,52 106,132 34,132 10,52" fill="#caffbf" opacity="0.12" />
+        <circle cx="70" cy="78" r="24" fill="#7bd7ff" opacity="0.18" />
+      </svg>
+    </div>
+    <div class="shape shape-4">
+      <svg viewBox="0 0 140 140" aria-hidden="true">
+        <path
+          d="M20,40 C30,12 110,6 120,40 C128,70 112,118 72,126 C40,132 12,94 20,40 Z"
+          fill="#ff8bd1"
+          opacity="0.1" />
+        <path d="M44,54 C46,32 96,30 96,56 C96,82 64,78 64,100" stroke="#7bd7ff" stroke-width="6" opacity="0.22" />
+      </svg>
+    </div>
+  </div>
+
+  <nav class="top-nav">
+    <div class="inner">
+      <div class="logo">
+        <div class="logo-icon" aria-hidden="true">
+          <svg viewBox="0 0 64 64" role="img" aria-label="HomeDir logo">
+            <rect x="6" y="6" width="52" height="52" rx="12" fill="#0d071b" stroke="#ff8bd1" stroke-width="3" />
+            <path d="M20 44 L20 22 L32 14 L44 22 L44 44" fill="none" stroke="#7bd7ff" stroke-width="3" />
+            <rect x="28" y="32" width="8" height="12" fill="#ff8bd1" />
+          </svg>
+        </div>
+        <div class="logo-text">
+          <span id="navPlatformName">HomeDir</span>
+          <span class="logo-subtitle" id="navTagline">by OpenSourceSantiago</span>
+        </div>
+      </div>
+      <div class="links">
+        <a href="/comunidad" class="nav-link">Community</a>
+        <a href="/eventos" class="nav-link">Events</a>
+        <a href="/proyectos" class="nav-link">Projects</a>
+        <a href="/notifications/center" class="nav-link">Notifications</a>
+      </div>
+      <div class="nav-actions">
+        <button class="login-btn-nav" id="openLoginBtn">Login</button>
+        <div class="user-menu" id="userMenuNav">
+          <div class="user-avatar" id="navAvatar" aria-hidden="true">HD</div>
+          <div class="user-dropdown">
+            <div class="user-name" id="navUserName">Logged in</div>
+            <div class="user-actions">
+              <a href="/profile" class="btn">Profile</a>
+              <a href="/logout" class="btn" id="logoutBtn">Logout</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <div class="app-container">
+    {#insert body}{/insert}
+  </div>
+
+  <footer class="character-sheet">
+    <div class="character-container">
+      <div class="novice-warning" id="noviceWarning">
+        You're playing as a NOVICE guest! Login to save your progress and unlock your full character potential!
+      </div>
+      <div class="character-header">
+        <div class="character-title">
+          <h3 id="characterName">NOVICE GUEST</h3>
+          <span class="character-class" id="characterClass">VISITOR</span>
+        </div>
+        <div class="character-level" id="characterLevel">LEVEL 1</div>
+      </div>
+      <div class="character-main">
+        <div class="character-vitals">
+          <div class="vital-bar">
+            <div class="vital-label"><span class="vital-name">❤️ HP (HEALTH)</span> <span class="vital-value" id="hpValue">10 / 100</span></div>
+            <div class="vital-progress">
+              <div class="vital-fill hp-fill" id="hpBar" style="width: 10%"></div>
+            </div>
+          </div>
+          <div class="vital-bar">
+            <div class="vital-label"><span class="vital-name">⚡ SP (SKILL)</span> <span class="vital-value" id="spValue">5 / 100</span></div>
+            <div class="vital-progress">
+              <div class="vital-fill sp-fill" id="spBar" style="width: 5%"></div>
+            </div>
+          </div>
+          <div class="vital-bar">
+            <div class="vital-label"><span class="vital-name">⭐ XP (EXPERIENCE)</span> <span class="vital-value" id="xpValue">0 / 100</span></div>
+            <div class="vital-progress">
+              <div class="vital-fill xp-fill" id="xpBar" style="width: 0%"></div>
+            </div>
+          </div>
+        </div>
+        <div class="character-stats">
+          <div class="stat-box">
+            <div class="stat-icon">🎯</div>
+            <div class="stat-value" id="contributionsStat">0</div>
+            <div class="stat-label">Contributions</div>
+          </div>
+          <div class="stat-box">
+            <div class="stat-icon">🏆</div>
+            <div class="stat-value" id="questsStat">0</div>
+            <div class="stat-label">Quests</div>
+          </div>
+          <div class="stat-box">
+            <div class="stat-icon">📅</div>
+            <div class="stat-value" id="eventsStat">0</div>
+            <div class="stat-label">Events</div>
+          </div>
+          <div class="stat-box">
+            <div class="stat-icon">🚀</div>
+            <div class="stat-value" id="projectsStat">0</div>
+            <div class="stat-label">Projects</div>
+          </div>
+          <div class="stat-box">
+            <div class="stat-icon">🤝</div>
+            <div class="stat-value" id="connectionsStat">0</div>
+            <div class="stat-label">Connections</div>
+          </div>
+          <div class="stat-box">
+            <div class="stat-icon">💎</div>
+            <div class="stat-value" id="experienceStat">0</div>
+            <div class="stat-label">Total XP</div>
+          </div>
+        </div>
+        <div class="character-equipment">
+          <div class="equipment-header">
+            <h4>🎒 EQUIPMENT</h4>
+          </div>
+          <div class="equipment-grid" id="equipmentGrid">
+            <div class="equipment-slot empty" data-slot="0">
+              <div class="equipment-tooltip">EMPTY SLOT</div>
+            </div>
+            <div class="equipment-slot empty" data-slot="1">
+              <div class="equipment-tooltip">EMPTY SLOT</div>
+            </div>
+            <div class="equipment-slot empty" data-slot="2">
+              <div class="equipment-tooltip">EMPTY SLOT</div>
+            </div>
+            <div class="equipment-slot empty" data-slot="3">
+              <div class="equipment-tooltip">EMPTY SLOT</div>
+            </div>
+            <div class="equipment-slot empty" data-slot="4">
+              <div class="equipment-tooltip">EMPTY SLOT</div>
+            </div>
+            <div class="equipment-slot empty" data-slot="5">
+              <div class="equipment-tooltip">EMPTY SLOT</div>
+            </div>
+          </div>
+          <div class="equipment-count">0 / 6 ITEMS</div>
+        </div>
+      </div>
+      <div class="character-actions" id="characterActions">
+        <button class="character-action-btn" id="loginCharacterBtn"><span>🎮 LOGIN TO SAVE CHARACTER</span></button>
+        <button class="character-action-btn" id="logoutCharacterBtn" style="display: none;"><span>🚪 LOGOUT</span></button>
+      </div>
+    </div>
+  </footer>
+
+  <div class="login-modal" id="loginModal" role="dialog" aria-modal="true" aria-labelledby="loginTitle">
+    <div class="login-card">
+      <button class="close-modal" id="closeLoginBtn" aria-label="Close login">×</button>
+      <h2 id="loginTitle">Welcome to HomeDir</h2>
+      <p class="modal-subtitle">Login to manage your profile and data</p>
+      <div class="login-buttons">
+        <button class="login-btn" id="googleLogin">
+          <svg viewbox="0 0 24 24" fill="currentColor">
+            <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.743.28-8.09z" fill="#4285F4" />
+            <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+            <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+            <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+          </svg>
+          Continue with Google
+        </button>
+        <button class="login-btn" id="githubLogin">
+          <svg viewbox="0 0 24 24" fill="currentColor">
+            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033 3-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+          </svg>
+          Continue with GitHub
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+  <script src="/js/homedir.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a reusable Qute layout with shared navigation, character-sheet footer, login modal, and external pixel CSS
- create the new homepage template that plugs into the shared layout with updated hero cards and community view
- simplify the root resource to render the new index template and point to static assets

## Testing
- `./mvnw test` *(fails: network is unreachable while downloading Maven wrapper dependencies)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eedc98f3c8333b0a21edee1d2a766)