### PR TITLE
feat(home): compact top spacing and improve viewport usage

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -2053,6 +2053,36 @@ footer {
    HOME HIGHLIGHTS (Social / Events / Project)
    =========================================== */
 
+.homedir-main-home {
+  max-width: 1360px;
+  padding: 1.2rem 1.25rem 1.6rem;
+  gap: 0.95rem;
+}
+
+.homedir-main-home .home-highlight-hero {
+  gap: 0.5rem;
+  margin-bottom: 0.45rem;
+}
+
+.homedir-main-home .home-panorama-grid {
+  margin: 0 auto 0.9rem;
+  padding: 0;
+  gap: 0.8rem;
+}
+
+.homedir-main-home .home-pane {
+  min-height: 470px;
+  margin-bottom: 0;
+}
+
+.homedir-main-home .home-top-metric {
+  padding: 0.62rem 0.76rem;
+}
+
+.homedir-main-home .home-pane-item {
+  padding: 0.58rem;
+}
+
 .home-highlight-hero {
   gap: 0.65rem;
   margin-bottom: 1rem;
@@ -2339,6 +2369,14 @@ footer {
 }
 
 @media (max-width: 1120px) {
+  .homedir-main-home {
+    max-width: 1200px;
+  }
+
+  .homedir-main-home .home-panorama-grid {
+    gap: 0.75rem;
+  }
+
   .home-panorama-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -2353,6 +2391,15 @@ footer {
 }
 
 @media (max-width: 860px) {
+  .homedir-main-home {
+    padding: 0.95rem 0.85rem 1.25rem;
+    gap: 0.75rem;
+  }
+
+  .homedir-main-home .home-highlight-hero {
+    margin-bottom: 0.3rem;
+  }
+
   .home-top-metrics {
     grid-template-columns: 1fr;
   }

--- a/quarkus-app/src/main/resources/templates/home.qute.html
+++ b/quarkus-app/src/main/resources/templates/home.qute.html
@@ -1,4 +1,4 @@
-{#include layout/main activePage="home"}
+{#include layout/main activePage="home" mainClass="homedir-main-home"}
 {#title}{i18n.nav_home}{/title}
 {#body}
 <header class="public-header home-highlight-hero">

--- a/quarkus-app/src/main/resources/templates/layout/main.html
+++ b/quarkus-app/src/main/resources/templates/layout/main.html
@@ -3,6 +3,7 @@
 {@ boolean noFooter = false}
 {@ boolean noCharacterSheet = false}
 {@ String activePage = ""}
+{@ String mainClass = ""}
 {@ boolean userAuthenticated = false}
 {@ String userName = ""}
 {@ String userInitial = ""}
@@ -51,7 +52,7 @@
     {#include fragments/header /}
     {/if}
 
-    <main id="main-content" class="homedir-main" role="main">
+    <main id="main-content" class="homedir-main {mainClass}" role="main">
       {#insert body}{/}
     </main>
 


### PR DESCRIPTION
## Summary
- add a page-scoped mainClass hook in layout to tune spacing per page
- apply homedir-main-home class in Home template only
- compact Home top spacing and grid gutters to show highlights earlier in viewport

## Validation
- cd quarkus-app && ./mvnw -DskipTests compile (BUILD SUCCESS)

## Impact
- Home uses space more efficiently on desktop and mobile
- no behavioral changes outside Home