### PR TITLE
fix: avoid 500 when approving community submissions

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunitySubmissionApiResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunitySubmissionApiResource.java
@@ -103,10 +103,16 @@ public class CommunitySubmissionApiResource {
       CommunitySubmission submission =
           submissionService.approve(id, currentUserId().orElse("admin"), request != null ? request.note() : null);
       return Response.ok(new SubmissionResponse(toView(submission))).build();
+    } catch (CommunitySubmissionService.ValidationException e) {
+      return Response.status(Response.Status.BAD_REQUEST).entity(Map.of("error", e.getMessage())).build();
     } catch (CommunitySubmissionService.DuplicateSubmissionException e) {
       return Response.status(Response.Status.CONFLICT).entity(Map.of("error", e.getMessage())).build();
     } catch (CommunitySubmissionService.NotFoundException e) {
       return Response.status(Response.Status.NOT_FOUND).entity(Map.of("error", e.getMessage())).build();
+    } catch (IllegalStateException e) {
+      return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+          .entity(Map.of("error", "approve_storage_unavailable"))
+          .build();
     }
   }
 

--- a/quarkus-app/src/main/resources/META-INF/resources/js/community-submissions.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/community-submissions.js
@@ -235,6 +235,9 @@
       if (response.status === 409) {
         throw new Error("La URL ya existe en el feed curado.");
       }
+      if (response.status === 503 || errorCode === "approve_storage_unavailable") {
+        throw new Error("No fue posible publicar el contenido en este momento. Reintenta en unos minutos.");
+      }
       throw new Error(errorCode || "No se pudo procesar la moderación.");
     }
   }


### PR DESCRIPTION
## Summary
- harden `CommunitySubmissionService.approve` for legacy/incomplete submissions
- fallback from atomic move to regular move when filesystem does not support `ATOMIC_MOVE`
- return explicit API errors (`400` invalid data, `503` storage unavailable) instead of generic `500`
- show clear moderation error message in UI when storage is unavailable

## Validation
- `mvn -f quarkus-app/pom.xml "-Dtest=CommunityModerationPageTest,CommunitySubmissionApiResourceTest,CommunityContentApiResourceTest" test`
