### PR TITLE
Implement community page structure with mock data

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
@@ -1,5 +1,6 @@
 package com.scanales.eventflow.public_;
 
+import com.scanales.eventflow.public_.view.CommunityViewModel;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
 import jakarta.inject.Inject;
@@ -22,24 +23,28 @@ public class PublicPagesResource {
 
   @GET
   public TemplateInstance home() {
-    return home.data("pageTitle", "Home");
+    return home.data("pageTitle", "Home").data("activePage", "home");
   }
 
   @GET
   @Path("/community")
   public TemplateInstance community() {
-    return community.data("pageTitle", "Comunidad");
+    CommunityViewModel vm = CommunityViewModel.mock();
+    return community
+        .data("pageTitle", "Comunidad")
+        .data("vm", vm)
+        .data("activePage", "community");
   }
 
   @GET
   @Path("/projects")
   public TemplateInstance projects() {
-    return projects.data("pageTitle", "Proyectos");
+    return projects.data("pageTitle", "Proyectos").data("activePage", "projects");
   }
 
   @GET
   @Path("/events")
   public TemplateInstance events() {
-    return events.data("pageTitle", "Eventos");
+    return events.data("pageTitle", "Eventos").data("activePage", "events");
   }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/view/CommunityViewModel.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/view/CommunityViewModel.java
@@ -1,0 +1,71 @@
+package com.scanales.eventflow.public_.view;
+
+import java.util.List;
+
+public class CommunityViewModel {
+
+  public String orgName;
+  public String orgDescription;
+  public long totalMembers;
+  public long totalContributors;
+  public long totalCommits;
+  public long totalPullRequests;
+  public long totalIssues;
+  public List<TopContributor> topContributors;
+  public List<CommunityActivity> recentActivity;
+
+  public static CommunityViewModel mock() {
+    CommunityViewModel vm = new CommunityViewModel();
+    vm.orgName = "OSS Santiago";
+    vm.orgDescription = "Open Source community building tools, platforms and events.";
+    vm.totalMembers = 2400;
+    vm.totalContributors = 42;
+    vm.totalCommits = 12345;
+    vm.totalPullRequests = 320;
+    vm.totalIssues = 180;
+
+    vm.topContributors =
+        List.of(
+            new TopContributor("scanalesespinoza", 120, 15, 8),
+            new TopContributor("oss-member-1", 80, 10, 4),
+            new TopContributor("oss-member-2", 60, 7, 2),
+            new TopContributor("oss-member-3", 50, 5, 3),
+            new TopContributor("oss-member-4", 40, 3, 1));
+
+    vm.recentActivity =
+        List.of(
+            new CommunityActivity("scanalesespinoza", "opened pull request", "homedir", "2 hours ago"),
+            new CommunityActivity("oss-member-1", "created issue", "eventflow", "5 hours ago"),
+            new CommunityActivity("oss-member-2", "pushed commits", "arkit8s", "1 day ago"));
+
+    return vm;
+  }
+
+  public static class TopContributor {
+    public String username;
+    public int commits;
+    public int pullRequests;
+    public int issues;
+
+    public TopContributor(String username, int commits, int pullRequests, int issues) {
+      this.username = username;
+      this.commits = commits;
+      this.pullRequests = pullRequests;
+      this.issues = issues;
+    }
+  }
+
+  public static class CommunityActivity {
+    public String username;
+    public String action;
+    public String repo;
+    public String when;
+
+    public CommunityActivity(String username, String action, String repo, String when) {
+      this.username = username;
+      this.action = action;
+      this.repo = repo;
+      this.when = when;
+    }
+  }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -2525,6 +2525,230 @@ footer {
     flex-wrap: wrap;
 }
 
+/* Comunidad */
+.hd-main {
+    width: 100%;
+}
+
+.hd-page--community {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.hd-section--hero {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.16), rgba(34, 211, 238, 0.16));
+}
+
+.hd-section--alt {
+    background: rgba(15, 23, 42, 0.5);
+    border-color: rgba(255, 255, 255, 0.08);
+}
+
+.hd-container {
+    width: 100%;
+    max-width: 1120px;
+    margin-inline: auto;
+    padding-inline: clamp(1rem, 3vw, 1.75rem);
+}
+
+.hd-grid {
+    display: grid;
+    gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.hd-grid--2cols {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.hd-grid--3cols {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.hd-grid--4cols {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.hd-grid--stats {
+    align-items: stretch;
+}
+
+.hd-grid--cards {
+    align-items: start;
+}
+
+.hd-hero-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.hd-eyebrow {
+    margin: 0;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    font-size: 0.9rem;
+}
+
+.hd-hero-panel {
+    height: 100%;
+}
+
+.hd-hero-panel--pixel {
+    background: linear-gradient(145deg, rgba(37, 99, 235, 0.2), rgba(15, 23, 42, 0.75));
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-xl);
+    padding: clamp(1rem, 2vw, 1.5rem);
+    box-shadow: var(--shadow-md);
+}
+
+.hd-character-card {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-lg);
+    padding: clamp(1rem, 2vw, 1.5rem);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    box-shadow: var(--shadow-sm);
+}
+
+.hd-character-title {
+    margin: 0;
+    font-size: 1.15rem;
+}
+
+.hd-character-username {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+.hd-character-username span {
+    color: var(--color-light);
+}
+
+.hd-character-stats {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    color: var(--color-light);
+}
+
+.hd-character-stats span:first-child {
+    color: var(--color-muted);
+}
+
+.hd-btn--full {
+    width: 100%;
+}
+
+.hd-section-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-bottom: 1rem;
+}
+
+.hd-section-subtitle {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+.hd-stat-card {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: 1rem;
+    box-shadow: var(--shadow-sm);
+}
+
+.hd-stat-label {
+    margin: 0 0 0.5rem 0;
+    color: var(--color-muted);
+}
+
+.hd-stat-value {
+    margin: 0;
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: var(--color-light);
+}
+
+.hd-card--contributor {
+    gap: 0.75rem;
+}
+
+.hd-card-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    color: var(--color-light);
+}
+
+.hd-card-list li {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.hd-card-list span:first-child {
+    color: var(--color-muted);
+}
+
+.hd-list--activity {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.hd-activity-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.hd-activity-main {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.hd-activity-user {
+    color: var(--color-light);
+    font-weight: 700;
+}
+
+.hd-activity-action {
+    color: var(--color-muted);
+}
+
+.hd-activity-repo {
+    color: var(--color-accent);
+}
+
+.hd-activity-when {
+    color: var(--color-muted);
+    font-size: 0.95rem;
+}
+
+.hd-nav-link--active {
+    color: var(--color-light);
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 1px rgba(34, 211, 238, 0.3);
+}
+
 @media (max-width: 768px) {
     .hd-hero-inner {
         grid-template-columns: 1fr;

--- a/quarkus-app/src/main/resources/templates/community.qute.html
+++ b/quarkus-app/src/main/resources/templates/community.qute.html
@@ -1,14 +1,103 @@
-{#include layouts/main}
-  {#title}Comunidad{/title}
+{#include layout/main}
+  {#title}Community – HomeDir{/title}
+  {#body}
+    <div class="hd-page hd-page--community">
+      <section class="hd-section hd-section--hero">
+        <div class="hd-container hd-grid hd-grid--2cols">
+          <div class="hd-hero-text">
+            <p class="hd-eyebrow">Community</p>
+            <h1 class="hd-hero-title">{vm.orgName}</h1>
+            <p class="hd-hero-subtitle">{vm.orgDescription}</p>
+          </div>
+          <div class="hd-hero-panel hd-hero-panel--pixel">
+            <div class="hd-character-card">
+              <h2 class="hd-character-title">Tu perfil GitHub</h2>
+              <p class="hd-character-username">user: <span>GitHub user (placeholder)</span></p>
+              <ul class="hd-character-stats">
+                <li><span>Repos:</span> <span>—</span></li>
+                <li><span>Stars:</span> <span>—</span></li>
+                <li><span>Followers:</span> <span>—</span></li>
+              </ul>
+              <button class="hd-btn hd-btn-primary hd-btn--full">
+                Conectar con GitHub (placeholder)
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
 
-  {#content}
-  <header class="section-header">
-    <h1>Comunidad</h1>
-    <p class="section-subtitle">Actividad y perfiles de la organización OSS Santiago</p>
-  </header>
+      <section class="hd-section">
+        <div class="hd-container">
+          <div class="hd-grid hd-grid--4cols hd-grid--stats">
+            <article class="hd-stat-card">
+              <p class="hd-stat-label">Miembros estimados</p>
+              <p class="hd-stat-value">{vm.totalMembers}</p>
+            </article>
+            <article class="hd-stat-card">
+              <p class="hd-stat-label">Contribuidores</p>
+              <p class="hd-stat-value">{vm.totalContributors}</p>
+            </article>
+            <article class="hd-stat-card">
+              <p class="hd-stat-label">Commits</p>
+              <p class="hd-stat-value">{vm.totalCommits}</p>
+            </article>
+            <article class="hd-stat-card">
+              <p class="hd-stat-label">PRs &amp; Issues</p>
+              <p class="hd-stat-value">
+                {vm.totalPullRequests} PR / {vm.totalIssues} Issues
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
 
-  <section class="section-body">
-    <p>Próxima iteración: conectar GitHub y datos de la comunidad.</p>
-  </section>
-  {/content}
+      <section class="hd-section">
+        <div class="hd-container">
+          <header class="hd-section-header">
+            <h2 class="hd-section-title">Top contributors</h2>
+            <p class="hd-section-subtitle">
+              Principales colaborador@s en los repositorios de OSS Santiago.
+            </p>
+          </header>
+
+          <div class="hd-grid hd-grid--3cols hd-grid--cards">
+            {#for c in vm.topContributors}
+            <article class="hd-card hd-card--contributor">
+              <h3 class="hd-card-title">@{c.username}</h3>
+              <ul class="hd-card-list">
+                <li><span>Commits:</span> <span>{c.commits}</span></li>
+                <li><span>PRs:</span> <span>{c.pullRequests}</span></li>
+                <li><span>Issues:</span> <span>{c.issues}</span></li>
+              </ul>
+            </article>
+            {/for}
+          </div>
+        </div>
+      </section>
+
+      <section class="hd-section hd-section--alt">
+        <div class="hd-container">
+          <header class="hd-section-header">
+            <h2 class="hd-section-title">Actividad reciente</h2>
+            <p class="hd-section-subtitle">
+              Últimos movimientos en los repos de la comunidad (datos mock por ahora).
+            </p>
+          </header>
+
+          <div class="hd-list hd-list--activity">
+            {#for a in vm.recentActivity}
+            <article class="hd-activity-item">
+              <div class="hd-activity-main">
+                <span class="hd-activity-user">@{a.username}</span>
+                <span class="hd-activity-action">{a.action}</span>
+                <span class="hd-activity-repo">{a.repo}</span>
+              </div>
+              <span class="hd-activity-when">{a.when}</span>
+            </article>
+            {/for}
+          </div>
+        </div>
+      </section>
+    </div>
+  {/body}
 {/include}

--- a/quarkus-app/src/main/resources/templates/fragments/nav.html
+++ b/quarkus-app/src/main/resources/templates/fragments/nav.html
@@ -1,3 +1,4 @@
+{@ String activePage = "" }
 <nav class="hd-nav" aria-label="Principal">
   <div class="hd-nav-inner hd-nav-bar">
     <a href="/" class="hd-nav-brand">Homedir</a>
@@ -10,12 +11,12 @@
       <span aria-hidden="true">☰</span>
     </button>
     <div class="hd-nav-menu" id="primary-nav" data-hd-nav-menu>
-      <a href="/" class="hd-nav-link">Inicio</a>
-      <a href="/eventos" class="hd-nav-link">Eventos</a>
-      <a href="/comunidad" class="hd-nav-link">Comunidad</a>
-      <a href="/notifications/center" class="hd-nav-link">Notificaciones</a>
-      <a href="/docs" class="hd-nav-link">Docs</a>
-      <a href="/contacto" class="hd-nav-link">Contacto</a>
+      <a href="/" class="hd-nav-link {#if activePage == 'home'}hd-nav-link--active{/if}">Inicio</a>
+      <a href="/events" class="hd-nav-link {#if activePage == 'events'}hd-nav-link--active{/if}">Eventos</a>
+      <a href="/community" class="hd-nav-link {#if activePage == 'community'}hd-nav-link--active{/if}">Comunidad</a>
+      <a href="/notifications/center" class="hd-nav-link {#if activePage == 'notifications'}hd-nav-link--active{/if}">Notificaciones</a>
+      <a href="/docs" class="hd-nav-link {#if activePage == 'docs'}hd-nav-link--active{/if}">Docs</a>
+      <a href="/contacto" class="hd-nav-link {#if activePage == 'contact'}hd-nav-link--active{/if}">Contacto</a>
     </div>
     <div class="hd-nav-actions">
       <a href="/ingresar" class="hd-btn hd-btn-primary">Ingresar</a>

--- a/quarkus-app/src/main/resources/templates/layout/main.html
+++ b/quarkus-app/src/main/resources/templates/layout/main.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 {@ boolean noNav = false}
 {@ boolean noFooter = false}
+{@ String activePage = ""}
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
@@ -18,7 +19,7 @@
 </head>
 <body class="hd-body">
     {#if noNav != true}
-        {#include fragments/nav.html/}
+        {#include fragments/nav.html activePage=activePage/}
     {/if}
     <main id="main-content" class="hd-main" role="main">
         {#insert body}


### PR DESCRIPTION
## Summary
- add a CommunityViewModel with mock community metrics and activity for the Community page
- render the community template via PublicPagesResource using the layout with active navigation highlighting
- extend shared styles for community cards, stats, activity list, and add active nav state

## Testing
- mvn -f quarkus-app/pom.xml -DskipITs test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69302fb23c74833385f2aa0f72e71710)