### PR TITLE
feat(project): renovate Project section for Homedir dashboard

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/ProjectsResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/ProjectsResource.java
@@ -1,37 +1,103 @@
 package com.scanales.eventflow.public_;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scanales.eventflow.service.GithubService;
+import com.scanales.eventflow.service.GithubService.GithubContributor;
 import com.scanales.eventflow.service.UsageMetricsService;
 import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
+import io.quarkus.scheduler.Scheduled;
 import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
 
 @Path("/proyectos")
 public class ProjectsResource {
+  private static final Logger LOG = Logger.getLogger(ProjectsResource.class);
+  private static final int MAX_RELEASES = 8;
+  private static final Duration DEFAULT_CACHE_TTL = Duration.ofHours(6);
+  private static final Duration DEFAULT_RETRY_INTERVAL = Duration.ofMinutes(15);
+
+  @Inject UsageMetricsService metrics;
+  @Inject SecurityIdentity identity;
+  @Inject ObjectMapper mapper;
+  @Inject Config config;
+  @Inject GithubService githubService;
 
   @Inject
-  UsageMetricsService metrics;
+  @ConfigProperty(name = "home.project.github.repo-owner", defaultValue = "os-santiago")
+  String repoOwner;
+
   @Inject
-  SecurityIdentity identity;
+  @ConfigProperty(name = "home.project.github.repo-name", defaultValue = "homedir")
+  String repoName;
+
   @Inject
-  com.fasterxml.jackson.databind.ObjectMapper mapper;
-  @jakarta.inject.Inject
-  org.eclipse.microprofile.config.Config config;
+  @ConfigProperty(name = "projects.homedir.cache-ttl", defaultValue = "PT6H")
+  Duration cacheTtl;
+
+  @Inject
+  @ConfigProperty(name = "projects.homedir.retry-interval", defaultValue = "PT15M")
+  Duration retryInterval;
 
   @CheckedTemplate
   static class Templates {
-    static native TemplateInstance proyectos(List<ProjectCard> projects);
+    static native TemplateInstance proyectos(ProjectDashboard dashboard);
   }
 
-  private final java.net.http.HttpClient client = java.net.http.HttpClient.newBuilder().build();
-  private final java.util.concurrent.atomic.AtomicReference<List<ProjectCard>> cache = new java.util.concurrent.atomic.AtomicReference<>();
-  private volatile java.time.Instant lastFetch = java.time.Instant.MIN;
+  private final HttpClient client = HttpClient.newBuilder().build();
+  private final AtomicReference<ProjectSnapshot> snapshotCache =
+      new AtomicReference<>(ProjectSnapshot.empty());
+  private final AtomicBoolean refreshInProgress = new AtomicBoolean(false);
+  private final ExecutorService refreshExecutor =
+      Executors.newSingleThreadExecutor(
+          new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+              Thread t = new Thread(r, "projects-homedir-refresh");
+              t.setDaemon(true);
+              return t;
+            }
+          });
+
+  @PostConstruct
+  void init() {
+    triggerRefreshAsync(true, "startup");
+  }
+
+  @PreDestroy
+  void shutdown() {
+    refreshExecutor.shutdownNow();
+  }
+
+  @Scheduled(every = "{projects.homedir.refresh-interval:6h}")
+  void scheduledRefresh() {
+    triggerRefreshAsync(true, "schedule");
+  }
 
   @GET
   @PermitAll
@@ -40,63 +106,323 @@ public class ProjectsResource {
       @jakarta.ws.rs.core.Context jakarta.ws.rs.core.HttpHeaders headers,
       @jakarta.ws.rs.core.Context io.vertx.ext.web.RoutingContext context) {
     metrics.recordPageView("/proyectos", headers, context);
-    List<ProjectCard> projects = getProjects();
-    TemplateInstance template = Templates.proyectos(projects);
+
+    ProjectSnapshot snapshot = currentSnapshot();
+    List<GithubContributor> contributors = githubService.fetchHomeProjectContributors();
+    ProjectDashboard dashboard = buildDashboard(snapshot, contributors);
+    TemplateInstance template = Templates.proyectos(dashboard);
     return withLayoutData(template, "proyectos");
   }
 
