### PR TITLE
fix(community): return 404 for unknown member share links

### DIFF
--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
@@ -105,4 +105,9 @@ public class CommunityBoardResourceTest {
         .statusCode(303)
         .header("Location", containsString("/community/member/github-users/board-user"));
   }
+
+  @Test
+  void unknownMemberSharePageReturnsNotFound() {
+    given().when().get("/community/member/github-users/does-not-exist").then().statusCode(404);
+  }
 }


### PR DESCRIPTION
## Summary
- fixes `/community/member/{group}/{id}` to return HTTP 404 when group or member does not exist
- avoids surfacing a 500 error for unknown share links
- adds regression test for unknown member path

## Validation
- `./mvnw -q -DskipTests compile`
- `./mvnw -q "-Dtest=CommunityBoardResourceTest,CommunityContentApiResourceTest" test`
