### PR TITLE
feat(community): add board summary and group directories

### DIFF
--- a/docs/community-content.md
+++ b/docs/community-content.md
@@ -8,6 +8,9 @@ This module powers `/comunidad` with curated content loaded from files and commu
 - Views:
   - `featured`: ranked by votes + optional time decay.
   - `new`: sorted by `created_at` descending.
+- Community Board:
+  - `/comunidad/board` summary (HomeDir users, GitHub users, Discord users).
+  - `/comunidad/board/{group}` detail list with search and profile-link copy.
 
 ## Content Directory
 - Production target: `${homedir.data.dir}/community/content`
@@ -15,6 +18,8 @@ This module powers `/comunidad` with curated content loaded from files and commu
 - Legacy path: `/var/lib/homedir/community/content` (supported if linked or configured)
 - Config env var: `COMMUNITY_CONTENT_DIR`
 - App default (when env not set): `${homedir.data.dir}/community/content`
+- Optional Community Board Discord source:
+  - `community.board.discord.file` (YAML/JSON, default `${homedir.data.dir}/community/board/discord-users.yml`)
 
 ## File Schema
 - One file per item (`.yml` or `.yaml`).
@@ -45,6 +50,9 @@ Invalid/incomplete files are skipped and logged.
   - `load_duration_ms`
   - `files_loaded`
   - `files_invalid`
+- Community Board Discord users cache:
+  - `community.board.cache-ttl` (default `PT1H`)
+  - If refresh fails, last in-memory snapshot is kept.
 
 ## Voting
 - Endpoint: `PUT /api/community/content/{id}/vote`
@@ -71,6 +79,11 @@ Featured window:
 - `GET /api/community/content?view=new|featured&limit=&offset=`
 - `GET /api/community/content/{id}`
 - `PUT /api/community/content/{id}/vote`
+
+## Community Board Data Sources
+- `HomeDir users`: internal `UserProfile` store (Google-auth users with local profile).
+- `GitHub users`: union of linked GitHub accounts in `UserProfile` + synced community members.
+- `Discord users`: optional file (`members` array) loaded from configured path and cached.
 
 Each item includes counts and current user vote:
 - `vote_counts.recommended`

