### PR TITLE
fix(auth): configurable OIDC redirect path via ENV

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -4,7 +4,7 @@ quarkus.oidc.tenant-enabled=true
 # Google (Default Tenant)
 quarkus.oidc.provider=google
 quarkus.oidc.application-type=web-app
-quarkus.oidc.authentication.redirect-path=/login/callback
+quarkus.oidc.authentication.redirect-path=${OIDC_REDIRECT_PATH:/login/callback}
 quarkus.http.auth.form.enabled=false
 quarkus.oidc.client-id=${OIDC_CLIENT_ID:dev-client}
 quarkus.oidc.credentials.secret=${OIDC_CLIENT_SECRET:dev-secret}


### PR DESCRIPTION
Allows overriding quarkus.oidc.authentication.redirect-path using OIDC_REDIRECT_PATH environment variable to solve HTTP/HTTPS proxy issues.