-  private List<ProjectCard> getProjects() {
-    if (java.time.Instant.now().isBefore(lastFetch.plusSeconds(3600)) && cache.get() != null) {
-      return cache.get();
-    }
-    try {
-      java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
-          .uri(java.net.URI.create("https://api.github.com/orgs/os-santiago/repos?sort=updated&per_page=100"))
-          .header("Accept", "application/vnd.github+json")
-          .GET()
-          .build();
-
-      // Add token if available to avoid rate limits
-      String token = config.getOptionalValue("GH_TOKEN", String.class).orElse("");
-      if (!token.isBlank()) {
-        request = java.net.http.HttpRequest.newBuilder(request.uri())
-            .header("Authorization", "Bearer " + token)
-            .header("Accept", "application/vnd.github+json")
-            .GET()
-            .build();
-      }
-
-      var response = client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString());
-      if (response.statusCode() == 200) {
-        com.fasterxml.jackson.databind.JsonNode root = mapper.readTree(response.body());
-        List<ProjectCard> list = new java.util.ArrayList<>();
-        if (root.isArray()) {
-          for (com.fasterxml.jackson.databind.JsonNode node : root) {
-            if (node.path("archived").asBoolean(false))
-              continue;
-            String name = node.path("name").asText();
-            String desc = node.path("description").asText("Sin oscripción");
-            String url = node.path("html_url").asText();
-            String lang = node.path("language").asText("General");
-            list.add(new ProjectCard(name, desc, "Activo", url, lang));
-          }
-        }
-        // Custom additions or overrides could go here
-        list.add(new ProjectCard("Comunidad", "Directorio de integrantes.", "En diseño", "/comunidad", "Personas"));
-
-        cache.set(list);
-        lastFetch = java.time.Instant.now();
-        return list;
-      }
-    } catch (Exception e) {
-      // Log error and return cached or empty
-      e.printStackTrace();
-    }
-    return cache.get() != null ? cache.get() : List.of();
+  private ProjectSnapshot currentSnapshot() {
+    triggerRefreshAsync(false, "on-demand");
+    return snapshotCache.get();
   }
 
