### PR TITLE
fix: 401 on github callback

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/GithubLinkService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/GithubLinkService.java
@@ -152,7 +152,7 @@ public class GithubLinkService {
   }
 
   private String canonicalCallback() {
-    return "https://homedir.opensourcesantiago.io/private/github/callback";
+    return "https://homedir.opensourcesantiago.io/auth/github/callback";
   }
 
   private String currentUserId(SecurityIdentity identity) {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/GithubAuthResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/GithubAuthResource.java
@@ -7,10 +7,12 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
+import jakarta.annotation.security.PermitAll;
 import java.net.URI;
 import org.jboss.logging.Logger;
 
 @Path("/auth/github")
+@PermitAll
 public class GithubAuthResource {
 
     private static final Logger LOG = Logger.getLogger(GithubAuthResource.class);

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -22,12 +22,12 @@ quarkus.oidc.github.provider=github
 quarkus.oidc.github.application-type=web-app
 quarkus.oidc.github.client-id=${GH_CLIENT_ID}
 quarkus.oidc.github.credentials.secret=${GH_CLIENT_SECRET}
-quarkus.oidc.github.authentication.redirect-path=/auth/github/callback
+quarkus.oidc.github.authentication.redirect-path=/auth/github/oidc-callback-unused
 quarkus.oidc.github.authentication.scopes=read:user user:email
 quarkus.oidc.github.authentication.user-info-required=true
 quarkus.oidc.github.token.principal-claim=login
 quarkus.oidc.github.authentication.force-redirect-https=true
-%prod.quarkus.oidc.github.authentication.redirect-path=https://homedir.opensourcesantiago.io/auth/github/callback
+# %prod.quarkus.oidc.github.authentication.redirect-path=https://homedir.opensourcesantiago.io/auth/github/callback
 
 # Comunidad members live in os-santiago/os-santiago.github.io
 community.github.repo-owner=os-santiago


### PR DESCRIPTION
Changes OIDC redirect path to avoid conflict with manual resource, updates callback URI in service, and adds PermitAll.