### PR TITLE
fix(community): recover content when stale local filters hide all items

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/community-content.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/community-content.js
@@ -491,6 +491,13 @@
       }
       state.total = Number(data.total || state.items.length);
       state.offset = state.items.length;
+      if (reset && state.items.length > 0 && visibleItems().length === 0 && (state.tag || state.topic !== "all")) {
+        state.topic = "all";
+        state.tag = "";
+        sessionStorage.setItem("community.topic", "all");
+        sessionStorage.removeItem("community.tag");
+        updateTopicState();
+      }
       renderItems();
     } catch (error) {
       showFeedback("No se pudo cargar el contenido de comunidad.");
@@ -498,6 +505,7 @@
     } finally {
       state.loading = false;
       showSkeleton(false);
+      updateEmptyState(visibleItems().length);
       updateLoadMoreState();
     }
   }


### PR DESCRIPTION
## Hotfix scope
- prevent Community Picks from appearing blank when stale `topic/tag` filters persisted in sessionStorage no longer match current content
- ensure empty-state is recalculated after loading completes (so user gets feedback instead of blank section)

## What changed
- on first load reset, auto-clear stale `topic/tag` only when backend returned items but visible set is zero
- recompute empty state in `finally` after `state.loading = false`

## Validation
- ./mvnw "-Dtest=CommunityContentApiResourceTest" test
