### PR TITLE
fix: explicit jsr310 module registration

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/CommunityMember.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/CommunityMember.java
@@ -18,6 +18,7 @@ public class CommunityMember {
   private String role;
   private String profileUrl;
   private String avatarUrl;
+  @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING)
   private Instant joinedAt;
 
   public CommunityMember() {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/CommunitySyncService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/CommunitySyncService.java
@@ -61,6 +61,7 @@ public class CommunitySyncService {
 
   @PostConstruct
   void init() {
+    yamlMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
     yamlMapper.findAndRegisterModules();
     yamlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     yamlMapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/CommunitySyncServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/CommunitySyncServiceTest.java
@@ -13,7 +13,9 @@ public class CommunitySyncServiceTest {
     @Test
     public void testSerialization() throws Exception {
         ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+        yamlMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
         yamlMapper.findAndRegisterModules();
+        yamlMapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
         CommunityMember member = new CommunityMember();
         member.setUserId("user1");


### PR DESCRIPTION
Registers JavaTimeModule explicitly and forces JsonFormat.Shape.STRING for Instant in CommunityMember to resolve SnakeYAML Emitter errors.