### PR TITLE
fix: Include messages bundles in native build

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -117,6 +117,7 @@ quests.content.url=https://raw.githubusercontent.com/os-santiago/homedir/main/qu
 # Enable HTTPS for Native Image (Critical for Remote Fetch)
 quarkus.native.enable-https-url-handler=true
 quarkus.ssl.native=true
+quarkus.native.resources.includes=messages*.properties
 notifications.scheduler.enabled=true
 notifications.scheduler.interval=PT15S
 notifications.upcoming.window=PT5M


### PR DESCRIPTION
Added 'quarkus.native.resources.includes=messages*.properties' to ensure localization files are available in the production native image.