### PR TITLE
fix(config): force https for github oidc

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -26,6 +26,7 @@ quarkus.oidc.github.authentication.redirect-path=/auth/github/callback
 quarkus.oidc.github.authentication.scopes=read:user user:email
 quarkus.oidc.github.authentication.user-info-required=true
 quarkus.oidc.github.token.principal-claim=login
+quarkus.oidc.github.authentication.force-redirect-https=true
 
 # Comunidad members live in os-santiago/os-santiago.github.io
 community.github.repo-owner=os-santiago


### PR DESCRIPTION
Forces HTTPS for GitHub OIDC redirect URI to prevent 'http' callback errors in production.