### PR TITLE
feat(home): compact one-page highlights

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
@@ -653,4 +653,102 @@ public interface AppMessages {
 
     @Message("Collaborate on open source projects.")
     String home_projects_card_desc();
+
+    // Home Page Highlights
+    @Message("Social")
+    String home_pill_social();
+
+    @Message("Events")
+    String home_pill_events();
+
+    @Message("Project")
+    String home_pill_project();
+
+    @Message("Social · Events · Project")
+    String home_hero_title_combined();
+
+    @Message("One-page highlights to quickly discover what is new in the Community platform for OSS Santiago.")
+    String home_hero_desc();
+
+    @Message("updates available")
+    String home_metric_updates();
+
+    @Message("upcoming events")
+    String home_metric_upcoming();
+
+    @Message("active contributors")
+    String home_metric_contributors();
+
+    @Message("Social highlights")
+    String home_social_highlights_eyebrow();
+
+    @Message("Latest community content")
+    String home_social_highlights_title();
+
+    @Message("Open Social")
+    String home_btn_open_social();
+
+    @Message("No social updates loaded yet. Open Social to check the latest refresh.")
+    String home_social_empty();
+
+    @Message("Events highlights")
+    String home_events_highlights_eyebrow();
+
+    @Message("Upcoming agenda")
+    String home_events_highlights_title();
+
+    @Message("Open Events")
+    String home_btn_open_events();
+
+    @Message("No upcoming events yet. Visit Events for historical sessions.")
+    String home_events_empty();
+
+    @Message("Date TBA")
+    String home_event_date_tba();
+
+    @Message("Open the event for full details.")
+    String home_event_desc_default();
+
+    @Message("Project highlights")
+    String home_project_highlights_eyebrow();
+
+    @Message("Build with the core contributors")
+    String home_project_highlights_title();
+
+    @Message("Open Project")
+    String home_btn_open_project();
+
+    @Message("total contributions")
+    String home_project_total_contributions();
+
+    @Message("Latest release")
+    String home_project_release_label();
+
+    @Message("Latest commit")
+    String home_project_commit_label();
+
+    @Message("contribs")
+    String home_project_contribs_unit();
+
+    @Message("Top contributors")
+    String home_project_top_contributors();
+
+    @Message("No contributor data available at the moment.")
+    String home_project_no_data();
+
+    @Message("Ready to contribute")
+    String home_project_actions_chip();
+
+    @Message("Pick a path and start")
+    String home_project_actions_title();
+
+    @Message("Explore project tracks, choose an issue, and contribute through the shared workflow.")
+    String home_project_actions_desc();
+
+    @Message("Explore tracks")
+    String home_btn_explore_tracks();
+
+    @Message("View repository")
+    String home_btn_view_repo();
+
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
@@ -55,10 +55,10 @@ public class PublicPagesResource {
   @GET
   public TemplateInstance home() {
     List<GithubContributor> contributors = githubService.fetchContributors("os-santiago", "homedir");
-    List<GithubContributor> projectHighlights = contributors.stream().limit(8).toList();
+    List<GithubContributor> projectHighlights = contributors.stream().limit(6).toList();
     int contributionTotal = contributors.stream().mapToInt(GithubContributor::contributions).sum();
 
-    List<Event> popularEvents = eventService.findUpcomingEvents(4);
+    List<Event> popularEvents = eventService.findUpcomingEvents(3);
     int upcomingCount =
         (int)
             eventService.listEvents().stream()
@@ -66,7 +66,7 @@ public class PublicPagesResource {
                 .filter(event -> !event.getDate().isBefore(LocalDate.now()))
                 .count();
 
-    List<CommunityContentItem> socialHighlights = communityContentService.listNew(4, 0);
+    List<CommunityContentItem> socialHighlights = communityContentService.listNew(3, 0);
     int socialHighlightsCount = communityContentService.metrics().cacheSize();
 
     if (contributors.isEmpty()) {

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -2054,101 +2054,170 @@ footer {
    =========================================== */
 
 .home-highlight-hero {
-  gap: 1rem;
-  margin-bottom: 2rem;
+  gap: 0.65rem;
+  margin-bottom: 1rem;
 }
 
-.home-hero-pills {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+.home-highlight-hero .public-title {
+  font-size: clamp(1.25rem, 2.4vw, 2rem);
+  letter-spacing: 2px;
+  text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.6);
+}
+
+.home-highlight-hero .tagline {
+  font-size: 0.95rem;
+  line-height: 1.45;
+  max-width: 940px;
+}
+
+.home-top-metrics {
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.75rem;
+  margin-top: 0.3rem;
 }
 
-.home-hero-pill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.45rem 0.9rem;
-  border: 2px solid rgba(255, 255, 255, 0.7);
-  background: rgba(0, 0, 0, 0.35);
-  color: #ffffff;
+.home-top-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
   text-decoration: none;
-  font-family: var(--font-display);
-  font-size: 0.65rem;
-  letter-spacing: 1px;
-  text-transform: uppercase;
+  color: #ffffff;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: rgba(0, 0, 0, 0.28);
+  transition: border-color 0.12s ease, transform 0.12s ease;
 }
 
-.home-hero-pill:hover {
-  color: #ffd700;
+.home-top-metric:hover {
   border-color: #ffd700;
+  transform: translateY(-1px);
 }
 
-.home-quick-grid {
-  margin-bottom: 1.5rem;
+.home-top-metric strong {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  line-height: 1;
 }
 
-.home-quick-card {
-  position: relative;
+.home-top-metric small {
+  font-size: 0.68rem;
+  opacity: 0.9;
+  text-transform: uppercase;
+  letter-spacing: 0.7px;
+}
+
+.home-panorama-grid {
+  align-items: stretch;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.home-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-height: 520px;
+  padding: 1rem 0.95rem 0.9rem;
+}
+
+.home-pane-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.55rem;
+}
+
+.home-pane-header .section-subtitle {
+  font-size: 0.7rem;
+  margin: 0;
+}
+
+.home-pane-header .page-title {
+  margin: 0;
+  font-size: 1.06rem;
+  letter-spacing: 1px;
+  line-height: 1.2;
+}
+
+.home-pane-header .btn-primary {
+  padding: 0.52rem 0.75rem;
+  font-size: 0.56rem;
+  letter-spacing: 1.1px;
+  white-space: nowrap;
+}
+
+.home-pane-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  min-height: 0;
+}
+
+.home-pane-item {
+  display: block;
+  text-decoration: none;
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(0, 0, 0, 0.26);
+  padding: 0.65rem;
+  transition: border-color 0.12s ease, transform 0.12s ease;
+}
+
+.home-pane-item:hover {
+  border-color: #ffd700;
+  transform: translateY(-1px);
+}
+
+.home-pane-title {
+  margin: 0 0 0.3rem;
+  font-size: 0.9rem;
+  line-height: 1.3;
+}
+
+.home-pane-summary {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  opacity: 0.94;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
 }
 
-.home-quick-card::after {
-  content: "";
-  position: absolute;
-  inset: auto -40% -60% -40%;
-  height: 120px;
-  background: radial-gradient(ellipse at center, rgba(255, 255, 255, 0.22), transparent 70%);
-  pointer-events: none;
+.home-project-brief {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.45rem 0.6rem;
+  padding: 0.55rem;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(0, 0, 0, 0.22);
 }
 
-.home-quick-icon {
-  font-size: 2rem;
-  margin-bottom: 0.5rem;
-}
-
-.home-quick-metric {
-  margin-top: 0.75rem;
-  font-size: 0.8rem;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  color: #ffd700;
-}
-
-.home-quick-card-social {
-  background: linear-gradient(160deg, rgba(22, 46, 91, 0.75), rgba(0, 0, 0, 0.6));
-}
-
-.home-quick-card-events {
-  background: linear-gradient(160deg, rgba(41, 78, 54, 0.75), rgba(0, 0, 0, 0.6));
-}
-
-.home-quick-card-project {
-  background: linear-gradient(160deg, rgba(83, 45, 28, 0.75), rgba(0, 0, 0, 0.6));
-}
-
-.home-highlight-grid {
-  gap: 1rem;
-}
-
-.home-highlight-full {
-  grid-column: 1 / -1;
-}
-
-.home-highlight-header {
+.home-project-brief p {
+  margin: 0;
   display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 1rem;
+  flex-direction: column;
+  gap: 0.08rem;
 }
 
-.home-highlight-header .page-title {
-  margin: 0;
+.home-project-brief span {
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  opacity: 0.84;
 }
 
-.home-highlight-header .section-subtitle {
-  margin: 0;
+.home-project-brief strong {
+  font-family: var(--font-display);
+  font-size: 0.75rem;
+  line-height: 1.2;
+}
+
+.home-project-brief strong:last-child {
+  word-break: break-all;
 }
 
 .home-card-top {
@@ -2156,91 +2225,156 @@ footer {
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.42rem;
 }
 
 .home-chip {
   display: inline-flex;
   align-items: center;
-  padding: 0.2rem 0.5rem;
+  padding: 0.18rem 0.44rem;
   border: 1px solid rgba(255, 255, 255, 0.6);
-  font-size: 0.6rem;
-  letter-spacing: 1px;
+  font-size: 0.56rem;
+  letter-spacing: 0.7px;
   text-transform: uppercase;
 }
 
 .home-source {
-  font-size: 0.75rem;
+  font-size: 0.68rem;
   opacity: 0.85;
-}
-
-.home-social-card h3,
-.home-event-card h3,
-.home-project-contributors h3,
-.home-project-actions h3 {
-  margin-bottom: 0.6rem;
-  font-size: 1rem;
-}
-
-.home-social-card p,
-.home-event-card p,
-.home-project-contributors p,
-.home-project-actions p {
-  font-size: 0.9rem;
-  line-height: 1.45;
 }
 
 .home-highlight-empty {
   display: flex;
   align-items: center;
-  gap: 0.8rem;
+  gap: 0.55rem;
+  min-height: 88px;
 }
 
 .home-highlight-empty .material-symbols-outlined {
-  font-size: 2rem;
+  font-size: 1.35rem;
   opacity: 0.85;
 }
 
 .home-contributor-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 0.75rem;
-  margin-top: 0.75rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.home-contributor-grid-compact {
+  margin-top: 0.1rem;
 }
 
 .home-contributor-card {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 0.6rem;
+  gap: 0.28rem;
   text-decoration: none;
   color: #ffffff;
-  padding: 0.45rem;
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  background: rgba(0, 0, 0, 0.25);
+  padding: 0.44rem 0.32rem;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.28), rgba(0, 0, 0, 0.4));
+  border-radius: 8px;
+  min-height: 102px;
+  transition: transform 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
 }
 
 .home-contributor-card:hover {
   border-color: #ffd700;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 0 rgba(0, 0, 0, 0.35);
 }
 
-.home-contributor-card img {
-  width: 28px;
-  height: 28px;
+.home-contributor-avatar-shell {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at 35% 35%, rgba(255, 255, 255, 0.35), rgba(0, 0, 0, 0.25));
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);
+}
+
+.home-contributor-avatar {
+  width: 38px;
+  height: 38px;
   border-radius: 50%;
   object-fit: cover;
-  border: 1px solid rgba(255, 255, 255, 0.6);
+  border: 2px solid rgba(255, 255, 255, 0.7);
+}
+
+.home-contributor-login {
+  max-width: 100%;
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1.15;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.home-contributor-meta {
+  font-size: 0.58rem;
+  letter-spacing: 0.35px;
+  text-transform: uppercase;
+  color: #ffd700;
+  opacity: 0.95;
 }
 
 .home-project-actions-row {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 0.9rem;
+  gap: 0.5rem;
+  margin-top: auto;
+}
+
+.home-project-actions-row .btn-primary {
+  flex: 1 1 auto;
+  padding: 0.5rem 0.55rem;
+  font-size: 0.53rem;
+  letter-spacing: 0.85px;
+}
+
+@media (max-width: 1120px) {
+  .home-panorama-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .home-pane {
+    min-height: 470px;
+  }
+
+  .home-top-metrics {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 860px) {
-  .home-highlight-header {
-    align-items: flex-start;
-    flex-direction: column;
+  .home-top-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .home-panorama-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .home-pane {
+    min-height: 0;
+  }
+
+  .home-project-brief {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .home-contributor-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .home-pane-header .btn-primary {
+    padding: 0.45rem 0.65rem;
+    font-size: 0.52rem;
   }
 }

--- a/quarkus-app/src/main/resources/messages.properties
+++ b/quarkus-app/src/main/resources/messages.properties
@@ -220,3 +220,41 @@ home_events_title=Events
 home_events_card_desc=Upcoming meetups and gatherings.
 home_projects_title=Project
 home_projects_card_desc=Collaborate on open source projects.
+
+# Home Page Highlights
+home_pill_social=Social
+home_pill_events=Events
+home_pill_project=Project
+home_hero_title_combined=Social · Events · Project
+home_hero_desc=One-page highlights to quickly discover what is new in the Community platform for OSS Santiago.
+
+home_metric_updates=updates available
+home_metric_upcoming=upcoming events
+home_metric_contributors=active contributors
+
+home_social_highlights_eyebrow=Social highlights
+home_social_highlights_title=Latest community content
+home_btn_open_social=Open Social
+home_social_empty=No social updates loaded yet. Open Social to check the latest refresh.
+
+home_events_highlights_eyebrow=Events highlights
+home_events_highlights_title=Upcoming agenda
+home_btn_open_events=Open Events
+home_events_empty=No upcoming events yet. Visit Events for historical sessions.
+home_event_date_tba=Date TBA
+home_event_desc_default=Open the event for full details.
+
+home_project_highlights_eyebrow=Project highlights
+home_project_highlights_title=Build with the core contributors
+home_btn_open_project=Open Project
+home_project_total_contributions=total contributions
+home_project_release_label=Latest release
+home_project_commit_label=Latest commit
+home_project_contribs_unit=contribs
+home_project_top_contributors=Top contributors
+home_project_no_data=No contributor data available at the moment.
+home_project_actions_chip=Ready to contribute
+home_project_actions_title=Pick a path and start
+home_project_actions_desc=Explore project tracks, choose an issue, and contribute through the shared workflow.
+home_btn_explore_tracks=Explore tracks
+home_btn_view_repo=View repository

--- a/quarkus-app/src/main/resources/messages_es.properties
+++ b/quarkus-app/src/main/resources/messages_es.properties
@@ -217,3 +217,41 @@ home_events_title=Eventos
 home_events_card_desc=Próximas juntas y meetups.
 home_projects_title=Project
 home_projects_card_desc=Colabora en proyectos open source.
+
+# Home Page Highlights
+home_pill_social=Social
+home_pill_events=Eventos
+home_pill_project=Proyecto
+home_hero_title_combined=Social · Eventos · Proyecto
+home_hero_desc=Destacados en una página para descubrir rápidamente qué hay de nuevo en la plataforma comunitaria para OSS Santiago.
+
+home_metric_updates=actualizaciones disponibles
+home_metric_upcoming=próximos eventos
+home_metric_contributors=colaboradores activos
+
+home_social_highlights_eyebrow=Destacados sociales
+home_social_highlights_title=Contenido reciente de la comunidad
+home_btn_open_social=Abrir Social
+home_social_empty=Aún no hay actualizaciones sociales cargadas. Abre Social para ver las últimas novedades.
+
+home_events_highlights_eyebrow=Destacados de eventos
+home_events_highlights_title=Agenda próxima
+home_btn_open_events=Abrir Eventos
+home_events_empty=No hay eventos próximos aún. Visita Eventos para sesiones históricas.
+home_event_date_tba=Fecha por confirmar
+home_event_desc_default=Abre el evento para más detalles.
+
+home_project_highlights_eyebrow=Destacados del proyecto
+home_project_highlights_title=Construye con los contribuidores principales
+home_btn_open_project=Abrir Proyecto
+home_project_total_contributions=contribuciones totales
+home_project_release_label=Ultima release
+home_project_commit_label=Ultimo commit
+home_project_contribs_unit=contribs
+home_project_top_contributors=Contribuidores destacados
+home_project_no_data=No hay datos de contribuidores disponibles por el momento.
+home_project_actions_chip=Listo para contribuir
+home_project_actions_title=Elige un camino y comienza
+home_project_actions_desc=Explora las rutas del proyecto, elige un problema y contribuye a través del flujo de trabajo compartido.
+home_btn_explore_tracks=Explorar rutas
+home_btn_view_repo=Ver repositorio

--- a/quarkus-app/src/main/resources/templates/home.qute.html
+++ b/quarkus-app/src/main/resources/templates/home.qute.html
@@ -1,134 +1,127 @@
 {#include layout/main activePage="home"}
-{#title}Home{/title}
+{#title}{i18n.nav_home}{/title}
 {#body}
 <header class="public-header home-highlight-hero">
-  <p class="eyebrow">Home</p>
-  <h1 class="public-title">Social · Events · Project</h1>
+  <p class="eyebrow">{i18n.nav_home}</p>
+  <h1 class="public-title">{i18n.home_hero_title_combined}</h1>
   <p class="tagline">
-    One-page highlights to quickly discover what is new in the Community platform for OSS Santiago.
+    {i18n.home_hero_desc}
   </p>
-  <div class="home-hero-pills">
-    <a href="#social" class="home-hero-pill">Social</a>
-    <a href="#events" class="home-hero-pill">Events</a>
-    <a href="#project" class="home-hero-pill">Project</a>
+  <div class="home-top-metrics">
+    <a href="#home-social" class="home-top-metric">
+      <span class="home-chip">{i18n.home_pill_social}</span>
+      <strong>{socialHighlightsCount}</strong>
+      <small>{i18n.home_metric_updates}</small>
+    </a>
+    <a href="#home-events" class="home-top-metric">
+      <span class="home-chip">{i18n.home_pill_events}</span>
+      <strong>{upcomingCount}</strong>
+      <small>{i18n.home_metric_upcoming}</small>
+    </a>
+    <a href="#home-project" class="home-top-metric">
+      <span class="home-chip">{i18n.home_pill_project}</span>
+      <strong>{projectContributorCount}</strong>
+      <small>{i18n.home_metric_contributors}</small>
+    </a>
   </div>
 </header>
 
-<section class="page-grid home-quick-grid">
-  <a href="/comunidad" class="section-card home-quick-card home-quick-card-social">
-    <span class="material-symbols-outlined home-quick-icon">groups</span>
-    <h2>Social</h2>
-    <p>Community news, curated content and fast discovery.</p>
-    <p class="home-quick-metric">{socialHighlightsCount} updates available</p>
-  </a>
-
-  <a href="/eventos" class="section-card home-quick-card home-quick-card-events">
-    <span class="material-symbols-outlined home-quick-icon">calendar_month</span>
-    <h2>Events</h2>
-    <p>Upcoming meetups and activities with direct access.</p>
-    <p class="home-quick-metric">{upcomingCount} upcoming events</p>
-  </a>
-
-  <a href="/proyectos" class="section-card home-quick-card home-quick-card-project">
-    <span class="material-symbols-outlined home-quick-icon">rocket_launch</span>
-    <h2>Project</h2>
-    <p>Open collaboration, contributors and delivery momentum.</p>
-    <p class="home-quick-metric">{projectContributorCount} active contributors</p>
-  </a>
-</section>
-
-<section class="page-grid home-highlight-grid" id="social">
-  <div class="section-header home-highlight-header home-highlight-full">
-    <p class="section-subtitle">Social highlights</p>
-    <h2 class="page-title">Latest community content</h2>
-    <a href="/comunidad" class="btn-primary">Open Social</a>
-  </div>
-
-  {#if socialHighlights.isEmpty()}
-  <article class="section-card home-highlight-empty home-highlight-full">
-    <span class="material-symbols-outlined">rss_feed</span>
-    <p>No social updates loaded yet. Open Social to check the latest refresh.</p>
-  </article>
-  {#else}
-  {#for item in socialHighlights}
-  <a href="{item.url}" target="_blank" rel="noopener noreferrer" class="section-card home-social-card">
-    <div class="home-card-top">
-      <span class="home-chip">Social</span>
-      <span class="home-source">{item.source}</span>
+<section class="page-grid home-panorama-grid">
+  <article class="section-card home-pane" id="home-social">
+    <div class="home-pane-header">
+      <div>
+        <p class="section-subtitle">{i18n.home_social_highlights_eyebrow}</p>
+        <h2 class="page-title">{i18n.home_social_highlights_title}</h2>
+      </div>
+      <a href="/comunidad" class="btn-primary">{i18n.home_btn_open_social}</a>
     </div>
-    <h3>{item.title}</h3>
-    <p>{item.summary}</p>
-  </a>
-  {/for}
-  {/if}
-</section>
-
-<section class="page-grid home-highlight-grid" id="events">
-  <div class="section-header home-highlight-header home-highlight-full">
-    <p class="section-subtitle">Events highlights</p>
-    <h2 class="page-title">Upcoming agenda</h2>
-    <a href="/eventos" class="btn-primary">Open Events</a>
-  </div>
-
-  {#if popularEvents.isEmpty()}
-  <article class="section-card home-highlight-empty home-highlight-full">
-    <span class="material-symbols-outlined">event_busy</span>
-    <p>No upcoming events yet. Visit Events for historical sessions.</p>
-  </article>
-  {#else}
-  {#for event in popularEvents}
-  <a href="/event/{event.id}" class="section-card home-event-card">
-    <div class="home-card-top">
-      <span class="home-chip">Event</span>
-      <span class="home-source">{event.formattedDate ?: 'Date TBA'}</span>
-    </div>
-    <h3>{event.title}</h3>
-    <p>{event.descriptionSummary ?: 'Open the event for full details.'}</p>
-  </a>
-  {/for}
-  {/if}
-</section>
-
-<section class="page-grid home-highlight-grid" id="project">
-  <div class="section-header home-highlight-header home-highlight-full">
-    <p class="section-subtitle">Project highlights</p>
-    <h2 class="page-title">Build with the core contributors</h2>
-    <a href="/proyectos" class="btn-primary">Open Project</a>
-  </div>
-
-  <article class="section-card home-project-contributors">
-    <div class="home-card-top">
-      <span class="home-chip">Project</span>
-      <span class="home-source">{projectContributionTotal} total contributions</span>
-    </div>
-    <h3>Top contributors</h3>
-
-    {#if projectHighlights.isEmpty()}
-    <p>No contributor data available at the moment.</p>
+    {#if socialHighlights.isEmpty()}
+    <article class="home-highlight-empty">
+      <span class="material-symbols-outlined">rss_feed</span>
+      <p>{i18n.home_social_empty}</p>
+    </article>
     {#else}
-    <div class="home-contributor-grid">
-      {#for contributor in projectHighlights}
-      <a href="{contributor.htmlUrl}" target="_blank" rel="noopener noreferrer" class="home-contributor-card"
-        title="{contributor.login}">
-        <img src="{contributor.avatarUrl}" alt="{contributor.login}" loading="lazy">
-        <span>{contributor.login}</span>
+    <div class="home-pane-list">
+      {#for item in socialHighlights}
+      <a href="{item.url}" target="_blank" rel="noopener noreferrer" class="home-pane-item">
+        <div class="home-card-top">
+          <span class="home-chip">{i18n.home_pill_social}</span>
+          <span class="home-source">{item.source}</span>
+        </div>
+        <h3 class="home-pane-title">{item.title}</h3>
+        <p class="home-pane-summary">{item.summary}</p>
       </a>
       {/for}
     </div>
     {/if}
   </article>
 
-  <article class="section-card home-project-actions">
-    <div class="home-card-top">
-      <span class="home-chip">Project</span>
-      <span class="home-source">Ready to contribute</span>
+  <article class="section-card home-pane" id="home-events">
+    <div class="home-pane-header">
+      <div>
+        <p class="section-subtitle">{i18n.home_events_highlights_eyebrow}</p>
+        <h2 class="page-title">{i18n.home_events_highlights_title}</h2>
+      </div>
+      <a href="/eventos" class="btn-primary">{i18n.home_btn_open_events}</a>
     </div>
-    <h3>Pick a path and start</h3>
-    <p>Explore project tracks, choose an issue, and contribute through the shared workflow.</p>
+    {#if popularEvents.isEmpty()}
+    <article class="home-highlight-empty">
+      <span class="material-symbols-outlined">event_busy</span>
+      <p>{i18n.home_events_empty}</p>
+    </article>
+    {#else}
+    <div class="home-pane-list">
+      {#for event in popularEvents}
+      <a href="/event/{event.id}" class="home-pane-item">
+        <div class="home-card-top">
+          <span class="home-chip">{i18n.home_pill_events}</span>
+          <span class="home-source">{event.formattedDate ?: i18n.home_event_date_tba}</span>
+        </div>
+        <h3 class="home-pane-title">{event.title}</h3>
+        <p class="home-pane-summary">{event.descriptionSummary ?: i18n.home_event_desc_default}</p>
+      </a>
+      {/for}
+    </div>
+    {/if}
+  </article>
+
+  <article class="section-card home-pane" id="home-project">
+    <div class="home-pane-header">
+      <div>
+        <p class="section-subtitle">{i18n.home_project_highlights_eyebrow}</p>
+        <h2 class="page-title">{i18n.home_project_highlights_title}</h2>
+      </div>
+      <a href="/proyectos" class="btn-primary">{i18n.home_btn_open_project}</a>
+    </div>
+
+    <div class="home-project-brief">
+      <p><span>{i18n.home_project_release_label}</span><strong>v{app:version()}</strong></p>
+      <p><span>{i18n.home_project_commit_label}</span><strong>{app:gitCommit()}</strong></p>
+      <p><span>{i18n.home_metric_contributors}</span><strong>{projectContributorCount}</strong></p>
+      <p><span>{i18n.home_project_total_contributions}</span><strong>{projectContributionTotal}</strong></p>
+    </div>
+
+    {#if projectHighlights.isEmpty()}
+    <p class="home-pane-summary">{i18n.home_project_no_data}</p>
+    {#else}
+    <div class="home-contributor-grid home-contributor-grid-compact">
+      {#for contributor in projectHighlights}
+      <a href="{contributor.htmlUrl}" target="_blank" rel="noopener noreferrer" class="home-contributor-card"
+        title="{contributor.login}">
+        <span class="home-contributor-avatar-shell">
+          <img src="{contributor.avatarUrl}" alt="{contributor.login}" loading="lazy" class="home-contributor-avatar">
+        </span>
+        <span class="home-contributor-login">{contributor.login}</span>
+        <span class="home-contributor-meta">{contributor.contributions} {i18n.home_project_contribs_unit}</span>
+      </a>
+      {/for}
+    </div>
+    {/if}
+
     <div class="home-project-actions-row">
-      <a href="/proyectos" class="btn-primary">Explore tracks</a>
+      <a href="/proyectos" class="btn-primary">{i18n.home_btn_explore_tracks}</a>
       <a href="https://github.com/os-santiago/homedir" target="_blank" rel="noopener noreferrer" class="btn-primary">
-        View repository
+        {i18n.home_btn_view_repo}
       </a>
     </div>
   </article>


### PR DESCRIPTION
## Summary
- redesign Home into a compact one-page layout focused on highlights from Social, Events, and Project
- replace oversized top quick cards with compact metric anchors and 3 side-by-side content panes
- add project release/commit brief and compact contributor cards for at-a-glance project activity
- tune backend limits for home highlights (3 social, 3 events, 6 contributors)
- add i18n keys (EN/ES) and template extension helper for git commit display

## Validation
- mvn -f quarkus-app/pom.xml "-Dtest=HomePastEventsTest,HomeTimelineTest,NotificationsMenuTest" test