### PR TITLE
fix(community-ui): match Social card hover effects to Home

### DIFF
--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -87,6 +87,28 @@
     gap: 1rem;
   }
 
+  /* Match Home card behavior and disable retro glow sweep on Social cards */
+  .community-list .section-card {
+    background: rgba(0, 0, 0, 0.45);
+    border: 3px solid rgba(255, 255, 255, 0.7);
+    border-bottom: 6px solid rgba(0, 0, 0, 0.7);
+    border-right: 5px solid rgba(0, 0, 0, 0.6);
+    box-shadow: 0 6px 0 rgba(0, 0, 0, 0.6);
+    transition: all 0.12s ease;
+    animation: none;
+    cursor: default;
+  }
+
+  .community-list .section-card::before {
+    content: none;
+  }
+
+  .community-list .section-card:hover {
+    transform: translateY(4px);
+    box-shadow: 0 3px 0 rgba(0, 0, 0, 0.6);
+    background: rgba(0, 0, 0, 0.55);
+  }
+
   .community-item-header {
     display: flex;
     justify-content: space-between;
@@ -177,4 +199,3 @@
 <script src="/js/community-content.js" defer></script>
 {/body}
 {/include}
-


### PR DESCRIPTION
## Summary
- align Social card hover behavior with Home visual interaction
- remove retro sweep overlay from community list cards
- keep dark hover style to avoid white/glitch flashes in card backgrounds

## Technical
- scoped override in `CommunityResource/community.html` for `.community-list .section-card`
- disabled `::before` animated overlay on those cards
- matched transition/hover values used in Home cards

## Validation
- `mvn -f quarkus-app/pom.xml "-Dtest=CommunityContentApiResourceTest,HomePastEventsTest" test`
