### PR TITLE
fix: cleanup moderation queue flow after approve

### DIFF
--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -52,7 +52,7 @@
     </div>
     {/if}
 
-    {#if activeCommunitySubmenu == 'propose' || activeCommunitySubmenu == 'moderation'}
+    {#if activeCommunitySubmenu == 'propose'}
     <div class="section-card events-full-width community-submissions-card" id="community-submissions-root" data-authenticated="{isAuthenticated}" data-admin="{isAdmin}" data-active-submenu="{activeCommunitySubmenu}">
       <div class="section-header">
         <p class="section-subtitle">Community · Feed</p>
@@ -94,20 +94,34 @@
         </div>
         <div id="community-submissions-list" class="community-submissions-list"></div>
       </div>
+      {#else}
+      <div class="community-empty">
+        <p>Inicia sesión para proponer contenido al Community Feed.</p>
+        <a class="btn-primary" href="/private/profile">Iniciar sesión</a>
+      </div>
+      {/if}
+    </div>
+    {/if}
+
+    {#if activeCommunitySubmenu == 'moderation'}
+    <div class="section-card events-full-width community-submissions-card" id="community-submissions-root" data-authenticated="{isAuthenticated}" data-admin="{isAdmin}" data-active-submenu="{activeCommunitySubmenu}">
+      <div class="section-header">
+        <p class="section-subtitle">Community · Moderation</p>
+        <h2 class="page-title">Moderation queue</h2>
+      </div>
+      <p class="section-subtitle">Revisa propuestas pendientes y publícalas en el feed oficial.</p>
+      <div id="community-submission-feedback" class="community-feedback hidden" role="alert"></div>
       {#if isAdmin}
-      <div class="community-moderation-wrap" id="community-moderation-panel">
-        <h3>Moderation queue</h3>
-        <p class="section-subtitle">Revisa propuestas pendientes y publícalas en el feed oficial.</p>
+      <div class="community-moderation-wrap community-moderation-wrap--standalone" id="community-moderation-panel">
         <div id="community-moderation-empty" class="community-empty hidden">
           <p>No hay propuestas pendientes de moderación.</p>
         </div>
         <div id="community-moderation-list" class="community-submissions-list"></div>
       </div>
       {/if}
-      {#else}
+      {#if !isAdmin}
       <div class="community-empty">
-        <p>Inicia sesión para proponer contenido al Community Feed.</p>
-        <a class="btn-primary" href="/private/profile">Iniciar sesión</a>
+        <p>Solo administradores pueden moderar propuestas.</p>
       </div>
       {/if}
     </div>
@@ -348,6 +362,12 @@
     gap: 0.75rem;
     border-top: 1px solid rgba(255, 255, 255, 0.2);
     padding-top: 1rem;
+  }
+
+  .community-moderation-wrap--standalone {
+    margin-top: 0;
+    border-top: 0;
+    padding-top: 0;
   }
 
   .community-moderation-actions {

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityModerationPageTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityModerationPageTest.java
@@ -17,7 +17,8 @@ public class CommunityModerationPageTest {
         .get("/comunidad/moderation")
         .then()
         .statusCode(200)
-        .body(containsString("Proponer contenido"));
+        .body(containsString("Moderation queue"))
+        .body(containsString("Solo administradores pueden moderar propuestas."));
   }
 
   @Test

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunitySubmissionApiResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunitySubmissionApiResourceTest.java
@@ -212,6 +212,14 @@ public class CommunitySubmissionApiResourceTest {
             .extract()
             .path("item.content_id");
 
+    given()
+        .accept("application/json")
+        .when()
+        .get("/api/community/submissions/pending?limit=10&offset=0")
+        .then()
+        .statusCode(200)
+        .body("items", hasSize(0));
+
     assertTrue(waitForContent(contentId, Duration.ofSeconds(5)));
   }
 


### PR DESCRIPTION
## Summary
- split Community views so `/comunidad/moderation` shows only moderation queue (no propose form / no "Mis propuestas")
- refactor community submissions JS to support optional sections by submenu
- apply optimistic queue cleanup after approve/reject and hide already moderated ids in current session
- keep queue rendering strictly for `pending` status
- add tests for moderation page content and pending list cleanup after approve

## Validation
- `mvn -f quarkus-app/pom.xml "-Dtest=CommunityModerationPageTest,CommunitySubmissionApiResourceTest,CommunityContentApiResourceTest" test`
