### PR TITLE
fix(layout): stop 500 css and runtime JS errors in public pages

### DIFF
--- a/quarkus-app/src/main/resources/templates/layout/main.html
+++ b/quarkus-app/src/main/resources/templates/layout/main.html
@@ -27,7 +27,6 @@
   <link rel="stylesheet" href="/css/homedir.css" />
   <link rel="stylesheet" href="/css/notifications.css" />
   <link rel="stylesheet" href="/css/retro-theme.css" />
-  <link rel="stylesheet" href="/css/canva-theme-v2.css" />
   <!-- Open Graph / Social Sharing Defaults -->
   <meta property="og:site_name" content="HomeDir" />
   <meta property="og:type" content="website" />
@@ -65,12 +64,11 @@
 
   {#include fragments/login-modal.html/}
   <script src="/js/homedir.js"></script>
-  <script>window.__EF_AUTH__ = { isAuth: { app: { userAuthenticated: { userAuthenticated } } } };</script>
+  <script>window.__EF_AUTH__ = { isAuth: { app: { userAuthenticated: {#if userAuthenticated}true{#else}false{/if} } } };</script>
   <script src="/js/app.js" defer></script>
   <script src="/js/notifications-adapter.js" defer></script>
   <script src="/js/notifications.js" defer></script>
   <script src="/js/global-notifications-ws.js" defer></script>
-  <script src="/js/retro-theme.js" defer></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- remove broken `/css/canva-theme-v2.css` include from shared `layout/main`
- fix `userAuthenticated` script injection so it renders valid JS boolean
- remove duplicate `/js/retro-theme.js` include from shared `layout/main` (already loaded where needed)

## Why
Fixes prod console/runtime errors reported on `/` and `/comunidad`:
- 500 on `canva-theme-v2.css`
- `ReferenceError: userAuthenticated is not defined`
- `SyntaxError: Identifier ''COLLECTIBLES'' has already been declared`

## Validation
- `mvn -f quarkus-app/pom.xml "-Dtest=HomePastEventsTest,NotificationsMenuTest" test` (pass)