-  public record ProjectCard(
-      String name, String description, String status, String link, String tag) {
+  private void triggerRefreshAsync(boolean force, String reason) {
+    ProjectSnapshot snapshot = snapshotCache.get();
+    Instant now = Instant.now();
+    if (!force && !shouldRefresh(snapshot, now)) {
+      return;
+    }
+    if (!refreshInProgress.compareAndSet(false, true)) {
+      return;
+    }
+    refreshExecutor.submit(
+        () -> {
+          try {
+            refreshNow(reason);
+          } finally {
+            refreshInProgress.set(false);
+          }
+        });
+  }
+
+  private boolean shouldRefresh(ProjectSnapshot snapshot, Instant now) {
+    if (snapshot.loadedAt() != null && now.isBefore(snapshot.loadedAt().plus(effectiveCacheTtl()))) {
+      return false;
+    }
+    if (snapshot.lastAttemptAt() == null) {
+      return true;
+    }
+    return now.isAfter(snapshot.lastAttemptAt().plus(effectiveRetryInterval()));
+  }
+
+  private Duration effectiveCacheTtl() {
+    if (cacheTtl == null || cacheTtl.isNegative() || cacheTtl.isZero()) {
+      return DEFAULT_CACHE_TTL;
+    }
+    return cacheTtl;
+  }
+
+  private Duration effectiveRetryInterval() {
+    if (retryInterval == null || retryInterval.isNegative() || retryInterval.isZero()) {
+      return DEFAULT_RETRY_INTERVAL;
+    }
+    return retryInterval;
+  }
+
+  private void refreshNow(String reason) {
+    Instant startedAt = Instant.now();
+    ProjectRepository repository = loadRepository();
+    List<ProjectReleaseRaw> releases = loadReleases();
+    long durationMs = Duration.between(startedAt, Instant.now()).toMillis();
+
+    ProjectSnapshot previous = snapshotCache.get();
+    Instant attemptedAt = Instant.now();
+
+    ProjectRepository resolvedRepository = repository != null ? repository : previous.repository();
+    List<ProjectReleaseRaw> resolvedReleases =
+        !releases.isEmpty() ? List.copyOf(releases) : previous.releases();
+    boolean success = repository != null || !releases.isEmpty();
+    Instant loadedAt = success ? attemptedAt : previous.loadedAt();
+
+    ProjectSnapshot updated =
+        new ProjectSnapshot(
+            resolvedRepository, resolvedReleases, loadedAt, attemptedAt, durationMs, success);
+    snapshotCache.set(updated);
+
+    if (success) {
+      LOG.infov(
+          "Homedir project dashboard cache refreshed reason={0} releases={1} durationMs={2}",
+          reason,
+          resolvedReleases.size(),
+          durationMs);
+    } else {
+      LOG.warnv(
+          "Homedir project dashboard refresh failed reason={0}; keeping previous snapshot", reason);
+    }
+  }
+
+  private ProjectRepository loadRepository() {
+    try {
+      HttpRequest request =
+          githubRequestBuilder(URI.create("https://api.github.com/repos/" + repoOwner + "/" + repoName))
+              .GET()
+              .build();
+      HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() >= 400) {
+        LOG.warnf(
+            "Homedir repository fetch failed status=%d body=%s", response.statusCode(), response.body());
+        return null;
+      }
+      JsonNode node = mapper.readTree(response.body());
+      return new ProjectRepository(
+          node.path("name").asText(repoName),
+          node.path("description").asText("Open source platform for OSS Santiago community operations."),
+          node.path("html_url").asText("https://github.com/" + repoOwner + "/" + repoName),
+          node.path("stargazers_count").asInt(0),
+          node.path("forks_count").asInt(0),
+          node.path("open_issues_count").asInt(0),
+          node.path("subscribers_count").asInt(node.path("watchers_count").asInt(0)),
+          parseInstant(node.path("pushed_at").asText(null)));
+    } catch (Exception e) {
+      LOG.warn("Homedir repository fetch failed", e);
+      return null;
+    }
+  }
+
+  private List<ProjectReleaseRaw> loadReleases() {
+    try {
+      HttpRequest request =
+          githubRequestBuilder(
+                  URI.create(
+                      "https://api.github.com/repos/"
+                          + repoOwner
+                          + "/"
+                          + repoName
+                          + "/releases?per_page="
+                          + MAX_RELEASES))
+              .GET()
+              .build();
+      HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() >= 400) {
+        LOG.warnf("Homedir releases fetch failed status=%d body=%s", response.statusCode(), response.body());
+        return List.of();
+      }
+      JsonNode root = mapper.readTree(response.body());
+      if (!root.isArray()) {
+        return List.of();
+      }
+      List<ProjectReleaseRaw> releases = new ArrayList<>();
+      for (JsonNode node : root) {
+        if (node.path("draft").asBoolean(false)) {
+          continue;
+        }
+        String tag = node.path("tag_name").asText("");
+        if (tag.isBlank()) {
+          continue;
+        }
+        String name = node.path("name").asText("").trim();
+        String label = name.isBlank() ? tag : name;
+        releases.add(
+            new ProjectReleaseRaw(
+                tag,
+                label,
+                node.path("html_url")
+                    .asText("https://github.com/" + repoOwner + "/" + repoName + "/releases"),
+                parseInstant(node.path("published_at").asText(null)),
+                node.path("prerelease").asBoolean(false)));
+      }
+      return releases;
+    } catch (Exception e) {
+      LOG.warn("Homedir releases fetch failed", e);
+      return List.of();
+    }
+  }
+
+  private HttpRequest.Builder githubRequestBuilder(URI uri) {
+    HttpRequest.Builder builder =
+        HttpRequest.newBuilder(uri)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", "homedir-project-dashboard");
+    String token = config.getOptionalValue("GH_TOKEN", String.class).orElse("").trim();
+    if (!token.isBlank()) {
+      builder.header("Authorization", "Bearer " + token);
+    }
+    return builder;
+  }
+
+  private ProjectDashboard buildDashboard(
+      ProjectSnapshot snapshot, List<GithubContributor> contributors) {
+    List<ProjectFeature> features = defaultFeatures();
+    int liveFeatures = (int) features.stream().filter(feature -> "live".equals(feature.statusClass())).count();
+    int betaFeatures = (int) features.stream().filter(feature -> "beta".equals(feature.statusClass())).count();
+    int nextFeatures = (int) features.stream().filter(feature -> "next".equals(feature.statusClass())).count();
+
+    int weightedProgress = (liveFeatures * 100) + (betaFeatures * 65) + (nextFeatures * 30);
+    int maxProgress = Math.max(1, features.size() * 100);
+    int progressPercent = Math.min(100, (int) Math.round((weightedProgress * 100d) / maxProgress));
+
+    List<GithubContributor> topContributors = contributors.stream().limit(8).toList();
+    int totalContributions = contributors.stream().mapToInt(GithubContributor::contributions).sum();
+
+    List<ProjectRelease> releaseCards =
+        snapshot.releases().stream()
+            .map(
+                release ->
+                    new ProjectRelease(
+                        release.tag(),
+                        release.label(),
+                        release.url(),
+                        relativeTime(release.publishedAt()),
+                        release.prerelease()))
+            .toList();
+
+    String latestRelease = releaseCards.isEmpty() ? "No releases publicadas" : releaseCards.getFirst().label();
+    String latestReleaseAgo =
+        releaseCards.isEmpty() ? "n/d" : releaseCards.getFirst().publishedAgo();
+
+    List<ProjectHighlight> highlights =
+        List.of(
+            new ProjectHighlight(
+                "Cadencia de releases",
+                releaseCards.isEmpty() ? "Sin releases recientes" : releaseCards.size() + " releases recientes",
+                latestReleaseAgo + " desde la última publicación"),
+            new ProjectHighlight(
+                "Salud del backlog",
+                snapshot.repository().openIssues() + " issues abiertas",
+                "Controlado desde GitHub Issues"),
+            new ProjectHighlight(
+                "Actividad de código",
+                relativeTime(snapshot.repository().lastPushAt()),
+                "Último push al repositorio principal"));
+
+    return new ProjectDashboard(
+        snapshot.repository(),
+        progressPercent,
+        liveFeatures,
+        betaFeatures,
+        nextFeatures,
+        contributors.size(),
+        totalContributions,
+        latestRelease,
+        latestReleaseAgo,
+        relativeTime(snapshot.repository().lastPushAt()),
+        relativeTime(snapshot.loadedAt()),
+        releaseCards,
+        features,
+        topContributors,
+        highlights);
+  }
+
+  private List<ProjectFeature> defaultFeatures() {
+    return List.of(
+        new ProjectFeature(
+            "Curated Community Feed",
+            "Ingesta file-based con ranking, votos 3 estados y destacados semanales.",
+            "LIVE",
+            "live",
+            "/comunidad"),
+        new ProjectFeature(
+            "Events Persistence",
+            "Persistencia de eventos para sobrevivir reinicios y nuevos despliegues.",
+            "LIVE",
+            "live",
+            "/eventos"),
+        new ProjectFeature(
+            "One-page Home Highlights",
+            "Home compacto con Social, Events y Project en una vista rápida.",
+            "LIVE",
+            "live",
+            "/"),
+        new ProjectFeature(
+            "Global Notifications",
+            "Notificaciones globales en tiempo real con WebSocket y centro unificado.",
+            "BETA",
+            "beta",
+            "/notifications/center"),
+        new ProjectFeature(
+            "Contributor Telemetry Cache",
+            "Métricas de contribuidores cacheadas para evitar consultas por request.",
+            "BETA",
+            "beta",
+            "/proyectos"),
+        new ProjectFeature(
+            "ADev Practitioner Playbook",
+            "Formalizar la línea base ADev como guía operativa para próximos ciclos.",
+            "NEXT",
+            "next",
+            "https://github.com/scanalesespinoza/adev"));
+  }
+
+  private Instant parseInstant(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return null;
+    }
+    try {
+      return Instant.parse(raw);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  private String relativeTime(Instant date) {
+    if (date == null) {
+      return "n/d";
+    }
+    long minutes = ChronoUnit.MINUTES.between(date, Instant.now());
+    if (minutes < 1) {
+      return "ahora";
+    }
+    if (minutes < 60) {
+      return "hace " + minutes + "m";
+    }
+    long hours = minutes / 60;
+    if (hours < 24) {
+      return "hace " + hours + "h";
+    }
+    long days = hours / 24;
+    if (days < 30) {
+      return "hace " + days + "d";
+    }
+    long months = days / 30;
+    if (months < 12) {
+      return "hace " + months + "mo";
+    }
+    long years = months / 12;
+    return "hace " + years + "a";
   }
 
   private TemplateInstance withLayoutData(TemplateInstance templateInstance, String activePage) {
@@ -118,5 +444,87 @@ public class ProjectsResource {
       return null;
     }
     return trimmed.substring(0, 1).toUpperCase();
+  }
+
+  public record ProjectDashboard(
+      ProjectRepository repository,
+      int progressPercent,
+      int liveFeatures,
+      int betaFeatures,
+      int nextFeatures,
+      int contributorCount,
+      int totalContributions,
+      String latestRelease,
+      String latestReleaseAgo,
+      String lastPushAgo,
+      String snapshotAgo,
+      List<ProjectRelease> releases,
+      List<ProjectFeature> features,
+      List<GithubContributor> topContributors,
+      List<ProjectHighlight> highlights) {
+  }
+
+  public record ProjectRepository(
+      String name,
+      String description,
+      String htmlUrl,
+      int stars,
+      int forks,
+      int openIssues,
+      int watchers,
+      Instant lastPushAt) {
+    static ProjectRepository empty() {
+      return new ProjectRepository(
+          "homedir",
+          "Open source platform for OSS Santiago community operations.",
+          "https://github.com/os-santiago/homedir",
+          0,
+          0,
+          0,
+          0,
+          null);
+    }
+  }
+
+  public record ProjectRelease(
+      String tag,
+      String label,
+      String url,
+      String publishedAgo,
+      boolean prerelease) {
+  }
+
+  public record ProjectReleaseRaw(
+      String tag,
+      String label,
+      String url,
+      Instant publishedAt,
+      boolean prerelease) {
+  }
+
+  public record ProjectFeature(
+      String title,
+      String description,
+      String statusLabel,
+      String statusClass,
+      String href) {
+  }
+
+  public record ProjectHighlight(
+      String title,
+      String value,
+      String note) {
+  }
+
+  private record ProjectSnapshot(
+      ProjectRepository repository,
+      List<ProjectReleaseRaw> releases,
+      Instant loadedAt,
+      Instant lastAttemptAt,
+      long loadDurationMs,
+      boolean lastAttemptSucceeded) {
+    static ProjectSnapshot empty() {
+      return new ProjectSnapshot(ProjectRepository.empty(), List.of(), null, null, 0L, false);
+    }
   }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
@@ -3,7 +3,6 @@ package com.scanales.eventflow.public_;
 import com.scanales.eventflow.community.CommunityContentItem;
 import com.scanales.eventflow.community.CommunityContentService;
 import com.scanales.eventflow.model.Event;
-import com.scanales.eventflow.public_.view.ProjectsViewModel;
 import com.scanales.eventflow.service.EventService;
 import com.scanales.eventflow.service.GithubService;
 import com.scanales.eventflow.service.GithubService.GithubContributor;
@@ -30,9 +29,6 @@ public class PublicPagesResource {
 
   @Inject
   Template home;
-
-  @Inject
-  Template projects;
 
   @Inject
   Template events;
@@ -96,15 +92,8 @@ public class PublicPagesResource {
 
   @GET
   @Path("/projects")
-  public TemplateInstance projects() {
-    ProjectsViewModel vm = ProjectsViewModel.mock();
-    return withLayoutData(
-        projects
-            .data("pageTitle", "Proyectos - HomeDir")
-            .data("pageDescription",
-                "Explora y colabora en proyectos Open Source de la comunidad. Gana experiencia y contribuye al ecosistema.")
-            .data("vm", vm),
-        "proyectos");
+  public Response projects() {
+    return Response.seeOther(URI.create("/proyectos")).build();
   }
 
   @GET

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -161,6 +161,11 @@ home.project.github.cache-ttl=PT24H
 home.project.github.retry-interval=PT15M
 home.project.github.refresh-interval=24h
 
+# /proyectos homedir dashboard cache
+projects.homedir.cache-ttl=PT6H
+projects.homedir.retry-interval=PT15M
+projects.homedir.refresh-interval=6h
+
 # Now box configuration
 nowbox.enabled=true
 nowbox.lookback=PT30M

--- a/quarkus-app/src/main/resources/templates/ProjectsResource/proyectos.html
+++ b/quarkus-app/src/main/resources/templates/ProjectsResource/proyectos.html
@@ -1,84 +1,493 @@
 {#include layout/main activePage="proyectos"}
-{#title}Proyectos - Homedir{/title}
+{#title}Project · Homedir{/title}
 {#body}
-
-
-<header class="page-header events-page-header">
+<header class="page-header project-hd-hero">
   <div class="section-header">
-    <p class="section-subtitle">Roadmap · Homedir</p>
-    <h1>Proyectos activos</h1>
+    <p class="section-subtitle">Project · Homedir</p>
+    <h1>Control de avance del producto</h1>
   </div>
-  <p class="section-subtitle">Sigue el estado de los módulos y entra directo al repositorio o sección
-    correspondiente.
+  <p class="section-subtitle project-hd-tagline">
+    Una sola vista para entender estado real, features activas, releases y señales de progreso de <strong>homedir</strong>.
   </p>
-
-  <div class="project-actions">
-    <a href="https://github.com/os-santiago/homedir" class="btn-primary" target="_blank" rel="noopener">Abrir
-      repositorio</a>
-    <a href="/comunidad" class="btn-primary">Unirme a la comunidad</a>
+  <div class="project-hd-actions">
+    <a href="{dashboard.repository.htmlUrl}" target="_blank" rel="noopener" class="btn-primary">Repositorio</a>
+    <a href="{dashboard.repository.htmlUrl}/releases" target="_blank" rel="noopener" class="btn-primary">Releases</a>
+    <a href="{dashboard.repository.htmlUrl}/issues" target="_blank" rel="noopener" class="btn-primary">Issues</a>
   </div>
 </header>
 
-<section class="page-grid">
-  <div class="section-header project-section-header">
-    <p class="section-subtitle">Módulos</p>
-    <h2 class="page-title">Hoja de ruta visible</h2>
-  </div>
-
-  <article class="section-card">
-    <div class="project-card-content">
-      <div class="project-card-icon">
-        <span class="material-symbols-outlined">storage</span>
-      </div>
-      <p class="eyebrow">Backend</p>
-      <h3 class="project-card-title">Homedir Core</h3>
-      <p class="project-card-desc">Base de la plataforma:
-        autenticación, perfiles y orquestación de módulos.</p>
-
-      <div class="project-card-footer">
-        <span class="badge project-status-badge">En
-          producción</span>
-        <a class="nav-link" href="https://github.com/os-santiago/homedir" target="_blank" rel="noopener">Abrir
-          <span class="material-symbols-outlined" style="font-size: 1em; vertical-align: middle;">open_in_new</span></a>
-      </div>
-    </div>
+<section class="page-grid project-hd-metrics-grid">
+  <article class="section-card project-hd-metric">
+    <p class="project-hd-metric-label">Stars</p>
+    <h2 class="project-hd-metric-value">{dashboard.repository.stars}</h2>
+    <p class="project-hd-metric-note">Señal de interés comunitario</p>
   </article>
-  <article class="section-card">
-    <div class="project-card-content">
-      <div class="project-card-icon">
-        <span class="material-symbols-outlined">notifications_active</span>
-      </div>
-      <p class="eyebrow">Tiempo real</p>
-      <h3 class="project-card-title">Notificaciones Globales</h3>
-      <p class="project-card-desc">Canal WebSocket y centro de
-        notificaciones para eventos y alertas.</p>
-
-      <div class="project-card-footer">
-        <span class="badge project-status-badge">Beta</span>
-        <a class="nav-link" href="https://github.com/os-santiago/homedir/tree/main/quarkus-app" target="_blank"
-          rel="noopener">Abrir <span class="material-symbols-outlined"
-            style="font-size: 1em; vertical-align: middle;">open_in_new</span></a>
-      </div>
-    </div>
+  <article class="section-card project-hd-metric">
+    <p class="project-hd-metric-label">Forks</p>
+    <h2 class="project-hd-metric-value">{dashboard.repository.forks}</h2>
+    <p class="project-hd-metric-note">Ramas de colaboración activas</p>
   </article>
-  <article class="section-card">
-    <div class="project-card-content">
-      <div class="project-card-icon">
-        <span class="material-symbols-outlined">groups</span>
-      </div>
-      <p class="eyebrow">Personas</p>
-      <h3 class="project-card-title">Comunidad</h3>
-      <p class="project-card-desc">Directorio de integrantes y
-        onboarding con GitHub para contribuir.</p>
-
-      <div class="project-card-footer">
-        <span class="badge project-status-badge">En
-          diseño</span>
-        <a class="nav-link" href="/comunidad" target="_blank" rel="noopener">Abrir <span
-            class="material-symbols-outlined" style="font-size: 1em; vertical-align: middle;">open_in_new</span></a>
-      </div>
-    </div>
+  <article class="section-card project-hd-metric">
+    <p class="project-hd-metric-label">Issues</p>
+    <h2 class="project-hd-metric-value">{dashboard.repository.openIssues}</h2>
+    <p class="project-hd-metric-note">Backlog abierto actual</p>
+  </article>
+  <article class="section-card project-hd-metric">
+    <p class="project-hd-metric-label">Contribuidores</p>
+    <h2 class="project-hd-metric-value">{dashboard.contributorCount}</h2>
+    <p class="project-hd-metric-note">Contribuciones: {dashboard.totalContributions}</p>
+  </article>
+  <article class="section-card project-hd-metric">
+    <p class="project-hd-metric-label">Último push</p>
+    <h2 class="project-hd-metric-value project-hd-metric-small">{dashboard.lastPushAgo}</h2>
+    <p class="project-hd-metric-note">Actividad de código reciente</p>
+  </article>
+  <article class="section-card project-hd-metric">
+    <p class="project-hd-metric-label">Última release</p>
+    <h2 class="project-hd-metric-value project-hd-metric-small">{dashboard.latestRelease}</h2>
+    <p class="project-hd-metric-note">{dashboard.latestReleaseAgo}</p>
   </article>
 </section>
+
+<section class="page-grid project-hd-panorama-grid">
+  <article class="section-card project-hd-progress-card">
+    <div class="project-hd-progress-head">
+      <div>
+        <p class="section-subtitle">Avances</p>
+        <h2 class="page-title">Estado de implementación</h2>
+      </div>
+      <strong class="project-hd-progress-percent">{dashboard.progressPercent}%</strong>
+    </div>
+    <div class="project-hd-progress-track">
+      <div class="project-hd-progress-fill" style="--progress:{dashboard.progressPercent}%"></div>
+    </div>
+    <div class="project-hd-status-row">
+      <span class="project-hd-status live">LIVE {dashboard.liveFeatures}</span>
+      <span class="project-hd-status beta">BETA {dashboard.betaFeatures}</span>
+      <span class="project-hd-status next">NEXT {dashboard.nextFeatures}</span>
+    </div>
+    <div class="project-hd-highlights">
+      {#for h in dashboard.highlights}
+      <div class="project-hd-highlight-item">
+        <p class="project-hd-highlight-title">{h.title}</p>
+        <strong>{h.value}</strong>
+        <small>{h.note}</small>
+      </div>
+      {/for}
+    </div>
+    <p class="project-hd-footnote">Snapshot actualizado {dashboard.snapshotAgo}</p>
+  </article>
+
+  <article class="section-card project-hd-release-card">
+    <div class="project-hd-release-head">
+      <div>
+        <p class="section-subtitle">Releases</p>
+        <h2 class="page-title">Historial reciente</h2>
+      </div>
+      <a href="{dashboard.repository.htmlUrl}/releases" target="_blank" rel="noopener" class="btn-primary">Ver todas</a>
+    </div>
+    {#if dashboard.releases.isEmpty()}
+    <p class="project-hd-empty">No hay releases publicadas en este momento.</p>
+    {#else}
+    <div class="project-hd-release-list">
+      {#for r in dashboard.releases}
+      <a href="{r.url}" target="_blank" rel="noopener" class="project-hd-release-item">
+        <div>
+          <h3>{r.label}</h3>
+          <p>{r.tag}</p>
+        </div>
+        <div class="project-hd-release-meta">
+          {#if r.prerelease}
+          <span class="project-hd-status beta">PRE</span>
+          {/if}
+          <small>{r.publishedAgo}</small>
+        </div>
+      </a>
+      {/for}
+    </div>
+    {/if}
+  </article>
+</section>
+
+<section class="page-grid project-hd-features-grid">
+  <div class="section-header project-hd-full">
+    <p class="section-subtitle">Features</p>
+    <h2 class="page-title">Mapa funcional de Homedir</h2>
+  </div>
+  {#for f in dashboard.features}
+  <article class="section-card project-hd-feature-card">
+    <div class="project-hd-feature-head">
+      <h3>{f.title}</h3>
+      <span class="project-hd-status {f.statusClass}">{f.statusLabel}</span>
+    </div>
+    <p>{f.description}</p>
+    <a href="{f.href}" target="_blank" rel="noopener" class="project-hd-link">Abrir</a>
+  </article>
+  {/for}
+</section>
+
+<section class="page-grid">
+  <div class="section-header project-hd-full">
+    <p class="section-subtitle">Team</p>
+    <h2 class="page-title">Contribuidores destacados</h2>
+  </div>
+  <article class="section-card project-hd-contributors-card project-hd-full">
+    {#if dashboard.topContributors.isEmpty()}
+    <p class="project-hd-empty">Aún no hay datos de contribuidores disponibles.</p>
+    {#else}
+    <div class="project-hd-contributors-grid">
+      {#for c in dashboard.topContributors}
+      <a href="{c.htmlUrl}" target="_blank" rel="noopener" class="project-hd-contributor-item" title="{c.login}">
+        <img src="{c.avatarUrl}" alt="{c.login}">
+        <strong>{c.login}</strong>
+        <small>{c.contributions} contribs</small>
+      </a>
+      {/for}
+    </div>
+    {/if}
+  </article>
+</section>
+
+<style>
+  .project-hd-hero {
+    gap: 0.8rem;
+    margin-bottom: 1rem;
+  }
+
+  .project-hd-tagline {
+    max-width: 940px;
+  }
+
+  .project-hd-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    justify-content: center;
+  }
+
+  .project-hd-metrics-grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: 0.8rem;
+    margin-bottom: 1.1rem;
+  }
+
+  .project-hd-metric {
+    padding: 0.85rem 0.8rem;
+    min-height: 140px;
+  }
+
+  .project-hd-metric-label {
+    margin: 0 0 0.3rem;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    opacity: 0.85;
+  }
+
+  .project-hd-metric-value {
+    margin: 0 0 0.25rem;
+    font-size: 1.45rem;
+    line-height: 1.2;
+  }
+
+  .project-hd-metric-small {
+    font-size: 0.95rem;
+  }
+
+  .project-hd-metric-note {
+    margin: 0;
+    font-size: 0.75rem;
+    opacity: 0.86;
+    line-height: 1.35;
+  }
+
+  .project-hd-panorama-grid {
+    grid-template-columns: 1.2fr 1fr;
+    gap: 0.9rem;
+    margin-bottom: 1.1rem;
+  }
+
+  .project-hd-progress-card,
+  .project-hd-release-card {
+    padding: 1rem;
+  }
+
+  .project-hd-progress-head,
+  .project-hd-release-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.8rem;
+    margin-bottom: 0.8rem;
+  }
+
+  .project-hd-progress-head .page-title,
+  .project-hd-release-head .page-title {
+    margin: 0;
+    font-size: 1.05rem;
+    letter-spacing: 1px;
+  }
+
+  .project-hd-progress-percent {
+    font-family: var(--font-display);
+    font-size: 1.25rem;
+    color: #ffd700;
+  }
+
+  .project-hd-progress-track {
+    height: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(0, 0, 0, 0.35);
+    margin-bottom: 0.7rem;
+    overflow: hidden;
+  }
+
+  .project-hd-progress-fill {
+    height: 100%;
+    width: var(--progress);
+    background: linear-gradient(90deg, #ffd700, #ffad33);
+  }
+
+  .project-hd-status-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.8rem;
+  }
+
+  .project-hd-status {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 999px;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.68rem;
+    letter-spacing: 0.7px;
+    text-transform: uppercase;
+  }
+
+  .project-hd-status.live {
+    border-color: rgba(120, 255, 160, 0.8);
+    color: #8affc1;
+  }
+
+  .project-hd-status.beta {
+    border-color: rgba(255, 215, 0, 0.8);
+    color: #ffd700;
+  }
+
+  .project-hd-status.next {
+    border-color: rgba(255, 255, 255, 0.5);
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  .project-hd-highlights {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.6rem;
+  }
+
+  .project-hd-highlight-item {
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(0, 0, 0, 0.3);
+    padding: 0.55rem;
+  }
+
+  .project-hd-highlight-title {
+    margin: 0 0 0.2rem;
+    font-size: 0.63rem;
+    letter-spacing: 0.6px;
+    text-transform: uppercase;
+    opacity: 0.8;
+  }
+
+  .project-hd-highlight-item strong {
+    display: block;
+    font-size: 0.86rem;
+    margin-bottom: 0.2rem;
+  }
+
+  .project-hd-highlight-item small {
+    opacity: 0.78;
+    font-size: 0.7rem;
+  }
+
+  .project-hd-footnote {
+    margin: 0.7rem 0 0;
+    font-size: 0.72rem;
+    opacity: 0.8;
+  }
+
+  .project-hd-release-list {
+    display: grid;
+    gap: 0.55rem;
+  }
+
+  .project-hd-release-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.7rem;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(0, 0, 0, 0.3);
+    padding: 0.55rem;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .project-hd-release-item h3 {
+    margin: 0;
+    font-size: 0.88rem;
+  }
+
+  .project-hd-release-item p {
+    margin: 0.12rem 0 0;
+    font-size: 0.72rem;
+    opacity: 0.8;
+  }
+
+  .project-hd-release-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.2rem;
+    white-space: nowrap;
+  }
+
+  .project-hd-release-meta small {
+    opacity: 0.8;
+    font-size: 0.7rem;
+  }
+
+  .project-hd-features-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.8rem;
+    margin-bottom: 1.1rem;
+  }
+
+  .project-hd-full {
+    grid-column: 1 / -1;
+  }
+
+  .project-hd-feature-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    min-height: 190px;
+  }
+
+  .project-hd-feature-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .project-hd-feature-head h3 {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.3;
+  }
+
+  .project-hd-feature-card p {
+    margin: 0;
+    font-size: 0.82rem;
+    line-height: 1.45;
+    opacity: 0.92;
+  }
+
+  .project-hd-link {
+    margin-top: auto;
+    font-size: 0.75rem;
+    text-decoration: none;
+    color: #ffd700;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+  }
+
+  .project-hd-contributors-card {
+    padding: 0.9rem;
+  }
+
+  .project-hd-contributors-grid {
+    display: grid;
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+    gap: 0.55rem;
+  }
+
+  .project-hd-contributor-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.2rem;
+    text-decoration: none;
+    color: inherit;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(0, 0, 0, 0.26);
+    padding: 0.4rem 0.35rem;
+  }
+
+  .project-hd-contributor-item img {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.6);
+    object-fit: cover;
+  }
+
+  .project-hd-contributor-item strong {
+    max-width: 100%;
+    font-size: 0.66rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .project-hd-contributor-item small {
+    font-size: 0.55rem;
+    text-transform: uppercase;
+    letter-spacing: 0.45px;
+    color: #ffd700;
+  }
+
+  .project-hd-empty {
+    margin: 0;
+    font-size: 0.85rem;
+    opacity: 0.9;
+  }
+
+  @media (max-width: 1200px) {
+    .project-hd-metrics-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .project-hd-panorama-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .project-hd-features-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .project-hd-contributors-grid {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 760px) {
+    .project-hd-metrics-grid,
+    .project-hd-features-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .project-hd-highlights {
+      grid-template-columns: 1fr;
+    }
+
+    .project-hd-contributors-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+</style>
 {/body}
 {/include}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/ProjectsResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/ProjectsResourceTest.java
@@ -1,0 +1,36 @@
+package com.scanales.eventflow.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class ProjectsResourceTest {
+
+  @Test
+  public void proyectosShowsHomedirDashboard() {
+    given()
+        .accept("text/html")
+        .when()
+        .get("/proyectos")
+        .then()
+        .statusCode(200)
+        .body(containsString("Control de avance del producto"))
+        .body(containsString("Mapa funcional de Homedir"));
+  }
+
+  @Test
+  public void projectsAliasRedirectsToSpanishRoute() {
+    given()
+        .redirects()
+        .follow(false)
+        .when()
+        .get("/projects")
+        .then()
+        .statusCode(303)
+        .header("Location", endsWith("/proyectos"));
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild `/proyectos` as a full Homedir-only dashboard focused on:
  - eye-catching product stats
  - progress/advances snapshot
  - feature map with status (LIVE/BETA/NEXT)
  - recent releases timeline
  - top contributors block
- replace per-request GitHub fetch behavior with in-memory cached snapshot + async refresh
- add refresh controls via config:
  - `projects.homedir.cache-ttl`
  - `projects.homedir.retry-interval`
  - `projects.homedir.refresh-interval`
- make `/projects` redirect to `/proyectos` to keep a single source of truth
- add integration test coverage for `/proyectos` and `/projects` redirect

## Validation
- `mvn -f quarkus-app/pom.xml "-Dtest=ProjectsResourceTest,HomePastEventsTest,HomeTimelineTest,NotificationsMenuTest,CommunityContentApiResourceTest" test`