### PR TITLE
Add unified header layout for public pages

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityResource.java
@@ -79,18 +79,21 @@ public class CommunityResource {
     boolean needsGithub =
         isAuthenticated() && userProfileService.find(userId).map(p -> !p.hasGithub()).orElse(true);
 
-    return Templates.community(
-        filtered,
-        query,
-        joined,
-        missingGithub,
-        already,
-        needsGithub,
-        isAuthenticated(),
-        current,
-        communityService.countMembers(),
-        decode(prUrl),
-        prError);
+    TemplateInstance template =
+        Templates.community(
+            filtered,
+            query,
+            joined,
+            missingGithub,
+            already,
+            needsGithub,
+            isAuthenticated(),
+            current,
+            communityService.countMembers(),
+            decode(prUrl),
+            prError);
+
+    return withLayoutData(template, "comunidad");
   }
 
   @POST
@@ -195,4 +198,24 @@ public class CommunityResource {
 
   public record MemberView(
       String name, String github, String role, String profileUrl, String avatarUrl, String since) {}
+
+  private TemplateInstance withLayoutData(TemplateInstance templateInstance, String activePage) {
+    String name = currentUserName().orElse(null);
+    return templateInstance
+        .data("activePage", activePage)
+        .data("userAuthenticated", isAuthenticated())
+        .data("userName", name)
+        .data("userInitial", initialFrom(name));
+  }
+
+  private String initialFrom(String name) {
+    if (name == null) {
+      return null;
+    }
+    String trimmed = name.trim();
+    if (trimmed.isEmpty()) {
+      return null;
+    }
+    return trimmed.substring(0, 1).toUpperCase();
+  }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
@@ -4,6 +4,7 @@ import com.scanales.eventflow.public_.view.CommunityViewModel;
 import com.scanales.eventflow.public_.view.ProjectsViewModel;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
+import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -22,34 +23,53 @@ public class PublicPagesResource {
 
   @Inject Template events;
 
+  @Inject SecurityIdentity identity;
+
   @GET
   public TemplateInstance home() {
-    return home.data("pageTitle", "Home").data("activePage", "home");
+    return withLayoutData(home.data("pageTitle", "Home"), "home");
   }
 
   @GET
   @Path("/community")
   public TemplateInstance community() {
     CommunityViewModel vm = CommunityViewModel.mock();
-    return community
-        .data("pageTitle", "Comunidad")
-        .data("vm", vm)
-        .data("activePage", "community");
+    return withLayoutData(
+        community.data("pageTitle", "Comunidad").data("vm", vm), "comunidad");
   }
 
   @GET
   @Path("/projects")
   public TemplateInstance projects() {
     ProjectsViewModel vm = ProjectsViewModel.mock();
-    return projects
-        .data("pageTitle", "Proyectos")
-        .data("vm", vm)
-        .data("activePage", "projects");
+    return withLayoutData(
+        projects.data("pageTitle", "Proyectos").data("vm", vm), "proyectos");
   }
 
   @GET
   @Path("/events")
   public TemplateInstance events() {
-    return events.data("pageTitle", "Eventos").data("activePage", "events");
+    return withLayoutData(events.data("pageTitle", "Eventos"), "eventos");
+  }
+
+  private TemplateInstance withLayoutData(TemplateInstance templateInstance, String activePage) {
+    boolean authenticated = identity != null && !identity.isAnonymous();
+    String userName = authenticated ? identity.getPrincipal().getName() : null;
+    return templateInstance
+        .data("activePage", activePage)
+        .data("userAuthenticated", authenticated)
+        .data("userName", userName)
+        .data("userInitial", initialFrom(userName));
+  }
+
+  private String initialFrom(String name) {
+    if (name == null) {
+      return null;
+    }
+    String trimmed = name.trim();
+    if (trimmed.isEmpty()) {
+      return null;
+    }
+    return trimmed.substring(0, 1).toUpperCase();
   }
 }

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -149,6 +149,7 @@ body::before {
    HEADER / NAVBAR
    =========================================== */
 
+.hd-top-nav,
 .top-nav {
   position: relative;
   z-index: 10;
@@ -162,58 +163,169 @@ body::before {
   box-shadow: 0 4px 0 rgba(0, 0, 0, 0.4);
 }
 
+.hd-logo,
 .logo {
   display: flex;
   align-items: center;
+  gap: 0.75rem;
 }
 
+.hd-logo-link,
 .logo-link {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
   text-decoration: none;
   color: inherit;
 }
 
+.hd-logo-icon,
 .logo-icon {
   width: 48px;
   height: 48px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.7rem;
+  font-size: 1.1rem;
   background: rgba(255, 255, 255, 0.15);
   border: 3px solid rgba(255, 255, 255, 0.7);
   box-shadow: 3px 3px 0 rgba(0, 0, 0, 0.5);
 }
 
+.hd-logo-text,
 .logo-text {
   display: flex;
   flex-direction: column;
+  line-height: 1.2;
 }
 
-.logo-text span:first-child {
-  font-size: 0.8rem;
+.hd-logo-title {
+  font-size: 0.85rem;
   letter-spacing: 3px;
   text-transform: uppercase;
   text-shadow: 3px 3px 0 rgba(0, 0, 0, 0.5);
 }
 
+.hd-logo-subtitle,
 .logo-subtitle {
-  font-size: 0.5rem;
+  font-size: 0.55rem;
   opacity: 0.8;
   letter-spacing: 2px;
 }
 
-/* Nav actions */
+.hd-main-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.hd-nav-link,
+.nav-link {
+  font-size: 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  text-decoration: none;
+  color: #ffffff;
+  opacity: 0.9;
+  padding-bottom: 2px;
+  border-bottom: 2px solid transparent;
+  transition: all 0.15s ease;
+}
+
+.hd-nav-link:hover,
+.nav-link:hover,
+.hd-nav-link.is-active,
+.nav-link.nav-link-active {
+  opacity: 1;
+  border-bottom-color: #ffd700;
+}
+
+.hd-user-area {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.hd-notifications-btn {
+  background: rgba(255, 255, 255, 0.12);
+  border: 2px solid rgba(255, 255, 255, 0.65);
+  color: #ffffff;
+  font-size: 0.85rem;
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  cursor: pointer;
+  box-shadow: 0 3px 0 rgba(0, 0, 0, 0.45);
+}
+
+.hd-user-menu {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.45rem 0.75rem;
+  background: rgba(0, 0, 0, 0.35);
+  border: 2px solid rgba(255, 255, 255, 0.65);
+  border-radius: 12px;
+  box-shadow: 0 3px 0 rgba(0, 0, 0, 0.5);
+}
+
+.hd-user-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.18);
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  font-size: 0.85rem;
+}
+
+.hd-user-name {
+  font-size: 0.65rem;
+  letter-spacing: 1px;
+}
+
+.hd-login-btn,
+.login-btn-nav {
+  background: rgba(255, 255, 255, 0.2);
+  border: 3px solid rgba(255, 255, 255, 0.8);
+  border-bottom: 5px solid rgba(0, 0, 0, 0.5);
+  border-right: 4px solid rgba(0, 0, 0, 0.4);
+  color: #ffffff;
+  padding: 0.5rem 1.5rem;
+  font-size: 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  cursor: pointer;
+  text-decoration: none;
+  box-shadow: 0 4px 0 rgba(0, 0, 0, 0.5);
+  transition: all 0.1s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hd-login-btn:hover,
+.login-btn-nav:hover {
+  transform: translateY(2px);
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.5);
+}
+
+.hd-login-btn:active,
+.login-btn-nav:active {
+  transform: translateY(4px);
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0.5);
+}
+
+/* Nav actions (legacy/compat) */
 .nav-actions {
   display: flex;
   align-items: center;
   gap: 1.5rem;
-}
-
-.nav-actions .login-btn-nav {
-  margin-left: 0.5rem;
 }
 
 .eyebrow {

--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -1,7 +1,7 @@
-{#include layout/base}
+{#include layout/main activePage='comunidad'}
 {#title}Comunidad{/title}
-{#breadcrumbs}<span>Inicio</span> / <strong>Comunidad</strong>{/breadcrumbs}
-{#main}
+{#body}
+<nav class="breadcrumbs"><span>Inicio</span> / <strong>Comunidad</strong></nav>
 <section class="hero hero--compact">
   <div class="hero__content">
     <div class="hero__kicker">Personas · Comunidad</div>
@@ -109,5 +109,5 @@
   </div>
   {/if}
 </section>
-{/main}
+{/body}
 {/include}

--- a/quarkus-app/src/main/resources/templates/EventsDirectoryResource/eventos.html
+++ b/quarkus-app/src/main/resources/templates/EventsDirectoryResource/eventos.html
@@ -1,7 +1,7 @@
-{#include layout/base}
+{#include layout/main activePage='eventos'}
 {#title}Eventos{/title}
-{#breadcrumbs}<span>Inicio</span> / <strong>Eventos</strong>{/breadcrumbs}
-{#main}
+{#body}
+<nav class="breadcrumbs"><span>Inicio</span> / <strong>Eventos</strong></nav>
 <section class="hero hero--compact">
   <div class="hero__content">
     <div class="hero__kicker">Agenda · Homedir</div>
@@ -101,5 +101,5 @@
   </div>
   {/if}
 </section>
-{/main}
+{/body}
 {/include}

--- a/quarkus-app/src/main/resources/templates/ProjectsResource/proyectos.html
+++ b/quarkus-app/src/main/resources/templates/ProjectsResource/proyectos.html
@@ -1,7 +1,7 @@
-{#include layout/base}
+{#include layout/main activePage='proyectos'}
 {#title}Proyectos{/title}
-{#breadcrumbs}<span>Inicio</span> / <strong>Proyectos</strong>{/breadcrumbs}
-{#main}
+{#body}
+<nav class="breadcrumbs"><span>Inicio</span> / <strong>Proyectos</strong></nav>
 <section class="hero hero--compact">
   <div class="hero__content">
     <div class="hero__kicker">Roadmap · Homedir</div>
@@ -35,5 +35,5 @@
     {/for}
   </div>
 </section>
-{/main}
+{/body}
 {/include}

--- a/quarkus-app/src/main/resources/templates/fragments/header.html
+++ b/quarkus-app/src/main/resources/templates/fragments/header.html
@@ -1,26 +1,38 @@
-<nav class="top-nav" aria-label="Navegación principal">
-  <div class="logo">
-    <a href="/" class="logo-link" aria-label="Ir al inicio de HomeDir">
-      <div class="logo-icon" aria-hidden="true">
-        <svg viewBox="0 0 64 64" role="img" aria-label="HomeDir logo">
-          <rect x="6" y="6" width="52" height="52" rx="12" fill="#0d071b" stroke="#ff8bd1" stroke-width="3" />
-          <path d="M20 44 L20 22 L32 14 L44 22 L44 44" fill="none" stroke="#7bd7ff" stroke-width="3" />
-          <rect x="28" y="32" width="8" height="12" fill="#ff8bd1" />
-        </svg>
-      </div>
-      <div class="logo-text">
-        <span>HomeDir</span>
-        <span class="logo-subtitle">by OpenSourceSantiago</span>
+{#if activePage is null}
+  {@ String activePage = ""}
+{/if}
+<header class="hd-top-nav" aria-label="Navegación principal">
+  <div class="hd-logo">
+    <a href="/" class="hd-logo-link" aria-label="Ir al inicio de HomeDir">
+      <span class="hd-logo-icon" aria-hidden="true">⌂</span>
+      <div class="hd-logo-text">
+        <span class="hd-logo-title">HomeDir</span>
+        <span class="hd-logo-subtitle">by OpenSourceSantiago</span>
       </div>
     </a>
   </div>
 
-  <div class="nav-actions">
-    <a href="/" class="nav-link">Home</a>
-    <a href="/community" class="nav-link">Comunidad</a>
-    <a href="/projects" class="nav-link">Proyectos</a>
-    <a href="/events" class="nav-link">Eventos</a>
-    <a href="/notifications/center" class="nav-link">Notificaciones</a>
-    <button class="login-btn-nav" type="button">Login</button>
+  <nav class="hd-main-nav">
+    <a href="/" class="hd-nav-link {#if activePage == 'home'}is-active{/if}">Home</a>
+    <a href="/comunidad" class="hd-nav-link {#if activePage == 'comunidad'}is-active{/if}">Comunidad</a>
+    <a href="/proyectos" class="hd-nav-link {#if activePage == 'proyectos'}is-active{/if}">Proyectos</a>
+    <a href="/eventos" class="hd-nav-link {#if activePage == 'eventos'}is-active{/if}">Eventos</a>
+  </nav>
+
+  <div class="hd-user-area">
+    <button class="hd-notifications-btn" title="Notificaciones" type="button" aria-label="Notificaciones">
+      🔔
+    </button>
+
+    {#if userAuthenticated}
+      <div class="hd-user-menu" aria-label="Menú de usuario">
+        <div class="hd-user-avatar" aria-hidden="true">
+          {#if userInitial??}{userInitial}{#else}👤{/if}
+        </div>
+        <span class="hd-user-name">{userName ?: 'Usuario'}</span>
+      </div>
+    {#else}
+      <a href="/ingresar" class="hd-login-btn">Login</a>
+    {/if}
   </div>
-</nav>
+</header>

--- a/quarkus-app/src/main/resources/templates/home.qute.html
+++ b/quarkus-app/src/main/resources/templates/home.qute.html
@@ -1,7 +1,7 @@
-{#include layouts/main}
+{#include layout/main}
   {#title}HomeDir{/title}
 
-  {#content}
+  {#body}
   <header class="public-header">
     <p class="eyebrow">Plataforma retro · Comunidad OSSantiago</p>
     <h1 class="public-title">HomeDir</h1>
@@ -11,7 +11,7 @@
   </header>
 
   <section class="main-sections">
-    <a href="/community" class="section-card">
+    <a href="/comunidad" class="section-card">
       <div class="icon-wrapper" aria-hidden="true">
         <svg viewBox="0 0 64 64" role="img" aria-label="Icono de comunidad">
           <circle cx="20" cy="26" r="10" fill="#7bd7ff" />
@@ -31,7 +31,7 @@
       </div>
     </a>
 
-    <a href="/events" class="section-card">
+    <a href="/eventos" class="section-card">
       <div class="icon-wrapper" aria-hidden="true">
         <svg viewBox="0 0 64 64" role="img" aria-label="Icono de eventos">
           <rect x="10" y="14" width="44" height="36" rx="6" fill="#7bd7ff" />
@@ -52,7 +52,7 @@
       </div>
     </a>
 
-    <a href="/projects" class="section-card">
+    <a href="/proyectos" class="section-card">
       <div class="icon-wrapper" aria-hidden="true">
         <svg viewBox="0 0 64 64" role="img" aria-label="Icono de proyectos">
           <rect x="10" y="16" width="44" height="32" rx="6" fill="#ff8bd1" />
@@ -72,5 +72,5 @@
       </div>
     </a>
   </section>
-  {/content}
+  {/body}
 {/include}

--- a/quarkus-app/src/main/resources/templates/layout/main.html
+++ b/quarkus-app/src/main/resources/templates/layout/main.html
@@ -2,38 +2,50 @@
 {@ boolean noNav = false}
 {@ boolean noFooter = false}
 {@ String activePage = ""}
+{@ boolean userAuthenticated = false}
+{@ String userName}
+{@ String userInitial}
 <html lang="en">
 <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{#insert title}HomeDir - Community Platform{/}</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{#insert title}HomeDir - Community Platform{/}</title>
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Courier+Prime&display=swap" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Courier+Prime&display=swap"
+    rel="stylesheet" />
 
-    <link rel="icon" href="/favicon.ico" />
-    <link rel="stylesheet" href="/styles.css" />
-    <link rel="stylesheet" href="/css/homedir.css" />
-    <link rel="stylesheet" href="/css/notifications.css" />
+  <link rel="icon" href="/favicon.ico" />
+  <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="/css/homedir.css" />
+  <link rel="stylesheet" href="/css/notifications.css" />
 </head>
-<body class="hd-body">
-    {#if noNav != true}
-        {#include fragments/nav.html activePage=activePage/}
-    {/if}
-    <main id="main-content" class="hd-main" role="main">
-        {#insert body}
-        {/}
-    </main>
-    {#if noFooter != true}
-        {#include fragments/footer.html/}
-    {/if}
+<body class="homedir-body">
+  {#include fragments/floating-shapes /}
 
-    <script src="/js/homedir.js"></script>
-    <script>window.__EF_AUTH__ = { isAuth: {app:isAuthenticated()} };</script>
-    <script src="/js/app.js" defer></script>
-    <script src="/js/notifications-adapter.js" defer></script>
-    <script src="/js/notifications.js" defer></script>
-    <script src="/js/global-notifications-ws.js" defer></script>
+  {#if noNav != true}
+    {#include fragments/header
+      activePage=activePage
+      userAuthenticated=userAuthenticated
+      userName=userName
+      userInitial=userInitial /}
+  {/if}
+
+  <main id="main-content" class="homedir-main" role="main">
+    {#insert body}{/}
+  </main>
+
+  {#if noFooter != true}
+    {#include fragments/footer.html/}
+  {/if}
+
+  <script src="/js/homedir.js"></script>
+  <script>window.__EF_AUTH__ = { isAuth: {app:isAuthenticated()} };</script>
+  <script src="/js/app.js" defer></script>
+  <script src="/js/notifications-adapter.js" defer></script>
+  <script src="/js/notifications.js" defer></script>
+  <script src="/js/global-notifications-ws.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a shared layout with the new header, floating shapes, and standardized footer includes
- update public templates and resources to pass active page and user identity data to the header
- consolidate header styling and switch navigation/links to the Spanish primary routes

## Testing
- ./mvnw -pl quarkus-app test *(fails: Maven wrapper download blocked by network in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693043fc1d088333a7904699cd014530)