### PR TITLE
feat(community): add stable member share profiles

### DIFF
--- a/docs/community-content.md
+++ b/docs/community-content.md
@@ -11,6 +11,7 @@ This module powers `/comunidad` with curated content loaded from files and commu
 - Community Board:
   - `/comunidad/board` summary (HomeDir users, GitHub users, Discord users).
   - `/comunidad/board/{group}` detail list with search and profile-link copy.
+  - `/community/member/{group}/{id}` stable shareable member profile page.
 
 ## Content Directory
 - Production target: `${homedir.data.dir}/community/content`

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberAliasResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberAliasResource.java
@@ -1,0 +1,19 @@
+package com.scanales.eventflow.public_;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+
+@Path("/comunidad/member")
+@PermitAll
+public class CommunityMemberAliasResource {
+
+  @GET
+  @Path("/{group}/{id}")
+  public Response redirect(@PathParam("group") String group, @PathParam("id") String id) {
+    return Response.seeOther(URI.create("/community/member/" + group + "/" + id)).build();
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberResource.java
@@ -1,0 +1,125 @@
+package com.scanales.eventflow.public_;
+
+import com.scanales.eventflow.community.CommunityBoardGroup;
+import com.scanales.eventflow.community.CommunityBoardMemberView;
+import com.scanales.eventflow.community.CommunityBoardService;
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.annotation.security.PermitAll;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import java.util.Optional;
+import org.jboss.logging.Logger;
+
+@Path("/community/member")
+public class CommunityMemberResource {
+  private static final Logger LOG = Logger.getLogger(CommunityMemberResource.class);
+
+  @Inject SecurityIdentity identity;
+  @Inject CommunityBoardService boardService;
+
+  @CheckedTemplate
+  static class Templates {
+    static native TemplateInstance profile(
+        boolean isAuthenticated,
+        String groupPath,
+        String groupTitle,
+        String displayName,
+        String handle,
+        String avatarUrl,
+        String memberSince,
+        String profileLink,
+        String boardLink);
+  }
+
+  @GET
+  @Path("/{group}/{id}")
+  @PermitAll
+  @Produces(MediaType.TEXT_HTML)
+  public TemplateInstance profile(@PathParam("group") String groupPath, @PathParam("id") String id) {
+    CommunityBoardGroup group =
+        CommunityBoardGroup.fromPath(groupPath).orElseThrow(() -> new NotFoundException("group_not_found"));
+    CommunityBoardMemberView member =
+        boardService.findMember(group, id).orElseThrow(() -> new NotFoundException("member_not_found"));
+    TemplateInstance template =
+        Templates.profile(
+            isAuthenticated(),
+            group.path(),
+            titleFor(group),
+            member.displayName(),
+            member.handle(),
+            member.avatarUrl(),
+            member.memberSince(),
+            profileLinkFor(group, member),
+            "/comunidad/board/" + group.path());
+    return withLayoutData(template);
+  }
+
+  private String profileLinkFor(CommunityBoardGroup group, CommunityBoardMemberView member) {
+    if (group == CommunityBoardGroup.GITHUB_USERS) {
+      return "/u/" + member.id();
+    }
+    if (group == CommunityBoardGroup.HOMEDIR_USERS
+        && member.handle() != null
+        && member.handle().startsWith("@")
+        && member.handle().length() > 1) {
+      return "/u/" + member.handle().substring(1);
+    }
+    return "/comunidad/board/" + group.path() + "?member=" + member.id();
+  }
+
+  private String titleFor(CommunityBoardGroup group) {
+    return switch (group) {
+      case HOMEDIR_USERS -> "HomeDir users";
+      case GITHUB_USERS -> "GitHub users";
+      case DISCORD_USERS -> "Discord users";
+    };
+  }
+
+  private TemplateInstance withLayoutData(TemplateInstance template) {
+    boolean authenticated = isAuthenticated();
+    String name = currentUserName().orElse(null);
+    return template
+        .data("activePage", "comunidad")
+        .data("userAuthenticated", authenticated)
+        .data("userName", name)
+        .data("userInitial", initialFrom(name));
+  }
+
+  private Optional<String> currentUserName() {
+    if (!isAuthenticated()) {
+      return Optional.empty();
+    }
+    String name = identity.getAttribute("name");
+    if (name == null || name.isBlank()) {
+      name = identity.getPrincipal() != null ? identity.getPrincipal().getName() : null;
+    }
+    return Optional.ofNullable(name);
+  }
+
+  private boolean isAuthenticated() {
+    try {
+      return identity != null && !identity.isAnonymous();
+    } catch (Exception e) {
+      LOG.warn("Security identity check failed (treating as anonymous): " + e.getMessage());
+      return false;
+    }
+  }
+
+  private String initialFrom(String name) {
+    if (name == null) {
+      return null;
+    }
+    String trimmed = name.trim();
+    if (trimmed.isEmpty()) {
+      return null;
+    }
+    return trimmed.substring(0, 1).toUpperCase();
+  }
+}

--- a/quarkus-app/src/main/resources/templates/CommunityMemberResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/CommunityMemberResource/profile.html
@@ -1,0 +1,90 @@
+{#include layout/main activePage="comunidad"}
+{#title}{displayName} · Community Member{/title}
+{#body}
+  <header class="page-header events-page-header">
+    <div class="section-header">
+      <p class="section-subtitle">Community · Member</p>
+      <h1>{displayName}</h1>
+    </div>
+    <p class="section-subtitle">{groupTitle}</p>
+  </header>
+
+  <section class="page-grid">
+    <div class="section-card events-full-width board-member-shell">
+      <article class="board-member-profile">
+        {#if avatarUrl}
+          <img class="board-member-avatar-lg" src="{avatarUrl}" alt="{displayName}" loading="lazy" />
+        {#else}
+          <div class="board-member-avatar-lg board-member-avatar-fallback-lg">
+            {displayName.substring(0,1)}
+          </div>
+        {/if}
+
+        <div class="board-member-profile-text">
+          <h2>{displayName}</h2>
+          <p>{handle}</p>
+          {#if memberSince}
+            <small>Member since {memberSince}</small>
+          {/if}
+        </div>
+      </article>
+
+      <div class="board-member-profile-actions">
+        <a class="btn-primary" href="{profileLink}">Open profile</a>
+        <a class="btn-primary" href="{boardLink}">Back to board</a>
+      </div>
+    </div>
+  </section>
+
+  <style>
+    .board-member-shell,
+    .board-member-shell:hover {
+      transform: none;
+      animation: none;
+      cursor: default;
+    }
+
+    .board-member-profile {
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .board-member-avatar-lg {
+      width: 72px;
+      height: 72px;
+      border-radius: 999px;
+      object-fit: cover;
+      border: 3px solid rgba(255, 255, 255, 0.65);
+      background: rgba(0, 0, 0, 0.45);
+      flex-shrink: 0;
+    }
+
+    .board-member-avatar-fallback-lg {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: 1.25rem;
+    }
+
+    .board-member-profile-text h2,
+    .board-member-profile-text p {
+      margin: 0;
+    }
+
+    .board-member-profile-text p {
+      margin-top: 0.2rem;
+      opacity: 0.9;
+    }
+
+    .board-member-profile-actions {
+      margin-top: 1rem;
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+  </style>
+{/body}
+{/include}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
@@ -67,6 +67,7 @@ public class CommunityBoardResourceTest {
         .then()
         .statusCode(200)
         .body(containsString("board-user"))
+        .body(containsString("/community/member/github-users/board-user"))
         .body(containsString("Copy profile link"));
   }
 
@@ -80,5 +81,28 @@ public class CommunityBoardResourceTest {
         .then()
         .statusCode(303)
         .header("Location", containsString("/comunidad/board"));
+  }
+
+  @Test
+  void memberSharePageRenders() {
+    given()
+        .when()
+        .get("/community/member/github-users/board-user")
+        .then()
+        .statusCode(200)
+        .body(containsString("Board User"))
+        .body(containsString("Open profile"));
+  }
+
+  @Test
+  void spanishMemberAliasRedirectsToCanonicalSharePath() {
+    given()
+        .redirects()
+        .follow(false)
+        .when()
+        .get("/comunidad/member/github-users/board-user")
+        .then()
+        .statusCode(303)
+        .header("Location", containsString("/community/member/github-users/board-user"));
   }
 }


### PR DESCRIPTION
## Summary
- adds stable shareable member pages at `/community/member/{group}/{id}`
- adds Spanish alias redirect `/comunidad/member/{group}/{id}`
- updates Community Board member links to use stable share URLs instead of transient query links
- avoids exposing raw HomeDir user emails in URLs by using deterministic non-PII slugs
- extends tests for share page and alias redirect coverage

## Validation
- `./mvnw -q -DskipTests compile`
- `./mvnw -q "-Dtest=CommunityBoardResourceTest,CommunityContentApiResourceTest" test`
