### PR TITLE
fix(auth): set explicit landing page to /private/profile

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -58,6 +58,7 @@ quarkus.http.proxy.allow-forwarded=true
 quarkus.http.auth.session.encryption-key=${SESSION_KEY}
 quarkus.http.auth.permission.private.paths=/private/*
 quarkus.http.auth.permission.private.policy=authenticated
+quarkus.http.auth.form.landing-page=/private/profile
 
 
 # Controla el uso de la nueva UI (layout + templates v2).


### PR DESCRIPTION
Sets quarkus.http.auth.form.landing-page=/private/profile strictly to resolve user confusion about post-login redirection.