### PR TITLE
fix(auth): update login buttons to use private site flow

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -58,6 +58,7 @@ quarkus.http.auth.session.encryption-key=${SESSION_KEY}
 quarkus.http.auth.permission.private.paths=/private/*
 quarkus.http.auth.permission.private.policy=authenticated
 
+
 # Controla el uso de la nueva UI (layout + templates v2).
 # true  -> usa la nueva UI basada en layout/main + clases hd-*
 # false -> fallback (si se implementa) a templates anteriores / minimal

--- a/quarkus-app/src/main/resources/templates/LoginPage/ingresar.html
+++ b/quarkus-app/src/main/resources/templates/LoginPage/ingresar.html
@@ -18,9 +18,9 @@
       {/if}
 
       <div class="hd-login-actions">
-        <a href="/q/oidc/login" class="hd-btn hd-btn-primary">Ingresar con Google</a>
+        <a href="/private/profile" class="hd-btn hd-btn-primary">Ingresar con Google</a>
         {#if githubEnabled}
-        <a href="/q/oidc/login/github" class="hd-btn hd-btn-secondary">Ingresar con GitHub</a>
+        <a href="/private/profile" class="hd-btn hd-btn-secondary">Ingresar con GitHub</a>
         {#else}
         <span class="hd-login-hint">Habilita GH_CLIENT_ID/GH_CLIENT_SECRET para activar GitHub.</span>
         {/if}


### PR DESCRIPTION
Updates ingresar.html to point login buttons to /private/profile, leveraging the native OIDC interception flow to return the user to their origin.