### PR TITLE
fix: remove visible merge conflict marker

### DIFF
--- a/quarkus-app/src/main/resources/templates/layout/main.html
+++ b/quarkus-app/src/main/resources/templates/layout/main.html
@@ -39,7 +39,7 @@
   <meta name="twitter:title" content="{pageTitle ?: 'HomeDir'}" />
   <meta name="twitter:description" content="{pageDescription ?: 'Join the Open Source Santiago community platform.'}" />
   <meta name="twitter:image" content="{pageImage ?: 'https://homedir.opensourcesantiago.io/images/og-default.png'}" />
-  >>>>>>> fix/revert-release-registry
+
 
   {#insert head}{/}
 </head>


### PR DESCRIPTION
Removes a stray >>>>>>> marker from main.html that was visible on the home page.