### PR TITLE
test(admin): align ADMIN_LIST with admin tests

### DIFF
--- a/quarkus-app/src/test/resources/application.properties
+++ b/quarkus-app/src/test/resources/application.properties
@@ -6,4 +6,4 @@ metrics.trend.decimals=1
 metrics.min-view-threshold=0
 notifications.upcoming.window=PT5M
 notifications.endingSoon.window=PT5M
-ADMIN_LIST=admin@example.org
+ADMIN_LIST=admin@example.org,sergio.canales.e@gmail.com


### PR DESCRIPTION
Fixes recurring PR Validation failures (403 on admin test endpoints) by aligning test ADMIN_LIST with the admin test user.\n\nValidation:\n- mvn -f quarkus-app/pom.xml -Dtest=AdminAccessTest,AdminMetricsExportTest test