### PR TITLE
Add global Homedir layout and public page templates

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -16,7 +16,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
 
-@Path("/")
+@Path("/legacy-home")
 public class HomeResource {
 
   @Inject UsageMetricsService metrics;
@@ -31,7 +31,8 @@ public class HomeResource {
   public TemplateInstance home(
       @jakarta.ws.rs.core.Context HttpHeaders headers,
       @jakarta.ws.rs.core.Context RoutingContext context) {
-    metrics.recordPageView("/", headers, context);
+    // TODO: Legacy landing page kept for reference; main public routes moved to PublicPagesResource.
+    metrics.recordPageView("/legacy-home", headers, context);
     LandingViewModel viewModel = landingService.buildViewModel();
     return index
         .data("vm", viewModel)

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
@@ -1,0 +1,45 @@
+package com.scanales.eventflow.public_;
+
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/")
+@Produces(MediaType.TEXT_HTML)
+public class PublicPagesResource {
+
+  @Inject Template home;
+
+  @Inject Template community;
+
+  @Inject Template projects;
+
+  @Inject Template events;
+
+  @GET
+  public TemplateInstance home() {
+    return home.data("pageTitle", "Home");
+  }
+
+  @GET
+  @Path("/community")
+  public TemplateInstance community() {
+    return community.data("pageTitle", "Comunidad");
+  }
+
+  @GET
+  @Path("/projects")
+  public TemplateInstance projects() {
+    return projects.data("pageTitle", "Proyectos");
+  }
+
+  @GET
+  @Path("/events")
+  public TemplateInstance events() {
+    return events.data("pageTitle", "Eventos");
+  }
+}

--- a/quarkus-app/src/main/resources/templates/community.qute.html
+++ b/quarkus-app/src/main/resources/templates/community.qute.html
@@ -1,0 +1,12 @@
+{#include layouts/homedir-layout}
+  {#title}Comunidad{/title}
+
+  {#body}
+    <section class="page-header">
+      <h1 class="page-title">Comunidad OSS Santiago</h1>
+      <p class="page-subtitle">
+        Aquí irá la integración con GitHub y las estadísticas de participación de la comunidad.
+      </p>
+    </section>
+  {/body}
+{/include}

--- a/quarkus-app/src/main/resources/templates/events.qute.html
+++ b/quarkus-app/src/main/resources/templates/events.qute.html
@@ -1,0 +1,12 @@
+{#include layouts/homedir-layout}
+  {#title}Eventos{/title}
+
+  {#body}
+    <section class="page-header">
+      <h1 class="page-title">Eventos OSS Santiago</h1>
+      <p class="page-subtitle">
+        Aquí se listarán meetups, charlas y conferencias, tanto activas como pasadas.
+      </p>
+    </section>
+  {/body}
+{/include}

--- a/quarkus-app/src/main/resources/templates/home.qute.html
+++ b/quarkus-app/src/main/resources/templates/home.qute.html
@@ -1,0 +1,29 @@
+{#include layouts/homedir-layout}
+  {#title}HomeDir{/title}
+
+  {#body}
+    <section class="page-header">
+      <h1 class="page-title">HomeDir</h1>
+      <p class="page-subtitle">
+        by OpenSourceSantiago · Plataforma comunitaria para comunidades, proyectos y eventos.
+      </p>
+    </section>
+
+    <section class="page-grid">
+      <a href="/community" class="section-card">
+        <h2>Comunidad</h2>
+        <p>Conoce a las personas y la actividad de la organización OSS Santiago.</p>
+      </a>
+
+      <a href="/projects" class="section-card">
+        <h2>Proyectos</h2>
+        <p>Explora los repositorios y la colaboración dentro de OSS Santiago.</p>
+      </a>
+
+      <a href="/events" class="section-card">
+        <h2>Eventos</h2>
+        <p>Revisa meetups, charlas y conferencias activas y pasadas.</p>
+      </a>
+    </section>
+  {/body}
+{/include}

--- a/quarkus-app/src/main/resources/templates/layouts/homedir-layout.qute.html
+++ b/quarkus-app/src/main/resources/templates/layouts/homedir-layout.qute.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>HomeDir - {#insert title}HomeDir{/insert}</title>
+
+  <!-- Fuente principal (Press Start 2P) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+
+  <!-- CSS principal homogenizado (se asumirá /css/homedir.css a usar en iteraciones siguientes) -->
+  <link rel="stylesheet" href="/css/homedir.css">
+</head>
+<body>
+  <!-- HEADER / NAVBAR -->
+  {#include layouts/partials/navbar /}
+
+  <!-- CONTENIDO PRINCIPAL -->
+  <main class="page-container">
+    {#insert body}{/insert}
+  </main>
+
+  <!-- FOOTER ESTÁNDAR -->
+  {#include layouts/partials/footer /}
+</body>
+</html>

--- a/quarkus-app/src/main/resources/templates/layouts/partials/footer.qute.html
+++ b/quarkus-app/src/main/resources/templates/layouts/partials/footer.qute.html
@@ -1,0 +1,10 @@
+<footer class="site-footer">
+  <div class="footer-inner">
+    <p class="footer-text">
+      HomeDir · OSSantiago · Community Platform
+    </p>
+    <p class="footer-subtext">
+      {#insert footer-extra}Construyendo comunidades y proyectos Open Source{/insert}
+    </p>
+  </div>
+</footer>

--- a/quarkus-app/src/main/resources/templates/layouts/partials/navbar.qute.html
+++ b/quarkus-app/src/main/resources/templates/layouts/partials/navbar.qute.html
@@ -1,0 +1,26 @@
+<header class="top-nav">
+  <div class="logo">
+    <a href="/" class="logo-link">
+      <div class="logo-icon">
+        <!-- Puedes usar aquí la versión simplificada del SVG de la casa/logotipo -->
+        <span>🏠</span>
+      </div>
+      <div class="logo-text">
+        <span>HomeDir</span>
+        <span class="logo-subtitle">by OpenSourceSantiago</span>
+      </div>
+    </a>
+  </div>
+
+  <nav class="nav-actions">
+    <a href="/community" class="nav-link">Comunidad</a>
+    <a href="/projects" class="nav-link">Proyectos</a>
+    <a href="/events" class="nav-link">Eventos</a>
+
+    <!-- Área de usuario / Login (placeholder por ahora) -->
+    <div class="nav-user">
+      <!-- En iteraciones futuras se reemplaza por estado real de sesión -->
+      <a href="/login" class="login-btn-nav">Login</a>
+    </div>
+  </nav>
+</header>

--- a/quarkus-app/src/main/resources/templates/projects.qute.html
+++ b/quarkus-app/src/main/resources/templates/projects.qute.html
@@ -1,0 +1,12 @@
+{#include layouts/homedir-layout}
+  {#title}Proyectos{/title}
+
+  {#body}
+    <section class="page-header">
+      <h1 class="page-title">Proyectos OSS Santiago</h1>
+      <p class="page-subtitle">
+        Aquí se mostrarán los repositorios destacados y la actividad de colaboración de la comunidad.
+      </p>
+    </section>
+  {/body}
+{/include}


### PR DESCRIPTION
## Summary
- introduce shared Homedir layout with navbar and footer partials
- add public Qute templates for home, community, projects, and events pages using the global layout
- create PublicPagesResource for the main routes and move the legacy landing route to a non-conflicting path

## Testing
- `./mvnw test -q` *(fails: unable to download dependencies due to network restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69301cb186dc833394f8c97a635c8084)