### PR TITLE
feat(community): unify submenu navigation across community pages

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityBoardResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityBoardResource.java
@@ -55,7 +55,7 @@ public class CommunityBoardResource {
             summary.homedirUsers(),
             summary.githubUsers(),
             summary.discordUsers());
-    return withLayoutData(template);
+    return withLayoutData(template, "board");
   }
 
   @GET
@@ -86,14 +86,15 @@ public class CommunityBoardResource {
             slice.offset(),
             normalizeHighlightedMember(highlightedMember),
             slice.items());
-    return withLayoutData(template);
+    return withLayoutData(template, "board");
   }
 
-  private TemplateInstance withLayoutData(TemplateInstance template) {
+  private TemplateInstance withLayoutData(TemplateInstance template, String activeCommunitySubmenu) {
     boolean authenticated = isAuthenticated();
     String name = currentUserName().orElse(null);
     return template
         .data("activePage", "comunidad")
+        .data("activeCommunitySubmenu", activeCommunitySubmenu)
         .data("userAuthenticated", authenticated)
         .data("userName", name)
         .data("userInitial", initialFrom(name));

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberResource.java
@@ -64,7 +64,7 @@ public class CommunityMemberResource {
             member.memberSince(),
             profileLinkFor(group, member),
             "/comunidad/board/" + group.path());
-    return Response.ok(withLayoutData(template)).build();
+    return Response.ok(withLayoutData(template, "board")).build();
   }
 
   private String profileLinkFor(CommunityBoardGroup group, CommunityBoardMemberView member) {
@@ -88,11 +88,12 @@ public class CommunityMemberResource {
     };
   }
 
-  private TemplateInstance withLayoutData(TemplateInstance template) {
+  private TemplateInstance withLayoutData(TemplateInstance template, String activeCommunitySubmenu) {
     boolean authenticated = isAuthenticated();
     String name = currentUserName().orElse(null);
     return template
         .data("activePage", "comunidad")
+        .data("activeCommunitySubmenu", activeCommunitySubmenu)
         .data("userAuthenticated", authenticated)
         .data("userName", name)
         .data("userInitial", initialFrom(name));

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityResource.java
@@ -45,6 +45,7 @@ public class CommunityResource {
             summary.discordUsers());
     return template
         .data("activePage", "comunidad")
+        .data("activeCommunitySubmenu", "new".equals(initialView) ? "feed" : "picks")
         .data("userAuthenticated", authenticated)
         .data("userName", currentUserName().orElse(null))
         .data("userInitial", initialFrom(currentUserName().orElse(null)));

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -2370,6 +2370,22 @@ footer {
   letter-spacing: 0.85px;
 }
 
+.community-submenu {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 0.25rem 0 0.9rem;
+}
+
+.community-submenu-link {
+  text-decoration: none;
+}
+
+.community-submenu-link-active {
+  filter: brightness(1.08);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.25) inset;
+}
+
 @media (max-width: 1120px) {
   .homedir-main-home {
     max-width: 1200px;

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -51,7 +51,7 @@ settings_save=Guardar Preferencias
 
 # --- Global Navigation ---
 nav_home=Inicio
-nav_community=Comunidad
+nav_community=Community
 nav_projects=Proyectos
 nav_events=Eventos
 nav_quests=Misiones

--- a/quarkus-app/src/main/resources/templates/CommunityBoardResource/board.html
+++ b/quarkus-app/src/main/resources/templates/CommunityBoardResource/board.html
@@ -10,6 +10,7 @@
       Quienes participan, desde donde colaboran y como compartir su presencia en la comunidad.
     </p>
   </header>
+  {#include fragments/community-submenu.html /}
 
   <section class="page-grid">
     <div class="section-card events-full-width board-shell">

--- a/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
@@ -8,12 +8,12 @@
     </div>
     <p class="section-subtitle">{groupDescription}</p>
   </header>
+  {#include fragments/community-submenu.html /}
 
   <section class="page-grid">
     <div class="section-card events-full-width board-detail-shell">
       <div class="board-detail-head">
         <p class="section-subtitle">{total} members</p>
-        <a class="btn-primary" href="/comunidad/board">Back to board</a>
       </div>
 
       <form class="search-form board-search-form" method="get" action="/comunidad/board/{groupPath}">
@@ -78,7 +78,7 @@
 
     .board-detail-head {
       display: flex;
-      justify-content: space-between;
+      justify-content: flex-start;
       align-items: center;
       gap: 1rem;
       margin-bottom: 1rem;

--- a/quarkus-app/src/main/resources/templates/CommunityMemberResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/CommunityMemberResource/profile.html
@@ -8,6 +8,7 @@
     </div>
     <p class="section-subtitle">{groupTitle}</p>
   </header>
+  {#include fragments/community-submenu.html /}
 
   <section class="page-grid">
     <div class="section-card events-full-width board-member-shell">

--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -10,16 +10,11 @@
       Descubre recursos curados, vota en 3 estados y sigue lo más relevante de la semana.
     </p>
   </header>
+  {#include fragments/community-submenu.html /}
 
   <section class="page-grid">
     <div class="section-card events-full-width community-shell-card">
       <div id="community-content-root" data-authenticated="{isAuthenticated}" data-page-size="10" data-initial-view="{initialView}">
-        <div class="community-tabs">
-          <button type="button" class="btn-primary community-tab active" data-view="featured">Community Picks</button>
-          <button type="button" class="btn-primary community-tab" data-view="new">Community Feed</button>
-          <a class="btn-primary community-tab-link" href="/comunidad/board">Community Board</a>
-        </div>
-
         <div id="community-feedback" class="community-feedback hidden" role="alert"></div>
 
         <div id="community-skeleton" class="community-skeleton hidden" aria-hidden="true">
@@ -88,22 +83,6 @@
     content: none;
   }
 
-  .community-tabs {
-    display: flex;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-    flex-wrap: wrap;
-  }
-
-  .community-tab-link {
-    text-decoration: none;
-  }
-
-  .community-tab.active {
-    filter: brightness(1.1);
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.25) inset;
-  }
-
   .community-feedback {
     margin-bottom: 1rem;
     padding: 0.75rem;
@@ -142,7 +121,7 @@
     gap: 1rem;
   }
 
-  /* Match Home card behavior and disable retro glow sweep on Social cards */
+  /* Match Home card behavior and disable retro glow sweep on Community cards */
   .community-item-card,
   .community-list .section-card {
     background: rgba(0, 0, 0, 0.45);

--- a/quarkus-app/src/main/resources/templates/fragments/community-submenu.html
+++ b/quarkus-app/src/main/resources/templates/fragments/community-submenu.html
@@ -1,0 +1,15 @@
+{@ String activeCommunitySubmenu = "main"}
+<nav class="community-submenu" aria-label="Community submenu">
+  <a href="/comunidad" class="btn-primary community-submenu-link {#if activeCommunitySubmenu == 'main'}community-submenu-link-active{/if}">
+    Community Main
+  </a>
+  <a href="/comunidad/feed" class="btn-primary community-submenu-link {#if activeCommunitySubmenu == 'feed'}community-submenu-link-active{/if}">
+    Community Feed
+  </a>
+  <a href="/comunidad/picks" class="btn-primary community-submenu-link {#if activeCommunitySubmenu == 'picks'}community-submenu-link-active{/if}">
+    Community Picks
+  </a>
+  <a href="/comunidad/board" class="btn-primary community-submenu-link {#if activeCommunitySubmenu == 'board'}community-submenu-link-active{/if}">
+    Community Board
+  </a>
+</nav>


### PR DESCRIPTION
## Summary
- changes Community navigation label in Spanish i18n bundle to `Community` for main menu consistency
- adds a shared Community submenu fragment used by main Community, Board, Board detail and Member pages
- standardizes submenu buttons across all Community views: `Community Main`, `Community Feed`, `Community Picks`, `Community Board`
- highlights current submenu with an active state so users can quickly identify current section
- includes an explicit `Community Main` return button in all subpages via the shared submenu
- keeps existing look & feel by extending current button/card styles (no redesign)

## Validation
- `./mvnw -q -DskipTests compile`
- `./mvnw -q "-Dtest=CommunityBoardResourceTest" test`
- `./mvnw -q "-Dtest=CommunityBoardResourceTest,CommunityContentApiResourceTest" test`
