### PR TITLE
fix(ui): stabilize Social rendering and legacy script/css compatibility

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/canva-theme-v2.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/canva-theme-v2.css
@@ -1,0 +1,5 @@
+/*
+ * Legacy compatibility stylesheet.
+ * Some clients can request this path from cached HTML versions.
+ * Keep file present to avoid 500/404 noise during rollouts.
+ */

--- a/quarkus-app/src/main/resources/META-INF/resources/js/homedir.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/homedir.js
@@ -1,8 +1,8 @@
-let currentUser = null;
-let allUsers = [];
+var currentUser = window.currentUser || null;
+var allUsers = window.allUsers || [];
 
 // Equipment/Collectibles System
-const COLLECTIBLES = [
+var COLLECTIBLES = window.COLLECTIBLES || [
   { id: 'laptop', icon: '💻', name: 'DEVELOPER LAPTOP', rarity: 'common', description: '+5 Coding Power' },
   { id: 'keyboard', icon: '⌨️', name: 'MECHANICAL KEYBOARD', rarity: 'rare', description: '+10 Typing Speed' },
   { id: 'coffee', icon: '☕', name: 'ENERGY COFFEE', rarity: 'common', description: '+3 Focus' },
@@ -16,6 +16,9 @@ const COLLECTIBLES = [
   { id: 'crown', icon: '👑', name: 'LEADER CROWN', rarity: 'legendary', description: '+35 Leadership' },
   { id: 'glasses', icon: '👓', name: 'CODE GLASSES', rarity: 'common', description: '+4 Vision' }
 ];
+window.currentUser = currentUser;
+window.allUsers = allUsers;
+window.COLLECTIBLES = COLLECTIBLES;
 
 function generateEquipment(level, experience) {
   const equipment = [];

--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -110,7 +110,8 @@
   }
 
   /* Match Home card behavior and disable retro glow sweep on Social cards */
-  .community-item-card {
+  .community-item-card,
+  .community-list .section-card {
     background: rgba(0, 0, 0, 0.45);
     border: 3px solid rgba(255, 255, 255, 0.7);
     border-bottom: 6px solid rgba(0, 0, 0, 0.7);
@@ -126,7 +127,13 @@
     padding: 1rem;
   }
 
-  .community-item-card:hover {
+  .community-item-card::before,
+  .community-list .section-card::before {
+    content: none;
+  }
+
+  .community-item-card:hover,
+  .community-list .section-card:hover {
     background: rgba(0, 0, 0, 0.45);
   }
 
@@ -229,6 +236,6 @@
     }
   }
 </style>
-<script src="/js/community-content.js" defer></script>
+<script src="/js/community-content.js?v={app:version()}" defer></script>
 {/body}
 {/include}

--- a/quarkus-app/src/main/resources/templates/layout/main.html
+++ b/quarkus-app/src/main/resources/templates/layout/main.html
@@ -65,7 +65,11 @@
 
   {#include fragments/login-modal.html/}
   <script src="/js/homedir.js?v={app:version()}"></script>
-  <script>window.__EF_AUTH__ = { isAuth: { app: { userAuthenticated: {#if userAuthenticated}true{#else}false{/if} } } };</script>
+  <script>
+    window.__EF_AUTH__ = { isAuth: { app: { userAuthenticated: {#if userAuthenticated}true{#else}false{/if} } } };
+    window.userAuthenticated = window.__EF_AUTH__.isAuth.app.userAuthenticated;
+    var userAuthenticated = window.userAuthenticated;
+  </script>
   <script src="/js/app.js?v={app:version()}" defer></script>
   <script src="/js/notifications-adapter.js?v={app:version()}" defer></script>
   <script src="/js/notifications.js?v={app:version()}" defer></script>


### PR DESCRIPTION
## Summary
- align Social card rendering with Home visual behavior and prevent retro section-card effects from leaking into community cards
- add cache-busting for /js/community-content.js in community template to avoid stale mixed HTML/JS after deploys
- expose legacy userAuthenticated global from layout for backward compatibility with older scripts
- make homedir.js globals (currentUser, allUsers, COLLECTIBLES) idempotent to avoid duplicate declaration errors when legacy scripts coexist
- add a compatibility stylesheet at /css/canva-theme-v2.css to stop 500 errors from stale cached clients

## Validation
- mvn -f quarkus-app/pom.xml -DskipTests compile