--- a/quarkus-app/src/main/java/com/scanales/eventflow/community/CommunityBoardGroup.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/community/CommunityBoardGroup.java
@@ -1,0 +1,33 @@
+package com.scanales.eventflow.community;
+
+import java.util.Locale;
+import java.util.Optional;
+
+public enum CommunityBoardGroup {
+  HOMEDIR_USERS("homedir-users"),
+  GITHUB_USERS("github-users"),
+  DISCORD_USERS("discord-users");
+
+  private final String path;
+
+  CommunityBoardGroup(String path) {
+    this.path = path;
+  }
+
+  public String path() {
+    return path;
+  }
+
+  public static Optional<CommunityBoardGroup> fromPath(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return Optional.empty();
+    }
+    String normalized = raw.trim().toLowerCase(Locale.ROOT);
+    for (CommunityBoardGroup value : values()) {
+      if (value.path.equals(normalized)) {
+        return Optional.of(value);
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/community/CommunityBoardMemberView.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/community/CommunityBoardMemberView.java
@@ -1,0 +1,10 @@
+package com.scanales.eventflow.community;
+
+public record CommunityBoardMemberView(
+    String id,
+    String displayName,
+    String handle,
+    String avatarUrl,
+    String memberSince,
+    String profileLink,
+    String shareLink) {}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/community/CommunityBoardService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/community/CommunityBoardService.java
@@ -1,0 +1,383 @@
+package com.scanales.eventflow.community;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.scanales.eventflow.model.CommunityMember;
+import com.scanales.eventflow.model.UserProfile;
+import com.scanales.eventflow.service.CommunityService;
+import com.scanales.eventflow.service.UserProfileService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class CommunityBoardService {
+  private static final Logger LOG = Logger.getLogger(CommunityBoardService.class);
+  private static final int MAX_LIMIT = 100;
+  private static final DateTimeFormatter DATE_FMT =
+      DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneOffset.UTC);
+
+  @Inject UserProfileService userProfileService;
+  @Inject CommunityService communityService;
+
+  @ConfigProperty(name = "homedir.data.dir", defaultValue = "data")
+  String dataDirPath;
+
+  @ConfigProperty(name = "community.board.discord.file")
+  Optional<String> discordFileConfig;
+
+  @ConfigProperty(name = "community.board.cache-ttl", defaultValue = "PT1H")
+  Duration boardCacheTtl;
+
+  private final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+  private final ObjectMapper jsonMapper = new ObjectMapper();
+  private final AtomicReference<DiscordCache> discordCache = new AtomicReference<>(DiscordCache.empty());
+
+  public CommunityBoardSummary summary() {
+    return new CommunityBoardSummary(
+        homedirMembers().size(), githubMembers().size(), discordMembers().size());
+  }
+
+  public BoardSlice list(CommunityBoardGroup group, String query, int limit, int offset) {
+    List<CommunityBoardMemberView> source = members(group);
+    List<CommunityBoardMemberView> filtered = filter(source, query);
+    int normalizedLimit = normalizeLimit(limit);
+    int normalizedOffset = Math.max(0, offset);
+    if (normalizedOffset >= filtered.size()) {
+      return new BoardSlice(filtered.size(), normalizedLimit, normalizedOffset, List.of());
+    }
+    int end = Math.min(filtered.size(), normalizedOffset + normalizedLimit);
+    return new BoardSlice(
+        filtered.size(), normalizedLimit, normalizedOffset, filtered.subList(normalizedOffset, end));
+  }
+
+  public List<CommunityBoardMemberView> members(CommunityBoardGroup group) {
+    return switch (group) {
+      case HOMEDIR_USERS -> homedirMembers();
+      case GITHUB_USERS -> githubMembers();
+      case DISCORD_USERS -> discordMembers();
+    };
+  }
+
+  void resetDiscordCacheForTests() {
+    discordCache.set(DiscordCache.empty());
+  }
+
+  private List<CommunityBoardMemberView> homedirMembers() {
+    List<CommunityBoardMemberView> out = new ArrayList<>();
+    for (UserProfile profile : userProfileService.allProfiles().values()) {
+      String id = normalizeId(firstNonBlank(profile.getUserId(), profile.getEmail()));
+      if (id == null) {
+        continue;
+      }
+      String displayName =
+          firstNonBlank(profile.getName(), usernameFromEmail(profile.getEmail()), "Homedir user");
+      String githubLogin = profile.getGithub() != null ? trimToNull(profile.getGithub().login()) : null;
+      String handle =
+          githubLogin != null
+              ? "@" + githubLogin
+              : firstNonBlank(maskEmail(profile.getEmail()), maskEmail(profile.getUserId()), id);
+      String avatarUrl = profile.getGithub() != null ? trimToNull(profile.getGithub().avatarUrl()) : null;
+      String since =
+          profile.getGithub() != null && profile.getGithub().linkedAt() != null
+              ? DATE_FMT.format(profile.getGithub().linkedAt())
+              : null;
+      String link =
+          githubLogin != null
+              ? "/u/" + githubLogin
+              : "/comunidad/board/homedir-users?member=" + urlEncode(id);
+      out.add(new CommunityBoardMemberView(id, displayName, handle, avatarUrl, since, link, link));
+    }
+    out.sort(memberComparator());
+    return List.copyOf(out);
+  }
+
+  private List<CommunityBoardMemberView> githubMembers() {
+    Map<String, GithubMemberSeed> byLogin = new LinkedHashMap<>();
+
+    for (UserProfile profile : userProfileService.allProfiles().values()) {
+      if (profile.getGithub() == null) {
+        continue;
+      }
+      String login = normalizeId(profile.getGithub().login());
+      if (login == null) {
+        continue;
+      }
+      String displayName =
+          firstNonBlank(profile.getName(), usernameFromEmail(profile.getEmail()), login);
+      String avatar = trimToNull(profile.getGithub().avatarUrl());
+      Instant linkedAt = profile.getGithub().linkedAt();
+      byLogin.merge(
+          login, new GithubMemberSeed(displayName, avatar, linkedAt), CommunityBoardService::mergeSeeds);
+    }
+
+    for (CommunityMember member : communityService.listMembers()) {
+      String login = normalizeId(member.getGithub());
+      if (login == null) {
+        continue;
+      }
+      String displayName = firstNonBlank(member.getDisplayName(), login);
+      String avatar = trimToNull(member.getAvatarUrl());
+      Instant joinedAt = member.getJoinedAt();
+      byLogin.merge(
+          login, new GithubMemberSeed(displayName, avatar, joinedAt), CommunityBoardService::mergeSeeds);
+    }
+
+    List<CommunityBoardMemberView> out = new ArrayList<>();
+    for (Map.Entry<String, GithubMemberSeed> entry : byLogin.entrySet()) {
+      String login = entry.getKey();
+      GithubMemberSeed seed = entry.getValue();
+      String link = "/u/" + login;
+      out.add(
+          new CommunityBoardMemberView(
+              login,
+              seed.displayName(),
+              "@" + login,
+              seed.avatarUrl(),
+              seed.memberSince() != null ? DATE_FMT.format(seed.memberSince()) : null,
+              link,
+              link));
+    }
+    out.sort(memberComparator());
+    return List.copyOf(out);
+  }
+
+  private List<CommunityBoardMemberView> discordMembers() {
+    Instant now = Instant.now();
+    DiscordCache current = discordCache.get();
+    if (current.loadedAt() != null && now.isBefore(current.loadedAt().plus(boardCacheTtl))) {
+      return current.members();
+    }
+    Path file = resolveDiscordFile();
+    Instant modifiedAt = fileLastModified(file).orElse(null);
+    try {
+      List<CommunityBoardMemberView> loaded = parseDiscordFile(file);
+      DiscordCache next = new DiscordCache(List.copyOf(loaded), now, modifiedAt);
+      discordCache.set(next);
+      return next.members();
+    } catch (Exception e) {
+      if (!current.members().isEmpty()) {
+        LOG.warnf("Unable to refresh discord users file %s, keeping previous cache", file);
+        return current.members();
+      }
+      LOG.warnf("Unable to load discord users file %s: %s", file, e.getMessage());
+      DiscordCache empty = new DiscordCache(List.of(), now, modifiedAt);
+      discordCache.set(empty);
+      return empty.members();
+    }
+  }
+
+  private List<CommunityBoardMemberView> parseDiscordFile(Path file) throws Exception {
+    if (!Files.exists(file) || !Files.isRegularFile(file)) {
+      return List.of();
+    }
+    String name = file.getFileName().toString().toLowerCase(Locale.ROOT);
+    JsonNode root =
+        name.endsWith(".json")
+            ? jsonMapper.readTree(Files.readString(file))
+            : yamlMapper.readTree(Files.readString(file));
+    JsonNode membersNode = root.isArray() ? root : root.path("members");
+    if (membersNode == null || !membersNode.isArray()) {
+      return List.of();
+    }
+    List<CommunityBoardMemberView> out = new ArrayList<>();
+    for (JsonNode node : membersNode) {
+      String id = normalizeId(text(node, "id", text(node, "handle", text(node, "display_name", null))));
+      if (id == null) {
+        continue;
+      }
+      String displayName = firstNonBlank(text(node, "display_name", null), text(node, "name", null), id);
+      String handle = firstNonBlank(text(node, "handle", null), displayName);
+      String avatar = text(node, "avatar_url", null);
+      String joined = normalizeDateLabel(text(node, "joined_at", null));
+      String link = "/comunidad/board/discord-users?member=" + urlEncode(id);
+      out.add(new CommunityBoardMemberView(id, displayName, handle, avatar, joined, link, link));
+    }
+    out.sort(memberComparator());
+    return out;
+  }
+
+  private Path resolveDiscordFile() {
+    String configured = discordFileConfig.orElse("").trim();
+    if (!configured.isEmpty()) {
+      return Paths.get(configured);
+    }
+    String sysProp = System.getProperty("homedir.data.dir");
+    String base = (sysProp != null && !sysProp.isBlank()) ? sysProp : dataDirPath;
+    return Paths.get(base, "community", "board", "discord-users.yml");
+  }
+
+  private Optional<Instant> fileLastModified(Path file) {
+    try {
+      return Files.exists(file) ? Optional.of(Files.getLastModifiedTime(file).toInstant()) : Optional.empty();
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
+  private List<CommunityBoardMemberView> filter(List<CommunityBoardMemberView> source, String query) {
+    if (query == null || query.isBlank()) {
+      return source;
+    }
+    String normalized = query.trim().toLowerCase(Locale.ROOT);
+    return source.stream()
+        .filter(
+            member ->
+                contains(member.displayName(), normalized)
+                    || contains(member.handle(), normalized)
+                    || contains(member.id(), normalized))
+        .toList();
+  }
+
+  private static boolean contains(String value, String query) {
+    return value != null && value.toLowerCase(Locale.ROOT).contains(query);
+  }
+
+  private static int normalizeLimit(int value) {
+    if (value <= 0) {
+      return 30;
+    }
+    return Math.min(value, MAX_LIMIT);
+  }
+
+  private static Comparator<CommunityBoardMemberView> memberComparator() {
+    return Comparator.comparing(
+            CommunityBoardMemberView::displayName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER))
+        .thenComparing(CommunityBoardMemberView::handle, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
+  }
+
+  private static String text(JsonNode node, String field, String fallback) {
+    if (node == null) {
+      return fallback;
+    }
+    JsonNode value = node.path(field);
+    if (value.isMissingNode() || value.isNull()) {
+      return fallback;
+    }
+    String out = trimToNull(value.asText(null));
+    return out == null ? fallback : out;
+  }
+
+  private static String normalizeDateLabel(String raw) {
+    String value = trimToNull(raw);
+    if (value == null) {
+      return null;
+    }
+    try {
+      return DATE_FMT.format(Instant.parse(value));
+    } catch (Exception ignored) {
+    }
+    try {
+      return LocalDate.parse(value).toString();
+    } catch (Exception ignored) {
+    }
+    return value;
+  }
+
+  private static String usernameFromEmail(String email) {
+    String value = trimToNull(email);
+    if (value == null) {
+      return null;
+    }
+    int at = value.indexOf('@');
+    return at > 0 ? value.substring(0, at) : value;
+  }
+
+  private static String maskEmail(String value) {
+    String text = trimToNull(value);
+    if (text == null) {
+      return null;
+    }
+    int at = text.indexOf('@');
+    if (at <= 0) {
+      if (text.length() <= 3) {
+        return "***";
+      }
+      return text.substring(0, 2) + "***";
+    }
+    String local = text.substring(0, at);
+    String domain = text.substring(at);
+    if (local.length() <= 2) {
+      return "*" + domain;
+    }
+    return local.substring(0, 2) + "***" + domain;
+  }
+
+  private static GithubMemberSeed mergeSeeds(GithubMemberSeed left, GithubMemberSeed right) {
+    String displayName = firstNonBlank(left.displayName(), right.displayName());
+    String avatarUrl = firstNonBlank(left.avatarUrl(), right.avatarUrl());
+    Instant memberSince = chooseEarliest(left.memberSince(), right.memberSince());
+    return new GithubMemberSeed(displayName, avatarUrl, memberSince);
+  }
+
+  private static Instant chooseEarliest(Instant a, Instant b) {
+    if (a == null) {
+      return b;
+    }
+    if (b == null) {
+      return a;
+    }
+    return a.isBefore(b) ? a : b;
+  }
+
+  private static String urlEncode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+
+  private static String normalizeId(String raw) {
+    String value = trimToNull(raw);
+    return value == null ? null : value.toLowerCase(Locale.ROOT);
+  }
+
+  private static String firstNonBlank(String... values) {
+    if (values == null) {
+      return null;
+    }
+    for (String value : values) {
+      String normalized = trimToNull(value);
+      if (normalized != null) {
+        return normalized;
+      }
+    }
+    return null;
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  public record BoardSlice(
+      int total, int limit, int offset, List<CommunityBoardMemberView> items) {}
+
+  private record GithubMemberSeed(String displayName, String avatarUrl, Instant memberSince) {}
+
+  private record DiscordCache(List<CommunityBoardMemberView> members, Instant loadedAt, Instant modifiedAt) {
+    static DiscordCache empty() {
+      return new DiscordCache(List.of(), null, null);
+    }
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/community/CommunityBoardSummary.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/community/CommunityBoardSummary.java
@@ -1,0 +1,3 @@
+package com.scanales.eventflow.community;
+
+public record CommunityBoardSummary(int homedirUsers, int githubUsers, int discordUsers) {}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityBoardResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityBoardResource.java
@@ -1,0 +1,163 @@
+package com.scanales.eventflow.public_;
+
+import com.scanales.eventflow.community.CommunityBoardGroup;
+import com.scanales.eventflow.community.CommunityBoardMemberView;
+import com.scanales.eventflow.community.CommunityBoardService;
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.annotation.security.PermitAll;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Optional;
+import org.jboss.logging.Logger;
+
+@Path("/comunidad/board")
+public class CommunityBoardResource {
+  private static final Logger LOG = Logger.getLogger(CommunityBoardResource.class);
+
+  @Inject SecurityIdentity identity;
+  @Inject CommunityBoardService boardService;
+
+  @CheckedTemplate
+  static class Templates {
+    static native TemplateInstance board(
+        boolean isAuthenticated, int homedirUsers, int githubUsers, int discordUsers);
+
+    static native TemplateInstance detail(
+        boolean isAuthenticated,
+        String groupPath,
+        String groupTitle,
+        String groupDescription,
+        String searchQuery,
+        int total,
+        int limit,
+        int offset,
+        String highlightedMember,
+        List<CommunityBoardMemberView> members);
+  }
+
+  @GET
+  @PermitAll
+  @Produces(MediaType.TEXT_HTML)
+  public TemplateInstance board() {
+    var summary = boardService.summary();
+    TemplateInstance template =
+        Templates.board(
+            isAuthenticated(),
+            summary.homedirUsers(),
+            summary.githubUsers(),
+            summary.discordUsers());
+    return withLayoutData(template);
+  }
+
+  @GET
+  @Path("/{group}")
+  @PermitAll
+  @Produces(MediaType.TEXT_HTML)
+  public TemplateInstance detail(
+      @PathParam("group") String groupPath,
+      @QueryParam("q") String query,
+      @QueryParam("limit") Integer limitParam,
+      @QueryParam("offset") Integer offsetParam,
+      @QueryParam("member") String highlightedMember) {
+    CommunityBoardGroup group =
+        CommunityBoardGroup.fromPath(groupPath).orElseThrow(() -> new NotFoundException("group_not_found"));
+    int limit = normalizeLimit(limitParam);
+    int offset = Math.max(0, offsetParam == null ? 0 : offsetParam);
+    CommunityBoardService.BoardSlice slice = boardService.list(group, query, limit, offset);
+    String normalizedQuery = query == null ? "" : query.trim();
+    TemplateInstance template =
+        Templates.detail(
+            isAuthenticated(),
+            group.path(),
+            titleFor(group),
+            descriptionFor(group),
+            normalizedQuery,
+            slice.total(),
+            slice.limit(),
+            slice.offset(),
+            normalizeHighlightedMember(highlightedMember),
+            slice.items());
+    return withLayoutData(template);
+  }
+
+  private TemplateInstance withLayoutData(TemplateInstance template) {
+    boolean authenticated = isAuthenticated();
+    String name = currentUserName().orElse(null);
+    return template
+        .data("activePage", "comunidad")
+        .data("userAuthenticated", authenticated)
+        .data("userName", name)
+        .data("userInitial", initialFrom(name));
+  }
+
+  private int normalizeLimit(Integer limitParam) {
+    if (limitParam == null || limitParam <= 0) {
+      return 50;
+    }
+    return Math.min(limitParam, 100);
+  }
+
+  private String normalizeHighlightedMember(String member) {
+    if (member == null) {
+      return "";
+    }
+    String normalized = member.trim().toLowerCase();
+    return normalized;
+  }
+
+  private String titleFor(CommunityBoardGroup group) {
+    return switch (group) {
+      case HOMEDIR_USERS -> "HomeDir users";
+      case GITHUB_USERS -> "GitHub users";
+      case DISCORD_USERS -> "Discord users";
+    };
+  }
+
+  private String descriptionFor(CommunityBoardGroup group) {
+    return switch (group) {
+      case HOMEDIR_USERS -> "People who signed in with Google and created a Homedir account.";
+      case GITHUB_USERS -> "Contributors with a linked GitHub account in the OSSantiago ecosystem.";
+      case DISCORD_USERS -> "People who joined our official OSSantiago Discord server.";
+    };
+  }
+
+  private Optional<String> currentUserName() {
+    if (!isAuthenticated()) {
+      return Optional.empty();
+    }
+    String name = identity.getAttribute("name");
+    if (name == null || name.isBlank()) {
+      name = identity.getPrincipal() != null ? identity.getPrincipal().getName() : null;
+    }
+    return Optional.ofNullable(name);
+  }
+
+  private boolean isAuthenticated() {
+    try {
+      return identity != null && !identity.isAnonymous();
+    } catch (Exception e) {
+      LOG.warn("Security identity check failed (treating as anonymous): " + e.getMessage());
+      return false;
+    }
+  }
+
+  private String initialFrom(String name) {
+    if (name == null) {
+      return null;
+    }
+    String trimmed = name.trim();
+    if (trimmed.isEmpty()) {
+      return null;
+    }
+    return trimmed.substring(0, 1).toUpperCase();
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicPagesResource.java
@@ -13,6 +13,7 @@ import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -88,6 +89,30 @@ public class PublicPagesResource {
   @Path("/community")
   public Response community() {
     return Response.seeOther(URI.create("/comunidad")).build();
+  }
+
+  @GET
+  @Path("/community/feed")
+  public Response communityFeed() {
+    return Response.seeOther(URI.create("/comunidad/feed")).build();
+  }
+
+  @GET
+  @Path("/community/picks")
+  public Response communityPicks() {
+    return Response.seeOther(URI.create("/comunidad/picks")).build();
+  }
+
+  @GET
+  @Path("/community/board")
+  public Response communityBoard() {
+    return Response.seeOther(URI.create("/comunidad/board")).build();
+  }
+
+  @GET
+  @Path("/community/board/{group}")
+  public Response communityBoardGroup(@PathParam("group") String group) {
+    return Response.seeOther(URI.create("/comunidad/board/" + group)).build();
   }
 
   @GET

--- a/quarkus-app/src/main/resources/META-INF/resources/js/community-content.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/community-content.js
@@ -6,6 +6,7 @@
 
   const authenticated = String(root.dataset.authenticated || "false") === "true";
   const pageSize = Number.parseInt(root.dataset.pageSize || "10", 10) || 10;
+  const initialView = String(root.dataset.initialView || "featured") === "new" ? "new" : "featured";
 
   const listEl = document.getElementById("community-list");
   const skeletonEl = document.getElementById("community-skeleton");
@@ -15,7 +16,7 @@
   const tabButtons = Array.from(document.querySelectorAll(".community-tab"));
 
   const state = {
-    view: "featured",
+    view: initialView,
     items: [],
     offset: 0,
     total: 0,
@@ -250,6 +251,10 @@
       });
       load(true);
     });
+  });
+
+  tabButtons.forEach((candidate) => {
+    candidate.classList.toggle("active", candidate.dataset.view === state.view);
   });
 
   listEl.addEventListener("click", (event) => {

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -153,6 +153,8 @@ community.content.refresh-interval=15m
 community.content.featured.window-days=7
 community.content.ranking.decay-enabled=true
 community.votes.daily-limit=100
+community.board.cache-ttl=PT1H
+# community.board.discord.file=/var/lib/homedir/community/board/discord-users.yml
 
 # Home project contributors cache
 home.project.github.repo-owner=os-santiago

--- a/quarkus-app/src/main/resources/messages.properties
+++ b/quarkus-app/src/main/resources/messages.properties
@@ -214,7 +214,7 @@ home_contribute_btn=Contribute on GitHub
 
 home_eyebrow=Retro Platform · OSS Santiago Community
 home_tagline=by OpenSourceSantiago — Community platform to scale your open source teams and projects.
-home_community_title=Social
+home_community_title=Community
 home_community_card_desc=Discover curated community content.
 home_events_title=Events
 home_events_card_desc=Upcoming meetups and gatherings.
@@ -222,20 +222,20 @@ home_projects_title=Project
 home_projects_card_desc=Collaborate on open source projects.
 
 # Home Page Highlights
-home_pill_social=Social
+home_pill_social=Community
 home_pill_events=Events
 home_pill_project=Project
-home_hero_title_combined=Social · Events · Project
+home_hero_title_combined=Community · Events · Project
 home_hero_desc=One-page highlights to quickly discover what is new in the Community platform for OSS Santiago.
 
 home_metric_updates=updates available
 home_metric_upcoming=upcoming events
 home_metric_contributors=active contributors
 
-home_social_highlights_eyebrow=Social highlights
+home_social_highlights_eyebrow=Community highlights
 home_social_highlights_title=Latest community content
 home_btn_open_social=Open
-home_social_empty=No social updates loaded yet. Open Social to check the latest refresh.
+home_social_empty=No community updates loaded yet. Open Community to check the latest refresh.
 
 home_events_highlights_eyebrow=Events highlights
 home_events_highlights_title=Upcoming agenda

--- a/quarkus-app/src/main/resources/messages_es.properties
+++ b/quarkus-app/src/main/resources/messages_es.properties
@@ -211,7 +211,7 @@ home_contribute_btn=Contribuir en GitHub
 
 home_eyebrow=Plataforma retro · Comunidad OSS Santiago
 home_tagline=by OpenSourceSantiago — Plataforma comunitaria para escalar tus equipos y proyectos open source.
-home_community_title=Social
+home_community_title=Community
 home_community_card_desc=Descubre contenido curado por la comunidad.
 home_events_title=Eventos
 home_events_card_desc=Próximas juntas y meetups.
@@ -219,20 +219,20 @@ home_projects_title=Project
 home_projects_card_desc=Colabora en proyectos open source.
 
 # Home Page Highlights
-home_pill_social=Social
+home_pill_social=Community
 home_pill_events=Eventos
 home_pill_project=Proyecto
-home_hero_title_combined=Social · Eventos · Proyecto
+home_hero_title_combined=Community · Eventos · Proyecto
 home_hero_desc=Destacados en una página para descubrir rápidamente qué hay de nuevo en la plataforma comunitaria para OSS Santiago.
 
 home_metric_updates=actualizaciones disponibles
 home_metric_upcoming=próximos eventos
 home_metric_contributors=colaboradores activos
 
-home_social_highlights_eyebrow=Destacados sociales
+home_social_highlights_eyebrow=Destacados de comunidad
 home_social_highlights_title=Contenido reciente de la comunidad
 home_btn_open_social=Open
-home_social_empty=Aún no hay actualizaciones sociales cargadas. Abre Social para ver las últimas novedades.
+home_social_empty=Aún no hay actualizaciones de comunidad cargadas. Abre Community para ver las últimas novedades.
 
 home_events_highlights_eyebrow=Destacados de eventos
 home_events_highlights_title=Agenda próxima

--- a/quarkus-app/src/main/resources/templates/CommunityBoardResource/board.html
+++ b/quarkus-app/src/main/resources/templates/CommunityBoardResource/board.html
@@ -1,0 +1,81 @@
+{#include layout/main activePage="comunidad"}
+{#title}Community Board · Homedir{/title}
+{#body}
+  <header class="page-header events-page-header">
+    <div class="section-header">
+      <p class="section-subtitle">Community · Board</p>
+      <h1>Community Board</h1>
+    </div>
+    <p class="section-subtitle">
+      Quienes participan, desde donde colaboran y como compartir su presencia en la comunidad.
+    </p>
+  </header>
+
+  <section class="page-grid">
+    <div class="section-card events-full-width board-shell">
+      <div class="board-summary-grid">
+        <article class="board-summary-card">
+          <p class="section-subtitle">HomeDir users</p>
+          <h2>{homedirUsers}</h2>
+          <p>People who signed in with Google and created a Homedir account.</p>
+          <a class="btn-primary" href="/comunidad/board/homedir-users">View members</a>
+        </article>
+
+        <article class="board-summary-card">
+          <p class="section-subtitle">GitHub users</p>
+          <h2>{githubUsers}</h2>
+          <p>Contributors with a linked GitHub account in the OSSantiago ecosystem.</p>
+          <a class="btn-primary" href="/comunidad/board/github-users">View members</a>
+        </article>
+
+        <article class="board-summary-card">
+          <p class="section-subtitle">Discord users</p>
+          <h2>{discordUsers}</h2>
+          <p>People who joined our official OSSantiago Discord server.</p>
+          <a class="btn-primary" href="/comunidad/board/discord-users">View members</a>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <style>
+    .board-shell,
+    .board-shell:hover {
+      transform: none;
+      animation: none;
+      cursor: default;
+    }
+
+    .board-summary-grid {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .board-summary-card {
+      border: 2px solid rgba(255, 255, 255, 0.35);
+      border-radius: 10px;
+      padding: 1rem;
+      background: rgba(0, 0, 0, 0.35);
+      display: grid;
+      gap: 0.65rem;
+    }
+
+    .board-summary-card h2 {
+      margin: 0;
+      font-size: 2rem;
+      line-height: 1;
+    }
+
+    .board-summary-card p {
+      margin: 0;
+    }
+
+    @media (max-width: 980px) {
+      .board-summary-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+{/body}
+{/include}

--- a/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
@@ -1,0 +1,206 @@
+{#include layout/main activePage="comunidad"}
+{#title}{groupTitle} · Community Board{/title}
+{#body}
+  <header class="page-header events-page-header">
+    <div class="section-header">
+      <p class="section-subtitle">Community · Board</p>
+      <h1>{groupTitle}</h1>
+    </div>
+    <p class="section-subtitle">{groupDescription}</p>
+  </header>
+
+  <section class="page-grid">
+    <div class="section-card events-full-width board-detail-shell">
+      <div class="board-detail-head">
+        <p class="section-subtitle">{total} members</p>
+        <a class="btn-primary" href="/comunidad/board">Back to board</a>
+      </div>
+
+      <form class="search-form board-search-form" method="get" action="/comunidad/board/{groupPath}">
+        <input
+          type="search"
+          name="q"
+          value="{searchQuery}"
+          placeholder="Search by name, handle or email"
+          aria-label="Search member"
+          class="board-search-input" />
+        <input type="hidden" name="limit" value="{limit}" />
+        <button type="submit" class="btn-primary">Search</button>
+      </form>
+
+      <div class="board-members-grid">
+        {#if members.isEmpty}
+          <article class="board-member-card">
+            <p>No members found with current filter.</p>
+          </article>
+        {#else}
+          {#for member in members}
+            <article class="board-member-card {#if highlightedMember == member.id}is-highlighted{/if}">
+              <div class="board-member-main">
+                {#if member.avatarUrl}
+                  <img class="board-member-avatar" src="{member.avatarUrl}" alt="{member.displayName}" loading="lazy" />
+                {#else}
+                  <div class="board-member-avatar board-member-avatar-fallback">
+                    {member.displayName.substring(0,1)}
+                  </div>
+                {/if}
+                <div class="board-member-text">
+                  <h2>{member.displayName}</h2>
+                  <p>{member.handle}</p>
+                  {#if member.memberSince}
+                    <small>Member since {member.memberSince}</small>
+                  {/if}
+                </div>
+              </div>
+              <div class="board-member-actions">
+                <a class="btn-primary" href="{member.profileLink}">Open</a>
+                <button
+                  type="button"
+                  class="btn-primary board-copy-btn"
+                  data-share-link="{member.shareLink}">
+                  Copy profile link
+                </button>
+              </div>
+            </article>
+          {/for}
+        {/if}
+      </div>
+    </div>
+  </section>
+
+  <style>
+    .board-detail-shell,
+    .board-detail-shell:hover {
+      transform: none;
+      animation: none;
+      cursor: default;
+    }
+
+    .board-detail-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .board-search-form {
+      display: flex;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .board-search-input {
+      flex: 1 1 280px;
+      min-width: 220px;
+      background: rgba(0, 0, 0, 0.55);
+      border: 2px solid rgba(255, 255, 255, 0.5);
+      border-radius: 8px;
+      color: #fff;
+      padding: 0.6rem 0.75rem;
+    }
+
+    .board-members-grid {
+      display: grid;
+      gap: 0.85rem;
+    }
+
+    .board-member-card {
+      border: 2px solid rgba(255, 255, 255, 0.35);
+      border-radius: 10px;
+      padding: 0.85rem;
+      background: rgba(0, 0, 0, 0.35);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 0.9rem;
+      flex-wrap: wrap;
+    }
+
+    .board-member-card.is-highlighted {
+      border-color: rgba(120, 255, 160, 0.9);
+      box-shadow: 0 0 0 2px rgba(120, 255, 160, 0.18) inset;
+    }
+
+    .board-member-main {
+      display: flex;
+      align-items: center;
+      gap: 0.8rem;
+      min-width: 260px;
+    }
+
+    .board-member-avatar {
+      width: 44px;
+      height: 44px;
+      border-radius: 999px;
+      object-fit: cover;
+      border: 2px solid rgba(255, 255, 255, 0.6);
+      background: rgba(0, 0, 0, 0.5);
+      flex-shrink: 0;
+    }
+
+    .board-member-avatar-fallback {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+    }
+
+    .board-member-text h2 {
+      margin: 0;
+      font-size: 1rem;
+    }
+
+    .board-member-text p {
+      margin: 0.2rem 0;
+      opacity: 0.9;
+    }
+
+    .board-member-actions {
+      display: flex;
+      gap: 0.6rem;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .board-copy-btn.is-done {
+      border-color: rgba(120, 255, 160, 0.9);
+      background: rgba(120, 255, 160, 0.15);
+    }
+  </style>
+
+  <script>
+    document.addEventListener("click", async function (event) {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+      const button = target.closest(".board-copy-btn");
+      if (!button) {
+        return;
+      }
+      const rawLink = button.getAttribute("data-share-link");
+      if (!rawLink) {
+        return;
+      }
+      const fullLink = new URL(rawLink, window.location.origin).toString();
+      try {
+        await navigator.clipboard.writeText(fullLink);
+        button.classList.add("is-done");
+        button.textContent = "Link copied";
+        setTimeout(function () {
+          button.classList.remove("is-done");
+          button.textContent = "Copy profile link";
+        }, 1200);
+      } catch (err) {
+        button.textContent = "Copy failed";
+        setTimeout(function () {
+          button.textContent = "Copy profile link";
+        }, 1200);
+      }
+    });
+  </script>
+{/body}
+{/include}

--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -13,10 +13,11 @@
 
   <section class="page-grid">
     <div class="section-card events-full-width community-shell-card">
-      <div id="community-content-root" data-authenticated="{isAuthenticated}" data-page-size="10">
+      <div id="community-content-root" data-authenticated="{isAuthenticated}" data-page-size="10" data-initial-view="{initialView}">
         <div class="community-tabs">
-          <button type="button" class="btn-primary community-tab active" data-view="featured">Destacado</button>
-          <button type="button" class="btn-primary community-tab" data-view="new">Nuevo</button>
+          <button type="button" class="btn-primary community-tab active" data-view="featured">Community Picks</button>
+          <button type="button" class="btn-primary community-tab" data-view="new">Community Feed</button>
+          <a class="btn-primary community-tab-link" href="/comunidad/board">Community Board</a>
         </div>
 
         <div id="community-feedback" class="community-feedback hidden" role="alert"></div>
@@ -36,6 +37,33 @@
         <div class="community-actions">
           <button id="community-load-more" type="button" class="btn-primary hidden">Cargar más</button>
         </div>
+      </div>
+    </div>
+
+    <div class="section-card events-full-width community-board-preview">
+      <div class="section-header">
+        <p class="section-subtitle">Community · Board</p>
+        <h2 class="page-title">Quienes participan</h2>
+      </div>
+      <div class="community-board-grid">
+        <article class="community-board-card">
+          <h3>HomeDir users</h3>
+          <p class="community-board-value">{homedirUsers}</p>
+          <p>People who signed in with Google and created a Homedir account.</p>
+          <a class="btn-primary" href="/comunidad/board/homedir-users">View members</a>
+        </article>
+        <article class="community-board-card">
+          <h3>GitHub users</h3>
+          <p class="community-board-value">{githubUsers}</p>
+          <p>Contributors with a linked GitHub account in the OSSantiago ecosystem.</p>
+          <a class="btn-primary" href="/comunidad/board/github-users">View members</a>
+        </article>
+        <article class="community-board-card">
+          <h3>Discord users</h3>
+          <p class="community-board-value">{discordUsers}</p>
+          <p>People who joined our official OSSantiago Discord server.</p>
+          <a class="btn-primary" href="/comunidad/board/discord-users">View members</a>
+        </article>
       </div>
     </div>
   </section>
@@ -64,6 +92,11 @@
     display: flex;
     gap: 0.75rem;
     margin-bottom: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .community-tab-link {
+    text-decoration: none;
   }
 
   .community-tab.active {
@@ -213,6 +246,39 @@
     margin-top: 1rem;
   }
 
+  .community-board-preview,
+  .community-board-preview:hover {
+    transform: none;
+    animation: none;
+    cursor: default;
+  }
+
+  .community-board-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .community-board-card {
+    border: 2px solid rgba(255, 255, 255, 0.35);
+    border-radius: 10px;
+    padding: 1rem;
+    background: rgba(0, 0, 0, 0.3);
+    display: grid;
+    gap: 0.6rem;
+  }
+
+  .community-board-card h3,
+  .community-board-card p {
+    margin: 0;
+  }
+
+  .community-board-value {
+    font-size: 1.8rem;
+    line-height: 1;
+    font-weight: 700;
+  }
+
   @keyframes pulse {
     0% {
       opacity: 0.45;
@@ -233,6 +299,12 @@
     .community-item-card,
     .community-vote-btn {
       transition: none;
+    }
+  }
+
+  @media (max-width: 980px) {
+    .community-board-grid {
+      grid-template-columns: 1fr;
     }
   }
 </style>

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
@@ -1,0 +1,84 @@
+package com.scanales.eventflow.community;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import com.scanales.eventflow.model.UserProfile;
+import com.scanales.eventflow.service.UserProfileService;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class CommunityBoardResourceTest {
+
+  @Inject UserProfileService userProfileService;
+  @Inject CommunityBoardService boardService;
+
+  @BeforeEach
+  void setup() throws Exception {
+    userProfileService.linkGithub(
+        "board.user@example.com",
+        "Board User",
+        "board.user@example.com",
+        new UserProfile.GithubAccount(
+            "board-user",
+            "https://github.com/board-user",
+            "https://avatars.githubusercontent.com/u/12345",
+            "12345",
+            Instant.parse("2026-02-01T00:00:00Z")));
+
+    Path discordFile = Path.of(System.getProperty("homedir.data.dir"), "community", "board", "discord-users.yml");
+    Files.createDirectories(discordFile.getParent());
+    Files.writeString(
+        discordFile,
+        """
+        members:
+          - id: discord-001
+            display_name: Discord User
+            handle: discord_user#1001
+            joined_at: "2026-01-10T00:00:00Z"
+        """);
+    boardService.resetDiscordCacheForTests();
+  }
+
+  @Test
+  void boardSummaryPageRenders() {
+    given()
+        .when()
+        .get("/comunidad/board")
+        .then()
+        .statusCode(200)
+        .body(containsString("Community Board"))
+        .body(containsString("HomeDir users"))
+        .body(containsString("GitHub users"))
+        .body(containsString("Discord users"));
+  }
+
+  @Test
+  void boardDetailPageRendersMembers() {
+    given()
+        .when()
+        .get("/comunidad/board/github-users")
+        .then()
+        .statusCode(200)
+        .body(containsString("board-user"))
+        .body(containsString("Copy profile link"));
+  }
+
+  @Test
+  void englishCommunityAliasRedirectsToLocalizedBoardPath() {
+    given()
+        .redirects()
+        .follow(false)
+        .when()
+        .get("/community/board")
+        .then()
+        .statusCode(303)
+        .header("Location", containsString("/comunidad/board"));
+  }
+}


### PR DESCRIPTION
## Summary
- extends `/comunidad` with `Community Board` summary cards without replacing the existing visual language
- adds new routes for board browsing: `/comunidad/board` and `/comunidad/board/{group}` with search + copy profile link
- keeps curated content flow (`Community Picks`/`Community Feed`) and adds direct board access
- adds localized aliases for `/community/feed`, `/community/picks`, `/community/board` and `/community/board/{group}`
- adds optional Discord users file source with in-memory cache (`community.board.cache-ttl`) to avoid per-request backend calls

## Validation
- `./mvnw -q -DskipTests compile`
- `./mvnw -q "-Dtest=CommunityBoardResourceTest,CommunityContentApiResourceTest" test`

## Notes
- preserves current look and feel by reusing existing page/card styles and avoiding global CSS changes
