### PR TITLE
fix(k8s): update deployment to use GHCR image

### DIFF
--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
         - name: homedir
           # Alias tag; production uses immutable digests
-          image: quay.io/sergio_canales_e/homedir:2.2.11
+          image: ghcr.io/os-santiago/homedir:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Points the K8s deployment to ghcr.io/os-santiago/homedir:latest so it picks up the images built by our release workflow.