### PR TITLE
fix: Qute parsing error by using get() and proper spacing

### DIFF
--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -153,15 +153,15 @@
                   </select>
                   <label class="attended-label" title="Asistí">
                     <input type="checkbox" class="attended-checkbox" data-talk-id="{t.id}" {#if
-                      info[t.id].attended}checked{/if}>
+                      info.get(t.id).attended}checked{/if}>
                   </label>
                   <select id="rating-{t.id}" class="rating-select hd-form-input" data-talk-id="{t.id}" title="Valorar">
                     <option value="">★</option>
-                    <option value="1" {#if info[t.id].rating==1}selected{/if}>1</option>
-                    <option value="2" {#if info[t.id].rating==2}selected{/if}>2</option>
-                    <option value="3" {#if info[t.id].rating==3}selected{/if}>3</option>
-                    <option value="4" {#if info[t.id].rating==4}selected{/if}>4</option>
-                    <option value="5" {#if info[t.id].rating==5}selected{/if}>5</option>
+                    <option value="1" {#if info.get(t.id).rating==1}selected{/if}>1</option>
+                    <option value="2" {#if info.get(t.id).rating==2}selected{/if}>2</option>
+                    <option value="3" {#if info.get(t.id).rating==3}selected{/if}>3</option>
+                    <option value="4" {#if info.get(t.id).rating==4}selected{/if}>4</option>
+                    <option value="5" {#if info.get(t.id).rating==5}selected{/if}>5</option>
                   </select>
                   <button class="hd-btn hd-btn-secondary remove-talk" data-talk-id="{t.id}"
                     title="Eliminar">🗑️</button>


### PR DESCRIPTION
Fixes build failure caused by invalid Qute template syntax.