### PR TITLE
fix(i18n): rename main nav Social label to Community

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
@@ -296,7 +296,7 @@ public interface AppMessages {
     @Message("Join Community")
     String btn_join_community();
 
-    @Message("Social")
+    @Message("Community")
     String nav_community();
 
     @Message("Latest community activity")


### PR DESCRIPTION
## Summary
- updates `AppMessages.nav_community` default from `Social` to `Community`
- fixes the main top navigation label rendering as Social in production

## Validation
- `./mvnw -q -DskipTests compile`
