### PR TITLE
feat(community): add active filters bar with clear action

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/community-content.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/community-content.js
@@ -18,6 +18,9 @@
   const loadMoreBtn = document.getElementById("community-load-more");
   const feedbackEl = document.getElementById("community-feedback");
   const totalMetricEl = document.getElementById("community-content-total");
+  const activeFiltersEl = document.getElementById("community-active-filters");
+  const activeFilterChipsEl = document.getElementById("community-active-filter-chips");
+  const clearFiltersBtn = document.getElementById("community-clear-filters");
   const hotSectionEl = document.getElementById("community-hot");
   const hotListEl = document.getElementById("community-hot-list");
   const interestSectionEl = document.getElementById("community-interest");
@@ -335,6 +338,39 @@
     });
   }
 
+  function renderActiveFilters() {
+    if (!activeFiltersEl || !activeFilterChipsEl) {
+      return;
+    }
+    activeFilterChipsEl.textContent = "";
+
+    const chips = [];
+    if (state.filter === "internet") {
+      chips.push("Source: Internet");
+    } else if (state.filter === "members") {
+      chips.push("Source: Members");
+    }
+    if (state.topic && state.topic !== "all") {
+      chips.push(`Topic: ${state.topic}`);
+    }
+    if (state.tag) {
+      chips.push(`Tag: #${state.tag}`);
+    }
+
+    if (chips.length === 0) {
+      activeFiltersEl.classList.add("hidden");
+      return;
+    }
+
+    activeFiltersEl.classList.remove("hidden");
+    chips.forEach((label) => {
+      const chip = document.createElement("span");
+      chip.className = "community-active-filter-chip";
+      chip.textContent = label;
+      activeFilterChipsEl.appendChild(chip);
+    });
+  }
+
   function createVoteButton(item, voteKey, label, count) {
     const btn = document.createElement("button");
     btn.type = "button";
@@ -356,6 +392,7 @@
     listEl.textContent = "";
     renderInterestCards(state.items);
     renderTagRadar(state.items);
+    renderActiveFilters();
     if (totalMetricEl) {
       totalMetricEl.textContent = String(Number(state.total || state.items.length || 0));
     }
@@ -621,6 +658,26 @@
     renderItems();
   }
 
+  function clearAllFilters() {
+    const shouldReload = state.filter !== "all";
+    const changed = shouldReload || state.topic !== "all" || Boolean(state.tag);
+    if (!changed) {
+      return;
+    }
+    state.filter = "all";
+    state.topic = "all";
+    state.tag = "";
+    sessionStorage.setItem("community.topic", "all");
+    sessionStorage.removeItem("community.tag");
+    updateFilterState();
+    updateTopicState();
+    if (shouldReload) {
+      load(true);
+    } else {
+      renderItems();
+    }
+  }
+
   function toggleSummary(itemId) {
     const key = String(itemId || "");
     if (!key) return;
@@ -685,6 +742,12 @@
       const chip = target.closest(".community-radar-chip");
       if (!chip) return;
       setTag(chip.dataset.tag || "");
+    });
+  }
+
+  if (clearFiltersBtn) {
+    clearFiltersBtn.addEventListener("click", () => {
+      clearAllFilters();
     });
   }
 

--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -72,6 +72,13 @@
           <button type="button" class="community-topic-btn" data-topic="platform">Platform</button>
         </div>
 
+        <div id="community-active-filters" class="community-active-filters hidden" aria-live="polite">
+          <div id="community-active-filter-chips" class="community-active-filter-chips"></div>
+          <button id="community-clear-filters" type="button" class="community-clear-filters-btn">
+            Limpiar filtros
+          </button>
+        </div>
+
         <section id="community-interest" class="community-interest hidden" aria-live="polite">
           <div class="community-interest-header">
             <h3>Intereses rapidos</h3>
@@ -308,6 +315,48 @@
     gap: 0.45rem;
     flex-wrap: wrap;
     margin-bottom: 1rem;
+  }
+
+  .community-active-filters {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    margin: -0.4rem 0 0.75rem;
+  }
+
+  .community-active-filters.hidden {
+    display: none;
+  }
+
+  .community-active-filter-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .community-active-filter-chip {
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.2);
+    padding: 0.18rem 0.5rem;
+    font-size: 0.72rem;
+    opacity: 0.9;
+  }
+
+  .community-clear-filters-btn {
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    border-radius: 999px;
+    background: transparent;
+    color: inherit;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.72rem;
+    cursor: pointer;
+  }
+
+  .community-clear-filters-btn:hover {
+    border-color: rgba(255, 215, 0, 0.72);
   }
 
   .community-topic-btn {


### PR DESCRIPTION
## Summary
- add a compact active-filters bar in Community Picks
- show currently active source/topic/tag filters as chips
- add `Limpiar filtros` action to return quickly to full content

## Why
- improves discoverability and orientation while browsing
- avoids confusion when filters are active and content scope narrows
- keeps existing visual identity and low-motion behavior

## Platform impact
- no backend changes
- no extra API calls
- only client-side state/UI updates

## Validation
- ./mvnw "-Dtest=CommunityContentApiResourceTest,CommunityModerationPageTest" test
