### PR TITLE
feat(community): moderation queue UI for community feed

### DIFF
--- a/docs/community-content.md
+++ b/docs/community-content.md
@@ -92,6 +92,7 @@ Submission notes:
 - Proposals are persisted asynchronously in `${homedir.data.dir}/community/submissions/pending.json`.
 - Daily guardrail per user: `community.submissions.daily-limit` (default `5`).
 - On approve, Homedir generates one YAML item in the curated content directory so the existing feed/ranking/votes pipeline remains unchanged.
+- Admins can moderate pending proposals from `/comunidad/moderation` (approve/reject UI backed by the API endpoints above).
 
 ## Community Board Data Sources
 - `HomeDir users`: internal `UserProfile` store (Google-auth users with local profile).

--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -1,3 +1,5 @@
+{@ boolean isAdmin = false}
+{@ String activeCommunitySubmenu = "main"}
 {#include layout/main activePage="comunidad"}
 {#title}Comunidad Curada · Homedir{/title}
 {#body}
@@ -62,7 +64,7 @@
       </div>
     </div>
 
-    <div class="section-card events-full-width community-submissions-card" id="community-submissions-root" data-authenticated="{isAuthenticated}">
+    <div class="section-card events-full-width community-submissions-card" id="community-submissions-root" data-authenticated="{isAuthenticated}" data-admin="{isAdmin}" data-active-submenu="{activeCommunitySubmenu}">
       <div class="section-header">
         <p class="section-subtitle">Community · Feed</p>
         <h2 class="page-title">Proponer contenido</h2>
@@ -103,6 +105,16 @@
         </div>
         <div id="community-submissions-list" class="community-submissions-list"></div>
       </div>
+      {#if isAdmin}
+      <div class="community-moderation-wrap" id="community-moderation-panel">
+        <h3>Moderation queue</h3>
+        <p class="section-subtitle">Revisa propuestas pendientes y publícalas en el feed oficial.</p>
+        <div id="community-moderation-empty" class="community-empty hidden">
+          <p>No hay propuestas pendientes de moderación.</p>
+        </div>
+        <div id="community-moderation-list" class="community-submissions-list"></div>
+      </div>
+      {/if}
       {#else}
       <div class="community-empty">
         <p>Inicia sesión para proponer contenido al Community Feed.</p>
@@ -328,6 +340,32 @@
   .community-submissions-list {
     display: grid;
     gap: 0.65rem;
+  }
+
+  .community-moderation-wrap {
+    margin-top: 1rem;
+    display: grid;
+    gap: 0.75rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.2);
+    padding-top: 1rem;
+  }
+
+  .community-moderation-actions {
+    display: flex;
+    gap: 0.55rem;
+    flex-wrap: wrap;
+    margin-top: 0.2rem;
+  }
+
+  .community-moderation-note {
+    width: 100%;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.2);
+    color: inherit;
+    font: inherit;
+    padding: 0.45rem 0.55rem;
+    min-height: 58px;
   }
 
   .community-submission-item {

--- a/quarkus-app/src/main/resources/templates/fragments/community-submenu.html
+++ b/quarkus-app/src/main/resources/templates/fragments/community-submenu.html
@@ -1,4 +1,5 @@
 {@ String activeCommunitySubmenu = "main"}
+{@ boolean isAdmin = false}
 <nav class="community-submenu" aria-label="Community submenu">
   <a href="/comunidad" class="btn-primary community-submenu-link {#if activeCommunitySubmenu == 'main'}community-submenu-link-active{/if}">
     Community Main
@@ -12,4 +13,9 @@
   <a href="/comunidad/board" class="btn-primary community-submenu-link {#if activeCommunitySubmenu == 'board'}community-submenu-link-active{/if}">
     Community Board
   </a>
+  {#if isAdmin}
+  <a href="/comunidad/moderation" class="btn-primary community-submenu-link {#if activeCommunitySubmenu == 'moderation'}community-submenu-link-active{/if}">
+    Moderation
+  </a>
+  {/if}
 </nav>

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityModerationPageTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityModerationPageTest.java
@@ -1,0 +1,33 @@
+package com.scanales.eventflow.community;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class CommunityModerationPageTest {
+
+  @Test
+  void moderationPageRendersForAnonymous() {
+    given()
+        .when()
+        .get("/comunidad/moderation")
+        .then()
+        .statusCode(200)
+        .body(containsString("Proponer contenido"));
+  }
+
+  @Test
+  @TestSecurity(user = "admin@example.org")
+  void moderationQueueVisibleForAdmin() {
+    given()
+        .when()
+        .get("/comunidad/moderation")
+        .then()
+        .statusCode(200)
+        .body(containsString("Moderation queue"));
+  }
+}


### PR DESCRIPTION
## Summary
- add admin moderation workflow UI in /comunidad for pending submissions
- add Moderation entry in community submenu for admins (/comunidad/moderation)
- allow approve/reject actions directly from the page using existing submissions API
- keep current product look-and-feel and reuse existing community cards/styles
- document moderation route in docs/community-content.md

## Testing
- CommunityModerationPageTest
- CommunityBoardResourceTest
- CommunityContentApiResourceTest
- CommunitySubmissionApiResourceTest