### PR TITLE
fix: persist community approvals consistently across refresh

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunitySubmissionApiResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunitySubmissionApiResource.java
@@ -55,6 +55,10 @@ public class CommunitySubmissionApiResource {
       return Response.status(Response.Status.CONFLICT).entity(Map.of("error", e.getMessage())).build();
     } catch (CommunitySubmissionService.RateLimitExceededException e) {
       return Response.status(429).entity(Map.of("error", e.getMessage())).build();
+    } catch (IllegalStateException e) {
+      return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+          .entity(Map.of("error", "submission_storage_unavailable"))
+          .build();
     }
   }
 
@@ -130,6 +134,10 @@ public class CommunitySubmissionApiResource {
       return Response.ok(new SubmissionResponse(toView(submission))).build();
     } catch (CommunitySubmissionService.NotFoundException e) {
       return Response.status(Response.Status.NOT_FOUND).entity(Map.of("error", e.getMessage())).build();
+    } catch (IllegalStateException e) {
+      return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+          .entity(Map.of("error", "reject_storage_unavailable"))
+          .build();
     }
   }
 

--- a/quarkus-app/src/main/resources/META-INF/resources/js/community-submissions.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/community-submissions.js
@@ -19,7 +19,6 @@
   const moderationListEl = document.getElementById("community-moderation-list");
   const moderationEmptyEl = document.getElementById("community-moderation-empty");
   const moderationPanel = document.getElementById("community-moderation-panel");
-  const moderatedIds = new Set();
 
   if (!feedbackEl) {
     return;
@@ -105,7 +104,7 @@
       ? items.filter((item) => {
           const id = String(item && item.id ? item.id : "");
           const status = String(item && item.status ? item.status : "pending").toLowerCase();
-          return Boolean(id) && status === "pending" && !moderatedIds.has(id);
+          return Boolean(id) && status === "pending";
         })
       : [];
     moderationListEl.textContent = "";
@@ -180,7 +179,6 @@
         try {
           hideFeedback();
           await moderateSubmission(submissionId, action, note.value.trim());
-          moderatedIds.add(submissionId);
           card.remove();
           if (moderationListEl.children.length === 0) {
             moderationEmptyEl.classList.remove("hidden");

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunitySubmissionApiResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunitySubmissionApiResourceTest.java
@@ -4,8 +4,10 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.scanales.eventflow.service.PersistenceService;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import jakarta.inject.Inject;
@@ -23,6 +25,7 @@ public class CommunitySubmissionApiResourceTest {
 
   @Inject CommunitySubmissionService submissionService;
   @Inject CommunityContentService contentService;
+  @Inject PersistenceService persistenceService;
 
   @BeforeEach
   void setup() throws Exception {
@@ -219,6 +222,10 @@ public class CommunitySubmissionApiResourceTest {
         .then()
         .statusCode(200)
         .body("items", hasSize(0));
+
+    CommunitySubmission persisted = persistenceService.loadCommunitySubmissions().get(created.id());
+    assertNotNull(persisted);
+    assertTrue(persisted.status() == CommunitySubmissionStatus.APPROVED);
 
     assertTrue(waitForContent(contentId, Duration.ofSeconds(5)));
   }


### PR DESCRIPTION
## Summary
- make community submissions persistence deterministic for create/approve/reject
- save submissions synchronously and refresh in-memory state from disk before reads/writes
- add persistence fallback for filesystems without `ATOMIC_MOVE` in `PersistenceService`
- return explicit `503` errors for submission storage failures in create/reject
- avoid masking backend state in moderation UI by removing local moderated-id suppression
- add persistence assertion in approval API test

## Validation
- `mvn -f quarkus-app/pom.xml "-Dtest=CommunityModerationPageTest,CommunitySubmissionApiResourceTest,CommunityContentApiResourceTest,PersistenceServiceTest" test`
