### PR TITLE
fix(home): Community Highlights heading and sizing

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -2123,10 +2123,14 @@ footer {
 
 .home-highlights-intro {
   margin: 0;
-  font-size: 0.8rem;
+  max-width: 980px;
+  font-family: var(--font-display);
+  font-size: clamp(1.05rem, 2.1vw, 1.7rem);
   line-height: 1.35;
-  opacity: 0.88;
-  letter-spacing: 0.3px;
+  letter-spacing: 0.8px;
+  text-transform: none;
+  text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.6);
+  opacity: 0.96;
 }
 
 .home-top-metrics {

--- a/quarkus-app/src/main/resources/messages.properties
+++ b/quarkus-app/src/main/resources/messages.properties
@@ -230,7 +230,7 @@ home_hero_desc=One-page highlights to quickly discover what is new in the Commun
 home_welcome_title=Welcome
 home_welcome_en=HomeDir: your community to build, learn, and share.
 home_welcome_es=HomeDir: tu comunidad para construir, aprender y compartir.
-home_highlights_intro=Highlights
+home_highlights_intro=Community Highlights
 
 home_metric_updates=updates available
 home_metric_upcoming=upcoming events

--- a/quarkus-app/src/main/resources/messages_es.properties
+++ b/quarkus-app/src/main/resources/messages_es.properties
@@ -227,7 +227,7 @@ home_hero_desc=Destacados en una página para descubrir rápidamente qué hay de
 home_welcome_title=Welcome
 home_welcome_en=HomeDir: your community to build, learn, and share.
 home_welcome_es=HomeDir: tu comunidad para construir, aprender y compartir.
-home_highlights_intro=Highlights
+home_highlights_intro=Community Highlights
 
 home_metric_updates=actualizaciones disponibles
 home_metric_upcoming=próximos eventos


### PR DESCRIPTION
## Summary\n- rename home intro label from Highlights to Community Highlights\n- align Community Highlights visual size with the welcome title\n- keep existing home layout and look-and-feel\n\n## Validation\n- mvn -f quarkus-app/pom.xml -Dtest=HomeTimelineTest test