### PR TITLE
fix(ci): revert release registry to quay.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,17 +57,17 @@ jobs:
         # Action outputs: new_tag (v1.0.0), new_version (1.0.0)
         run: ./mvnw package -Drevision=${{ steps.tag_version.outputs.new_version }} -DskipTests
 
-      - name: Login to GitHub Container Registry
+      - name: Login to Quay.io
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: quay.io
+          username: ${{ vars.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build and Push Docker Image
         working-directory: quarkus-app
         env:
-          IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/homedir
+          IMAGE_NAME: ${{ vars.REGISTRY }}/${{ vars.IMAGE_NAME }}
           TAG: ${{ steps.tag_version.outputs.new_version }}
         run: |
           docker build -f src/main/docker/Dockerfile.jvm \


### PR DESCRIPTION
Restoring Quay.io registry configuration while preserving auto-tagging logic.