### PR TITLE
feat(community): improve card scanability with top/new badges

### DIFF
--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -612,7 +612,9 @@
 
   .community-origin-pill,
   .community-score-pill,
-  .community-read-pill {
+  .community-read-pill,
+  .community-rank-pill,
+  .community-fresh-pill {
     border: 1px solid rgba(255, 255, 255, 0.28);
     border-radius: 999px;
     padding: 0.16rem 0.5rem;
@@ -629,6 +631,16 @@
   .community-origin-pill.internet {
     border-color: rgba(120, 185, 255, 0.65);
     background: rgba(120, 185, 255, 0.14);
+  }
+
+  .community-rank-pill {
+    border-color: rgba(255, 215, 0, 0.65);
+    background: rgba(255, 215, 0, 0.14);
+  }
+
+  .community-fresh-pill {
+    border-color: rgba(120, 255, 160, 0.68);
+    background: rgba(120, 255, 160, 0.16);
   }
 
   .community-item-title {
@@ -656,9 +668,33 @@
     margin: 0 0 0.62rem;
     line-height: 1.5;
     display: -webkit-box;
-    -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
+  }
+
+  .community-item-summary.clamped {
+    -webkit-line-clamp: 1;
+  }
+
+  .community-item-summary.expanded {
+    display: block;
+    overflow: visible;
+  }
+
+  .community-summary-toggle {
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    border-radius: 999px;
+    background: transparent;
+    color: inherit;
+    padding: 0.14rem 0.48rem;
+    font-size: 0.72rem;
+    margin: -0.28rem 0 0.62rem;
+    width: fit-content;
+    cursor: pointer;
+  }
+
+  .community-summary-toggle:hover {
+    border-color: rgba(255, 215, 0, 0.72);
   }
 
   .community-topic-hint {


### PR DESCRIPTION
## Summary
- improve Community Picks scanability with visual badges and compact summaries
- add `Top 1-3` badges in featured view and `Nuevo` badge for recent items
- keep summaries collapsed by default and allow `Ver resumen` toggle per card

## Platform impact
- no backend changes
- no additional API calls
- all behavior computed client-side from already loaded data

## Validation
- ./mvnw "-Dtest=CommunityContentApiResourceTest,CommunityModerationPageTest" test
