### PR TITLE
Add mock projects page

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
@@ -1,6 +1,7 @@
 package com.scanales.eventflow.public_;
 
 import com.scanales.eventflow.public_.view.CommunityViewModel;
+import com.scanales.eventflow.public_.view.ProjectsViewModel;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
 import jakarta.inject.Inject;
@@ -39,7 +40,11 @@ public class PublicPagesResource {
   @GET
   @Path("/projects")
   public TemplateInstance projects() {
-    return projects.data("pageTitle", "Proyectos").data("activePage", "projects");
+    ProjectsViewModel vm = ProjectsViewModel.mock();
+    return projects
+        .data("pageTitle", "Proyectos")
+        .data("vm", vm)
+        .data("activePage", "projects");
   }
 
   @GET

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/view/ProjectsViewModel.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/view/ProjectsViewModel.java
@@ -1,0 +1,123 @@
+package com.scanales.eventflow.public_.view;
+
+import java.util.List;
+
+public class ProjectsViewModel {
+
+  public String orgName;
+  public String orgDescription;
+
+  public long totalRepositories;
+  public long activeRepositories;
+  public long totalStars;
+  public long totalContributors;
+
+  public List<ProjectSummary> featuredProjects;
+
+  public static ProjectsViewModel mock() {
+    ProjectsViewModel vm = new ProjectsViewModel();
+    vm.orgName = "OSS Santiago";
+    vm.orgDescription = "Organización OSS para herramientas de comunidad, eventos y plataformas.";
+
+    vm.totalRepositories = 12;
+    vm.activeRepositories = 7;
+    vm.totalStars = 420;
+    vm.totalContributors = 25;
+
+    vm.featuredProjects =
+        List.of(
+            new ProjectSummary(
+                "homedir",
+                "Plataforma modular para comunidades y eventos, construida sobre Quarkus.",
+                "Java",
+                120,
+                24,
+                10,
+                "Hace 2 horas",
+                "https://github.com/os-santiago/homedir",
+                98,
+                8),
+            new ProjectSummary(
+                "eventflow",
+                "Módulo de gestión de eventos y agenda para la comunidad.",
+                "Java",
+                80,
+                12,
+                5,
+                "Ayer",
+                "https://github.com/os-santiago/eventflow",
+                88,
+                6),
+            new ProjectSummary(
+                "oss-site",
+                "Sitio web público de OSS Santiago con contenidos y enlaces.",
+                "TypeScript",
+                60,
+                10,
+                3,
+                "Hace 3 días",
+                "https://github.com/os-santiago/oss-site",
+                70,
+                4),
+            new ProjectSummary(
+                "community-tools",
+                "Utilidades y scripts para automatizar flujos de la comunidad.",
+                "Python",
+                40,
+                6,
+                2,
+                "Hace 1 semana",
+                "https://github.com/os-santiago/community-tools",
+                64,
+                3),
+            new ProjectSummary(
+                "oss-playground",
+                "Repositorio de experimentos, demos y pruebas de concepto.",
+                "Varios",
+                30,
+                5,
+                1,
+                "Hace 2 semanas",
+                "https://github.com/os-santiago/oss-playground",
+                50,
+                2));
+
+    return vm;
+  }
+
+  public static class ProjectSummary {
+    public String name;
+    public String description;
+    public String primaryLanguage;
+    public int stars;
+    public int forks;
+    public int openIssues;
+    public String lastActivity;
+    public String url;
+    public int activityScore;
+    public int activeContributors;
+
+    public ProjectSummary(
+        String name,
+        String description,
+        String primaryLanguage,
+        int stars,
+        int forks,
+        int openIssues,
+        String lastActivity,
+        String url,
+        int activityScore,
+        int activeContributors) {
+      this.name = name;
+      this.description = description;
+      this.primaryLanguage = primaryLanguage;
+      this.stars = stars;
+      this.forks = forks;
+      this.openIssues = openIssues;
+      this.lastActivity = lastActivity;
+      this.url = url;
+      this.activityScore = activityScore;
+      this.activeContributors = activeContributors;
+    }
+  }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -2595,6 +2595,45 @@ footer {
     height: 100%;
 }
 
+.hd-hero-panel--projects {
+    background: linear-gradient(150deg, rgba(34, 211, 238, 0.16), rgba(37, 99, 235, 0.22));
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-xl);
+    padding: clamp(1rem, 2vw, 1.5rem);
+    box-shadow: var(--shadow-md);
+}
+
+.hd-panel-title {
+    margin: 0 0 0.75rem 0;
+    font-size: 1.1rem;
+    color: var(--color-light);
+}
+
+.hd-panel-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.hd-panel-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--color-light);
+}
+
+.hd-panel-list li span:first-child {
+    color: var(--color-muted);
+}
+
 .hd-hero-panel--pixel {
     background: linear-gradient(145deg, rgba(37, 99, 235, 0.2), rgba(15, 23, 42, 0.75));
     border: 1px solid var(--color-border);
@@ -2700,6 +2739,131 @@ footer {
 
 .hd-card-list span:first-child {
     color: var(--color-muted);
+}
+
+.hd-card--project {
+    gap: 0.75rem;
+    height: 100%;
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+    transition: transform var(--motion-fast) var(--ease-standard), box-shadow var(--motion-fast) var(--ease-standard);
+}
+
+.hd-card--project:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+}
+
+.hd-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.hd-card-title a {
+    color: var(--color-light);
+    text-decoration: none;
+}
+
+.hd-card-title a:hover {
+    color: var(--color-accent);
+}
+
+.hd-card-description {
+    margin: 0;
+    color: var(--color-muted);
+    line-height: 1.5;
+}
+
+.hd-card-meta {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.hd-card-meta-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.65rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.hd-card-meta-row dt {
+    margin: 0;
+    color: var(--color-muted);
+    font-weight: 600;
+}
+
+.hd-card-meta-row dd {
+    margin: 0;
+    color: var(--color-light);
+    font-weight: 700;
+}
+
+.hd-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    background: rgba(255, 255, 255, 0.04);
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.hd-pill--language {
+    border-color: rgba(34, 211, 238, 0.6);
+    background: rgba(34, 211, 238, 0.12);
+    box-shadow: 0 0 0 1px rgba(34, 211, 238, 0.2);
+    color: var(--color-light);
+}
+
+.hd-card-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.hd-card-meta-text {
+    color: var(--color-muted);
+    font-size: 0.95rem;
+}
+
+.hd-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.35rem 0.65rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-border);
+    background: rgba(255, 255, 255, 0.05);
+    font-weight: 700;
+    font-size: 0.9rem;
+    color: var(--color-light);
+}
+
+.hd-badge--accent {
+    border-color: rgba(34, 211, 238, 0.6);
+    background: rgba(34, 211, 238, 0.15);
+    box-shadow: 0 0 0 1px rgba(34, 211, 238, 0.2);
+}
+
+.hd-placeholder {
+    border: 1px dashed var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: 1.5rem;
+    background: rgba(255, 255, 255, 0.03);
+    text-align: center;
+    color: var(--color-muted);
+    line-height: 1.6;
 }
 
 .hd-list--activity {

--- a/quarkus-app/src/main/resources/templates/fragments/nav.html
+++ b/quarkus-app/src/main/resources/templates/fragments/nav.html
@@ -12,6 +12,7 @@
     </button>
     <div class="hd-nav-menu" id="primary-nav" data-hd-nav-menu>
       <a href="/" class="hd-nav-link {#if activePage == 'home'}hd-nav-link--active{/if}">Inicio</a>
+      <a href="/projects" class="hd-nav-link {#if activePage == 'projects'}hd-nav-link--active{/if}">Proyectos</a>
       <a href="/events" class="hd-nav-link {#if activePage == 'events'}hd-nav-link--active{/if}">Eventos</a>
       <a href="/community" class="hd-nav-link {#if activePage == 'community'}hd-nav-link--active{/if}">Comunidad</a>
       <a href="/notifications/center" class="hd-nav-link {#if activePage == 'notifications'}hd-nav-link--active{/if}">Notificaciones</a>

--- a/quarkus-app/src/main/resources/templates/projects.qute.html
+++ b/quarkus-app/src/main/resources/templates/projects.qute.html
@@ -1,14 +1,122 @@
-{#include layouts/main}
-  {#title}Proyectos{/title}
+{#include layout/main}
+  {#title}Proyectos – HomeDir{/title}
+  {#body}
+    <main class="hd-main hd-main--page">
 
-  {#content}
-  <header class="section-header">
-    <h1>Proyectos</h1>
-    <p class="section-subtitle">Repositorios y colaboración activa de OSS Santiago</p>
-  </header>
+      <!-- Hero Proyectos -->
+      <section class="hd-section hd-section--hero">
+        <div class="hd-container hd-grid hd-grid--2cols">
+          <div class="hd-hero-text">
+            <p class="hd-eyebrow">Projects</p>
+            <h1 class="hd-hero-title">
+              Proyectos OSS Santiago
+            </h1>
+            <p class="hd-hero-subtitle">
+              {vm.orgDescription}
+            </p>
+          </div>
 
-  <section class="section-body">
-    <p>Próxima iteración: conectar el catálogo de proyectos.</p>
-  </section>
-  {/content}
+          <div class="hd-hero-panel hd-hero-panel--projects">
+            <h2 class="hd-panel-title">Resumen de la organización</h2>
+            <ul class="hd-panel-list">
+              <li>
+                <span>Total repositorios</span>
+                <span>{vm.totalRepositories}</span>
+              </li>
+              <li>
+                <span>Repos activos</span>
+                <span>{vm.activeRepositories}</span>
+              </li>
+              <li>
+                <span>Stars acumuladas</span>
+                <span>{vm.totalStars}</span>
+              </li>
+              <li>
+                <span>Contribuidores recientes</span>
+                <span>{vm.totalContributors}</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- Top 5 repos -->
+      <section class="hd-section">
+        <div class="hd-container">
+          <header class="hd-section-header">
+            <h2 class="hd-section-title">Top 5 proyectos principales</h2>
+            <p class="hd-section-subtitle">
+              Repositorios destacados por actividad, colaboración y uso dentro de la comunidad.
+            </p>
+          </header>
+
+          <div class="hd-grid hd-grid--3cols hd-grid--cards">
+            {#for p in vm.featuredProjects}
+            <article class="hd-card hd-card--project">
+              <header class="hd-card-header">
+                <h3 class="hd-card-title">
+                  <a href="{p.url}" target="_blank" rel="noopener noreferrer">
+                    {p.name}
+                  </a>
+                </h3>
+                <span class="hd-pill hd-pill--language">
+                  {p.primaryLanguage}
+                </span>
+              </header>
+
+              <p class="hd-card-description">
+                {p.description}
+              </p>
+
+              <dl class="hd-card-meta">
+                <div class="hd-card-meta-row">
+                  <dt>⭐ Stars</dt>
+                  <dd>{p.stars}</dd>
+                </div>
+                <div class="hd-card-meta-row">
+                  <dt>🍴 Forks</dt>
+                  <dd>{p.forks}</dd>
+                </div>
+                <div class="hd-card-meta-row">
+                  <dt>🐛 Issues abiertas</dt>
+                  <dd>{p.openIssues}</dd>
+                </div>
+                <div class="hd-card-meta-row">
+                  <dt>👥 Contribuidores activos</dt>
+                  <dd>{p.activeContributors}</dd>
+                </div>
+              </dl>
+
+              <div class="hd-card-footer">
+                <span class="hd-badge hd-badge--accent">
+                  Score actividad: {p.activityScore}
+                </span>
+                <span class="hd-card-meta-text">
+                  Última actividad: {p.lastActivity}
+                </span>
+              </div>
+            </article>
+            {/for}
+          </div>
+        </div>
+      </section>
+
+      <!-- Placeholder de sección futura de colaboración -->
+      <section class="hd-section hd-section--alt">
+        <div class="hd-container">
+          <header class="hd-section-header">
+            <h2 class="hd-section-title">Colaboración y contribuciones</h2>
+            <p class="hd-section-subtitle">
+              En una próxima iteración, esta sección mostrará filtros y gráficos de contribuciones por proyecto, lenguaje y periodo de tiempo.
+            </p>
+          </header>
+
+          <div class="hd-placeholder">
+            <p>Placeholder: métricas avanzadas y visualizaciones de colaboración vendrán aquí.</p>
+          </div>
+        </div>
+      </section>
+
+    </main>
+  {/body}
 {/include}


### PR DESCRIPTION
## Summary
- add projects view model with mock OSS Santiago data for top repositories
- render /projects page with organization metrics and featured repository cards using the shared layout
- update navigation and styles to highlight the Projects page and support the new card and panel elements

## Testing
- ./mvnw test *(fails: network is unreachable while downloading Maven wrapper dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930403477e083338034fadc780b9a68)