### PR TITLE
chore: disable github oidc tenant

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -17,16 +17,16 @@ quarkus.oidc.token.principal-claim=id_token
 # Disable Quarkus built-in logout as Google does not provide an end_session_endpoint
 quarkus.oidc.logout.path=
 
-# GitHub Tenant
-quarkus.oidc.github.provider=github
-quarkus.oidc.github.application-type=web-app
-quarkus.oidc.github.client-id=${GH_CLIENT_ID}
-quarkus.oidc.github.credentials.secret=${GH_CLIENT_SECRET}
-quarkus.oidc.github.authentication.redirect-path=/auth/github/oidc-callback-unused
-quarkus.oidc.github.authentication.scopes=read:user user:email
-quarkus.oidc.github.authentication.user-info-required=true
-quarkus.oidc.github.token.principal-claim=login
-quarkus.oidc.github.authentication.force-redirect-https=true
+# GitHub Tenant (Disabled - Using Manual Auth)
+# quarkus.oidc.github.provider=github
+# quarkus.oidc.github.application-type=web-app
+# quarkus.oidc.github.client-id=${GH_CLIENT_ID}
+# quarkus.oidc.github.credentials.secret=${GH_CLIENT_SECRET}
+# quarkus.oidc.github.authentication.redirect-path=/auth/github/oidc-callback-unused
+# quarkus.oidc.github.authentication.scopes=read:user user:email
+# quarkus.oidc.github.authentication.user-info-required=true
+# quarkus.oidc.github.token.principal-claim=login
+# quarkus.oidc.github.authentication.force-redirect-https=true
 # %prod.quarkus.oidc.github.authentication.redirect-path=https://homedir.opensourcesantiago.io/auth/github/callback
 
 # Comunidad members live in os-santiago/os-santiago.github.io


### PR DESCRIPTION
Disables the Quarkus OIDC GitHub tenant configuration. This prevents the OIDC extension from intercepting requests to /private/github/start and ensures the manual JAX-RS resource handles the GitHub auth flow exclusively.