### PR TITLE
fix(home): use short Open labels and cache contributors

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
@@ -685,7 +685,7 @@ public interface AppMessages {
     @Message("Latest community content")
     String home_social_highlights_title();
 
-    @Message("Open Social")
+    @Message("Open")
     String home_btn_open_social();
 
     @Message("No social updates loaded yet. Open Social to check the latest refresh.")
@@ -697,7 +697,7 @@ public interface AppMessages {
     @Message("Upcoming agenda")
     String home_events_highlights_title();
 
-    @Message("Open Events")
+    @Message("Open")
     String home_btn_open_events();
 
     @Message("No upcoming events yet. Visit Events for historical sessions.")
@@ -715,7 +715,7 @@ public interface AppMessages {
     @Message("Build with the core contributors")
     String home_project_highlights_title();
 
-    @Message("Open Project")
+    @Message("Open")
     String home_btn_open_project();
 
     @Message("total contributions")

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
@@ -54,7 +54,7 @@ public class PublicPagesResource {
 
   @GET
   public TemplateInstance home() {
-    List<GithubContributor> contributors = githubService.fetchContributors("os-santiago", "homedir");
+    List<GithubContributor> contributors = githubService.fetchHomeProjectContributors();
     List<GithubContributor> projectHighlights = contributors.stream().limit(6).toList();
     int contributionTotal = contributors.stream().mapToInt(GithubContributor::contributions).sum();
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/GithubService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/GithubService.java
@@ -2,6 +2,9 @@ package com.scanales.eventflow.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.io.IOException;
@@ -12,9 +15,16 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -22,6 +32,7 @@ public class GithubService {
 
   private static final Logger LOG = Logger.getLogger(GithubService.class);
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+  private static final Duration DEFAULT_CONTRIBUTORS_CACHE_TTL = Duration.ofHours(24);
   private static final int MAX_CONTRIBUTORS = 10;
 
   @Inject
@@ -30,9 +41,58 @@ public class GithubService {
   @Inject
   Config config;
 
+  @Inject
+  @ConfigProperty(name = "home.project.github.repo-owner", defaultValue = "os-santiago")
+  String homeProjectRepoOwner;
+
+  @Inject
+  @ConfigProperty(name = "home.project.github.repo-name", defaultValue = "homedir")
+  String homeProjectRepoName;
+
+  @Inject
+  @ConfigProperty(name = "home.project.github.cache-ttl", defaultValue = "PT24H")
+  Duration contributorsCacheTtl;
+
+  @Inject
+  @ConfigProperty(name = "home.project.github.retry-interval", defaultValue = "PT15M")
+  Duration contributorsRetryInterval;
+
   private final HttpClient httpClient = HttpClient.newBuilder()
       .connectTimeout(REQUEST_TIMEOUT)
       .build();
+  private final AtomicReference<ContributorsCacheSnapshot> contributorsCache =
+      new AtomicReference<>(ContributorsCacheSnapshot.empty());
+  private final AtomicBoolean contributorsRefreshInProgress = new AtomicBoolean(false);
+  private final ExecutorService contributorsRefreshExecutor =
+      Executors.newSingleThreadExecutor(
+          new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+              Thread t = new Thread(r, "github-contributors-refresh");
+              t.setDaemon(true);
+              return t;
+            }
+          });
+
+  @PostConstruct
+  void initContributorsCache() {
+    triggerContributorsRefreshAsync(true, "startup");
+  }
+
+  @PreDestroy
+  void shutdown() {
+    contributorsRefreshExecutor.shutdownNow();
+  }
+
+  @Scheduled(every = "{home.project.github.refresh-interval:24h}")
+  void scheduledContributorsRefresh() {
+    triggerContributorsRefreshAsync(true, "schedule");
+  }
+
+  public List<GithubContributor> fetchHomeProjectContributors() {
+    maybeRefreshContributorsOnDemand();
+    return contributorsCache.get().contributors();
+  }
 
   public String exchangeCode(String code) throws IOException, InterruptedException {
     HttpRequest tokenRequest = HttpRequest.newBuilder()
@@ -88,8 +148,16 @@ public class GithubService {
   }
 
   public List<GithubContributor> fetchContributors(String owner, String repo) {
+    return loadContributorsFromGithub(owner, repo);
+  }
+
+  List<GithubContributor> loadContributorsFromGithub(String owner, String repo) {
+    if (owner == null || owner.isBlank() || repo == null || repo.isBlank()) {
+      return List.of();
+    }
     try {
-      HttpRequest request = HttpRequest.newBuilder()
+      String githubToken = getGithubApiToken();
+      HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
           .uri(
               URI.create(
                   "https://api.github.com/repos/"
@@ -99,12 +167,17 @@ public class GithubService {
                       + "/contributors?per_page="
                       + MAX_CONTRIBUTORS))
           .timeout(REQUEST_TIMEOUT)
-          .header("Accept", "application/json")
-          .build();
+          .header("Accept", "application/vnd.github+json")
+          .header("X-GitHub-Api-Version", "2022-11-28")
+          .header("User-Agent", "homedir-service");
+      if (!githubToken.isBlank()) {
+        requestBuilder.header("Authorization", "Bearer " + githubToken);
+      }
+      HttpRequest request = requestBuilder.build();
 
       HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
       if (response.statusCode() >= 400) {
-        LOG.warnf("GitHub contributors fetch failed: %s", response.body());
+        LOG.warnf("GitHub contributors fetch failed status=%d body=%s", response.statusCode(), response.body());
         return List.of();
       }
 
@@ -135,12 +208,117 @@ public class GithubService {
     }
   }
 
+  void refreshHomeProjectContributorsNowForTests() {
+    refreshHomeProjectContributors("test");
+  }
+
+  private void maybeRefreshContributorsOnDemand() {
+    triggerContributorsRefreshAsync(false, "on-demand");
+  }
+
+  private void triggerContributorsRefreshAsync(boolean force, String reason) {
+    ContributorsCacheSnapshot snapshot = contributorsCache.get();
+    Instant now = Instant.now();
+    if (!force && !shouldRefresh(snapshot, now)) {
+      return;
+    }
+    if (!contributorsRefreshInProgress.compareAndSet(false, true)) {
+      return;
+    }
+    contributorsRefreshExecutor.submit(
+        () -> {
+          try {
+            refreshHomeProjectContributors(reason);
+          } finally {
+            contributorsRefreshInProgress.set(false);
+          }
+        });
+  }
+
+  private void refreshHomeProjectContributors(String reason) {
+    Instant startedAt = Instant.now();
+    List<GithubContributor> loaded = loadContributorsFromGithub(homeProjectRepoOwner, homeProjectRepoName);
+    long durationMs = Duration.between(startedAt, Instant.now()).toMillis();
+    ContributorsCacheSnapshot previous = contributorsCache.get();
+    Instant attemptedAt = Instant.now();
+
+    if (!loaded.isEmpty()) {
+      contributorsCache.set(
+          new ContributorsCacheSnapshot(
+              List.copyOf(loaded),
+              attemptedAt,
+              attemptedAt,
+              durationMs,
+              true));
+      LOG.infov(
+          "GitHub contributors cache refreshed reason={0} contributors={1} durationMs={2}",
+          reason,
+          loaded.size(),
+          durationMs);
+      return;
+    }
+
+    if (!previous.contributors().isEmpty()) {
+      contributorsCache.set(
+          new ContributorsCacheSnapshot(
+              previous.contributors(),
+              previous.loadedAt(),
+              attemptedAt,
+              durationMs,
+              false));
+      LOG.warnv(
+          "GitHub contributors refresh returned empty reason={0}; keeping cached contributors={1}",
+          reason,
+          previous.contributors().size());
+      return;
+    }
+
+    contributorsCache.set(
+        new ContributorsCacheSnapshot(
+            List.of(),
+            previous.loadedAt(),
+            attemptedAt,
+            durationMs,
+            false));
+    LOG.warnv("GitHub contributors cache is empty after refresh reason={0}", reason);
+  }
+
+  private Duration effectiveCacheTtl() {
+    if (contributorsCacheTtl == null || contributorsCacheTtl.isNegative() || contributorsCacheTtl.isZero()) {
+      return DEFAULT_CONTRIBUTORS_CACHE_TTL;
+    }
+    return contributorsCacheTtl;
+  }
+
+  private Duration effectiveRetryInterval() {
+    if (contributorsRetryInterval == null
+        || contributorsRetryInterval.isNegative()
+        || contributorsRetryInterval.isZero()) {
+      return Duration.ofMinutes(15);
+    }
+    return contributorsRetryInterval;
+  }
+
+  private boolean shouldRefresh(ContributorsCacheSnapshot snapshot, Instant now) {
+    if (snapshot.loadedAt() != null && now.isBefore(snapshot.loadedAt().plus(effectiveCacheTtl()))) {
+      return false;
+    }
+    if (snapshot.lastAttemptAt() == null) {
+      return true;
+    }
+    return now.isAfter(snapshot.lastAttemptAt().plus(effectiveRetryInterval()));
+  }
+
   private String getGithubClientId() {
     return config.getOptionalValue("GH_CLIENT_ID", String.class).orElse("");
   }
 
   private String getGithubClientSecret() {
     return config.getOptionalValue("GH_CLIENT_SECRET", String.class).orElse("");
+  }
+
+  private String getGithubApiToken() {
+    return config.getOptionalValue("GH_TOKEN", String.class).orElse("").trim();
   }
 
   private String url(String value) {
@@ -151,5 +329,16 @@ public class GithubService {
   }
 
   public record GithubContributor(String login, String avatarUrl, String htmlUrl, int contributions) {
+  }
+
+  private record ContributorsCacheSnapshot(
+      List<GithubContributor> contributors,
+      Instant loadedAt,
+      Instant lastAttemptAt,
+      long lastLoadDurationMs,
+      boolean lastAttemptSucceeded) {
+    static ContributorsCacheSnapshot empty() {
+      return new ContributorsCacheSnapshot(List.of(), null, null, 0L, false);
+    }
   }
 }

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -154,6 +154,13 @@ community.content.featured.window-days=7
 community.content.ranking.decay-enabled=true
 community.votes.daily-limit=100
 
+# Home project contributors cache
+home.project.github.repo-owner=os-santiago
+home.project.github.repo-name=homedir
+home.project.github.cache-ttl=PT24H
+home.project.github.retry-interval=PT15M
+home.project.github.refresh-interval=24h
+
 # Now box configuration
 nowbox.enabled=true
 nowbox.lookback=PT30M

--- a/quarkus-app/src/main/resources/messages.properties
+++ b/quarkus-app/src/main/resources/messages.properties
@@ -234,19 +234,19 @@ home_metric_contributors=active contributors
 
 home_social_highlights_eyebrow=Social highlights
 home_social_highlights_title=Latest community content
-home_btn_open_social=Open Social
+home_btn_open_social=Open
 home_social_empty=No social updates loaded yet. Open Social to check the latest refresh.
 
 home_events_highlights_eyebrow=Events highlights
 home_events_highlights_title=Upcoming agenda
-home_btn_open_events=Open Events
+home_btn_open_events=Open
 home_events_empty=No upcoming events yet. Visit Events for historical sessions.
 home_event_date_tba=Date TBA
 home_event_desc_default=Open the event for full details.
 
 home_project_highlights_eyebrow=Project highlights
 home_project_highlights_title=Build with the core contributors
-home_btn_open_project=Open Project
+home_btn_open_project=Open
 home_project_total_contributions=total contributions
 home_project_release_label=Latest release
 home_project_commit_label=Latest commit

--- a/quarkus-app/src/main/resources/messages_es.properties
+++ b/quarkus-app/src/main/resources/messages_es.properties
@@ -231,19 +231,19 @@ home_metric_contributors=colaboradores activos
 
 home_social_highlights_eyebrow=Destacados sociales
 home_social_highlights_title=Contenido reciente de la comunidad
-home_btn_open_social=Abrir Social
+home_btn_open_social=Open
 home_social_empty=Aún no hay actualizaciones sociales cargadas. Abre Social para ver las últimas novedades.
 
 home_events_highlights_eyebrow=Destacados de eventos
 home_events_highlights_title=Agenda próxima
-home_btn_open_events=Abrir Eventos
+home_btn_open_events=Open
 home_events_empty=No hay eventos próximos aún. Visita Eventos para sesiones históricas.
 home_event_date_tba=Fecha por confirmar
 home_event_desc_default=Abre el evento para más detalles.
 
 home_project_highlights_eyebrow=Destacados del proyecto
 home_project_highlights_title=Construye con los contribuidores principales
-home_btn_open_project=Abrir Proyecto
+home_btn_open_project=Open
 home_project_total_contributions=contribuciones totales
 home_project_release_label=Ultima release
 home_project_commit_label=Ultimo commit

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/GithubServiceCacheTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/GithubServiceCacheTest.java
@@ -1,0 +1,92 @@
+package com.scanales.eventflow.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Optional;
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class GithubServiceCacheTest {
+
+  @Test
+  void keepsContributorsInMemoryBetweenRequests() {
+    StubGithubService service = newService();
+    service.enqueue(
+        List.of(new GithubService.GithubContributor("alice", "https://avatar", "https://profile", 5)));
+
+    service.refreshHomeProjectContributorsNowForTests();
+    List<GithubService.GithubContributor> first = service.fetchHomeProjectContributors();
+    List<GithubService.GithubContributor> second = service.fetchHomeProjectContributors();
+
+    assertEquals(1, service.fetchCalls);
+    assertEquals(1, first.size());
+    assertSame(first, second);
+    assertEquals("os-santiago", service.lastOwner);
+    assertEquals("homedir", service.lastRepo);
+  }
+
+  @Test
+  void keepsLastSuccessfulSnapshotWhenRefreshReturnsEmpty() {
+    StubGithubService service = newService();
+    service.enqueue(
+        List.of(new GithubService.GithubContributor("alice", "https://avatar", "https://profile", 5)));
+    service.refreshHomeProjectContributorsNowForTests();
+
+    service.enqueue(List.of());
+    service.refreshHomeProjectContributorsNowForTests();
+    List<GithubService.GithubContributor> contributors = service.fetchHomeProjectContributors();
+
+    assertEquals(2, service.fetchCalls);
+    assertFalse(contributors.isEmpty());
+    assertEquals("alice", contributors.getFirst().login());
+  }
+
+  private StubGithubService newService() {
+    StubGithubService service = new StubGithubService();
+    service.objectMapper = new ObjectMapper();
+    service.config = mockConfig();
+    service.homeProjectRepoOwner = "os-santiago";
+    service.homeProjectRepoName = "homedir";
+    service.contributorsCacheTtl = Duration.ofHours(24);
+    return service;
+  }
+
+  private Config mockConfig() {
+    Config cfg = Mockito.mock(Config.class);
+    when(cfg.getOptionalValue(eq("GH_TOKEN"), eq(String.class))).thenReturn(Optional.empty());
+    when(cfg.getOptionalValue(eq("GH_CLIENT_ID"), eq(String.class))).thenReturn(Optional.empty());
+    when(cfg.getOptionalValue(eq("GH_CLIENT_SECRET"), eq(String.class))).thenReturn(Optional.empty());
+    return cfg;
+  }
+
+  static class StubGithubService extends GithubService {
+    final ArrayDeque<List<GithubService.GithubContributor>> queuedResponses = new ArrayDeque<>();
+    int fetchCalls = 0;
+    String lastOwner = null;
+    String lastRepo = null;
+
+    @Override
+    List<GithubService.GithubContributor> loadContributorsFromGithub(String owner, String repo) {
+      fetchCalls++;
+      lastOwner = owner;
+      lastRepo = repo;
+      if (queuedResponses.isEmpty()) {
+        return List.of();
+      }
+      return queuedResponses.removeFirst();
+    }
+
+    void enqueue(List<GithubService.GithubContributor> contributors) {
+      queuedResponses.addLast(contributors);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- change Home pane action labels from `Open Social / Open Events / Open Project` to a short `Open` to avoid clipping on small widths
- switch Home contributors loading to an in-memory cache with daily TTL (`PT24H`) instead of fetching GitHub on every request
- add scheduled refresh (`24h`) plus retry window (`PT15M`) to avoid repeated calls when GitHub is unavailable
- keep last successful contributors snapshot when a refresh returns empty/fails
- add GitHub API request hardening (`User-Agent`, API version header, optional `GH_TOKEN` auth)
- add unit tests for contributors cache behavior

## Config
- `home.project.github.repo-owner`
- `home.project.github.repo-name`
- `home.project.github.cache-ttl`
- `home.project.github.retry-interval`
- `home.project.github.refresh-interval`

## Validation
- `mvn -f quarkus-app/pom.xml "-Dtest=GithubServiceCacheTest,HomePastEventsTest,HomeTimelineTest,NotificationsMenuTest" test`