### PR TITLE
fix(logic): correct alreadyMember state calculation

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityResource.java
@@ -101,7 +101,7 @@ public class CommunityResource {
         query,
         joined,
         missingGithub,
-        already,
+        (current != null) || already,
         needsGithub,
         isAuthenticated(),
         current,


### PR DESCRIPTION
Previously, alreadyMember relied solely on the ?already query param. Now it correctly checks if the user exists in the member list.