### PR TITLE
fix(community): harden approval persistence + storage permissions

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/community-submissions.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/community-submissions.js
@@ -250,6 +250,7 @@
     if (!response.ok) {
       const data = await response.json().catch(() => ({}));
       const errorCode = String(data.error || "");
+      const detail = String(data.detail || "");
       if (response.status === 403) {
         throw new Error("Solo admins pueden moderar propuestas.");
       }
@@ -260,7 +261,8 @@
         throw new Error("La URL ya existe en el feed curado.");
       }
       if (response.status === 503 || errorCode === "approve_storage_unavailable") {
-        throw new Error("No fue posible publicar el contenido en este momento. Reintenta en unos minutos.");
+        const suffix = detail ? ` (${detail})` : "";
+        throw new Error(`No fue posible publicar el contenido en este momento. Reintenta en unos minutos.${suffix}`);
       }
       throw new Error(errorCode || "No se pudo procesar la moderación.");
     }


### PR DESCRIPTION
## Summary\n- harden moderation approval persistence and return clearer storage diagnostics on 503\n- validate content dir writability before writing approved YAML files\n- include backend error detail in moderation UI message for faster triage\n- prepare community storage permissions in homedir-update.sh on every deploy to avoid regressions\n\n## Validation\n- mvn -f quarkus-app/pom.xml -Dtest=CommunitySubmissionApiResourceTest test\n- VPS permissions normalized for /work/data/community/{content,submissions} and update script synced to /usr/local/bin/homedir-update.sh\n\n## Expected prod outcome\n- approving a pending submission no longer fails with 503 due to storage permission drift\n- if storage fails for other reasons, logs + API now expose exact failure detail