### PR TITLE
chore: automate release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Production Release
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       release_level:


### PR DESCRIPTION
Sets the release workflow to trigger automatically on pushes to main.