### PR TITLE
chore(version): align metadata with GitHub versioning

### DIFF
--- a/.github/workflows/full_release_cycle.yml
+++ b/.github/workflows/full_release_cycle.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: 'Version to release'
         required: true
-        default: '3.304.13'
+        default: '3.330.1'
 
 jobs:
   build-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [3.304.13] - 2026-02-10
+## [3.330.1] - 2026-02-10
 ### Changed
 - Community section now resolves UI text from i18n keys in Picks, Propose Content, and Moderation flows.
 - Community client-side date formatting now follows browser/document locale.
-- `full_release_cycle` default version updated to `3.304.13`.
+- `full_release_cycle` default version updated to `3.330.1`.
 
 ### Fixed
 - Removed `z-index` from `.alpha-banner` to prevent overlap with the user profile popup.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# HomeDir 3.304.13
+# HomeDir 3.330.1
 
 **Summary**
 - Community UI now uses locale-aware copy in browser-facing flows for Picks, Propose Content, and Moderation.

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -7,7 +7,7 @@
     <version>${revision}</version>
 
     <properties>
-        <revision>3.304.13</revision>
+        <revision>3.330.1</revision>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.26.4</quarkus.platform.version>


### PR DESCRIPTION
## Summary\n- align local version references to GitHub-managed tag stream (3.330.1)\n- update quarkus-app/pom.xml revision\n- update ull_release_cycle default input\n- normalize CHANGELOG.md and RELEASE_NOTES.md headers for the same version\n\n## Notes\n- source of truth used: latest tags in GitHub (3.330.1 on 2026-02-10) and current production asset versioning.\n