### PR TITLE
fix: robust serialization

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/CommunitySyncService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/CommunitySyncService.java
@@ -61,7 +61,9 @@ public class CommunitySyncService {
 
   @PostConstruct
   void init() {
-    yamlMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+    com.fasterxml.jackson.datatype.jsr310.JavaTimeModule module = new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule();
+    module.addSerializer(java.time.Instant.class, com.fasterxml.jackson.databind.ser.std.ToStringSerializer.instance);
+    yamlMapper.registerModule(module);
     yamlMapper.findAndRegisterModules();
     yamlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     yamlMapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
@@ -276,7 +278,7 @@ public class CommunitySyncService {
     public String sha;
   }
 
-  private static class CommunityData {
+  public static class CommunityData {
     public List<CommunityMember> members;
 
     CommunityData(List<CommunityMember> members) {

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/CommunitySyncServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/CommunitySyncServiceTest.java
@@ -13,7 +13,9 @@ public class CommunitySyncServiceTest {
     @Test
     public void testSerialization() throws Exception {
         ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
-        yamlMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+        com.fasterxml.jackson.datatype.jsr310.JavaTimeModule module = new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule();
+        module.addSerializer(Instant.class, com.fasterxml.jackson.databind.ser.std.ToStringSerializer.instance);
+        yamlMapper.registerModule(module);
         yamlMapper.findAndRegisterModules();
         yamlMapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 


### PR DESCRIPTION
Makes wrapper public and uses ToStringSerializer to fix SnakeYAML Emitter issues.