### PR TITLE
fix: github redirect uri scheme in prod

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -27,6 +27,7 @@ quarkus.oidc.github.authentication.scopes=read:user user:email
 quarkus.oidc.github.authentication.user-info-required=true
 quarkus.oidc.github.token.principal-claim=login
 quarkus.oidc.github.authentication.force-redirect-https=true
+%prod.quarkus.oidc.github.authentication.redirect-path=https://homedir.opensourcesantiago.io/auth/github/callback
 
 # Comunidad members live in os-santiago/os-santiago.github.io
 community.github.repo-owner=os-santiago


### PR DESCRIPTION
Forces absolute HTTPS redirect URI for GitHub OAuth to prevent incorrect http callbacks behind proxy.