### PR TITLE
fix(cfp): enforce duration by format and restore language submit

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/cfp/CfpSubmissionService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/cfp/CfpSubmissionService.java
@@ -81,10 +81,20 @@ public class CfpSubmissionService {
           cfpFormOptionsService
               .normalizeLanguage(request.language())
               .orElseThrow(() -> new ValidationException("invalid_language"));
-      Integer durationMin =
-          cfpFormOptionsService
-              .normalizeDuration(request.durationMin())
-              .orElseThrow(() -> new ValidationException("invalid_duration"));
+      Integer durationMin;
+      Optional<Integer> expectedDuration = cfpFormOptionsService.expectedDurationForFormat(format);
+      if (expectedDuration.isPresent()) {
+        Integer selectedDuration = request.durationMin();
+        if (selectedDuration != null && !expectedDuration.get().equals(selectedDuration)) {
+          throw new ValidationException("invalid_duration");
+        }
+        durationMin = expectedDuration.get();
+      } else {
+        durationMin =
+            cfpFormOptionsService
+                .normalizeDuration(request.durationMin())
+                .orElseThrow(() -> new ValidationException("invalid_duration"));
+      }
       String track =
           cfpFormOptionsService
               .normalizeTrack(request.track())

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventResource.java
@@ -10,6 +10,7 @@ import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.annotation.security.PermitAll;
+import java.util.Map;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -24,7 +25,7 @@ public class EventResource {
   static class Templates {
     static native TemplateInstance detail(Event event);
 
-    static native TemplateInstance cfp(Event event, CfpFormCatalog cfpCatalog);
+    static native TemplateInstance cfp(Event event, CfpFormCatalog cfpCatalog, Map<String, Integer> cfpDurationByFormat);
   }
 
   @Inject EventService eventService;
@@ -63,7 +64,7 @@ public class EventResource {
       @jakarta.ws.rs.core.Context io.vertx.ext.web.RoutingContext context) {
     metrics.recordPageView("/event/cfp", headers, context);
     Event event = eventService.getEvent(id);
-    return withLayoutData(Templates.cfp(event, cfpFormOptionsService.catalog()), "eventos");
+    return withLayoutData(Templates.cfp(event, cfpFormOptionsService.catalog(), cfpFormOptionsService.durationByFormat()), "eventos");
   }
 
   private TemplateInstance withLayoutData(TemplateInstance templateInstance, String activePage) {

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -187,7 +187,8 @@ quarkus.qute.strict-rendering=true
 # CFP controlled form options (backend managed)
 cfp.form.levels=beginner|Beginner,intermediate|Intermediate,advanced|Advanced
 cfp.form.formats=talk|Talk,lightning-talk|Lightning Talk,workshop|Workshop,panel|Panel
-cfp.form.durations=15|15 min,30|30 min,45|45 min,60|60 min
+cfp.form.durations=15|15 min,30|30 min,60|60 min,90|90 min
+cfp.form.duration-by-format=talk=30,workshop=90,panel=60,lightning-talk=15
 cfp.form.languages=en|English,es|Spanish
 # Keep a maximum of 5 market-relevant tracks for 2026
 cfp.form.tracks=ai-agents-copilots|AI Agents & Copilots in Production,platform-engineering-idp|Platform Engineering & Internal Developer Platforms,cloud-native-security|Cloud Native Security & Supply Chain,developer-experience-innersource|Developer Experience & InnerSource,data-ai-platforms-llmops|Data/AI Platforms & LLMOps

--- a/quarkus-app/src/main/resources/templates/EventResource/cfp.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/cfp.html
@@ -56,13 +56,13 @@
           <select id="cfpFormat" name="format" class="form-select" required>
             <option value="">{i18n.events_cfp_form_select_placeholder}</option>
             {#for option in cfpCatalog.formats}
-            <option value="{option.value}">{option.label}</option>
+            <option value="{option.value}" data-duration="{cfpDurationByFormat.get(option.value)}">{option.label}</option>
             {/for}
           </select>
         </div>
         <div class="form-group">
           <label class="form-label" for="cfpDuration">{i18n.events_cfp_form_duration}</label>
-          <select id="cfpDuration" name="durationMin" class="form-select" required>
+          <select id="cfpDuration" name="durationMin" class="form-select" required disabled>
             <option value="">{i18n.events_cfp_form_select_placeholder}</option>
             {#for option in cfpCatalog.durations}
             <option value="{option.value}">{option.label}</option>
@@ -89,7 +89,7 @@
         </div>
         <div class="form-group" style="grid-column: 1 / -1;">
           <label class="form-label" for="cfpLinks">{i18n.events_cfp_form_links}</label>
-          <input id="cfpLinks" name="links" class="form-input" placeholder="https://example.org/slides, https://github.com/...">
+          <input id="cfpLinks" name="links" class="form-input" placeholder="https://sessionize.com/your-session, https://github.com/...">
         </div>
       </div>
       <div class="form-actions">
@@ -190,6 +190,9 @@
     const reloadBtn = document.getElementById("cfpReloadBtn");
     const feedback = document.getElementById("cfpFeedback");
     const mineList = document.getElementById("cfpMineList");
+    const formatSelect = document.getElementById("cfpFormat");
+    const durationSelect = document.getElementById("cfpDuration");
+    const languageSelect = document.getElementById("cfpLanguage");
 
     const labels = {
       pending: "{i18n.events_cfp_status_pending}",
@@ -224,6 +227,32 @@
     const formatLabels = buildOptionMap("cfpFormat");
     const languageLabels = buildOptionMap("cfpLanguage");
     const trackLabels = buildOptionMap("cfpTrack");
+    const durationByFormat = {};
+    if (formatSelect) {
+      Array.from(formatSelect.options || []).forEach((option) => {
+        const key = String(option.value || "").trim();
+        const raw = String(option.dataset?.duration || "").trim();
+        const parsed = Number.parseInt(raw, 10);
+        if (key && Number.isFinite(parsed)) {
+          durationByFormat[key] = parsed;
+        }
+      });
+    }
+
+    function syncDurationFromFormat() {
+      if (!durationSelect) {
+        return;
+      }
+      const formatValue = formatSelect ? String(formatSelect.value || "") : "";
+      const mappedDuration = durationByFormat[formatValue];
+      if (!mappedDuration) {
+        durationSelect.value = "";
+        durationSelect.disabled = true;
+        return;
+      }
+      durationSelect.value = String(mappedDuration);
+      durationSelect.disabled = true;
+    }
 
     function parseCsvInput(value) {
       if (!value) return [];
@@ -324,8 +353,8 @@
       if (!form) return;
       submitBtn.disabled = true;
       const formData = new FormData(form);
-      const durationRaw = formData.get("durationMin");
-      const duration = durationRaw ? Number.parseInt(String(durationRaw), 10) : null;
+      const duration = durationSelect ? Number.parseInt(String(durationSelect.value || ""), 10) : Number.NaN;
+      const languageValue = languageSelect ? String(languageSelect.value || "").trim() : String(formData.get("language") || "").trim();
       const payload = {
         title: String(formData.get("title") || ""),
         summary: String(formData.get("summary") || ""),
@@ -333,7 +362,7 @@
         level: String(formData.get("level") || ""),
         format: String(formData.get("format") || ""),
         duration_min: Number.isFinite(duration) ? duration : null,
-        language: String(formData.get("language") || ""),
+        language: languageValue,
         track: String(formData.get("track") || ""),
         links: parseCsvInput(String(formData.get("links") || ""))
       };
@@ -357,6 +386,7 @@
           return;
         }
         form.reset();
+        syncDurationFromFormat();
         showFeedback("{i18n.events_cfp_success_submit}", false);
         await loadMine();
       } catch (error) {
@@ -367,7 +397,9 @@
     }
 
     form?.addEventListener("submit", submitProposal);
+    formatSelect?.addEventListener("change", syncDurationFromFormat);
     reloadBtn?.addEventListener("click", loadMine);
+    syncDurationFromFormat();
     loadMine();
   })();
 </script>

--- a/quarkus-app/src/test/java/com/scanales/eventflow/cfp/CfpSubmissionApiResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/cfp/CfpSubmissionApiResourceTest.java
@@ -63,7 +63,7 @@ public class CfpSubmissionApiResourceTest {
               "abstract_text":"Detailed abstract for platform stories.",
               "level":"intermediate",
               "format":"talk",
-              "duration_min":45,
+              "duration_min":30,
               "language":"en",
               "track":"platform-engineering-idp",
               "links":["https://example.org/talk"]
@@ -90,6 +90,55 @@ public class CfpSubmissionApiResourceTest {
 
   @Test
   @TestSecurity(user = "member@example.com")
+  void createAcceptsLanguageLabel() {
+    given()
+        .contentType("application/json")
+        .body(
+            """
+            {
+              "title":"Language label support",
+              "summary":"Summary",
+              "abstract_text":"Abstract",
+              "level":"beginner",
+              "format":"talk",
+              "duration_min":30,
+              "language":"English",
+              "track":"platform-engineering-idp"
+            }
+            """)
+        .when()
+        .post("/api/events/" + EVENT_ID + "/cfp/submissions")
+        .then()
+        .statusCode(201)
+        .body("item.language", equalTo("en"));
+  }
+
+  @Test
+  @TestSecurity(user = "member@example.com")
+  void createRejectsDurationThatDoesNotMatchFormat() {
+    given()
+        .contentType("application/json")
+        .body(
+            """
+            {
+              "title":"Mismatched duration",
+              "summary":"Summary",
+              "abstract_text":"Abstract",
+              "level":"beginner",
+              "format":"workshop",
+              "duration_min":60,
+              "language":"en",
+              "track":"platform-engineering-idp"
+            }
+            """)
+        .when()
+        .post("/api/events/" + EVENT_ID + "/cfp/submissions")
+        .then()
+        .statusCode(400)
+        .body("error", equalTo("invalid_duration"));
+  }
+  @Test
+  @TestSecurity(user = "member@example.com")
   void createRejectsInvalidControlledValues() {
     given()
         .contentType("application/json")
@@ -101,7 +150,7 @@ public class CfpSubmissionApiResourceTest {
               "abstract_text":"Abstract",
               "level":"any-random-level",
               "format":"talk",
-              "duration_min":45,
+              "duration_min":30,
               "language":"en",
               "track":"platform-engineering-idp"
             }
@@ -197,7 +246,7 @@ public class CfpSubmissionApiResourceTest {
                 "Long abstract",
                 "advanced",
                 "talk",
-                45,
+                30,
                 "en",
                 "ai-agents-copilots",
                 List.of("ai", "platform"),
@@ -246,7 +295,7 @@ public class CfpSubmissionApiResourceTest {
                 "Deep dive abstract",
                 "intermediate",
                 "talk",
-                45,
+                30,
                 "en",
                 "cloud-native-security",
                 List.of("kubernetes"),

--- a/quarkus-app/src/test/java/com/scanales/eventflow/cfp/CfpSubmissionServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/cfp/CfpSubmissionServiceTest.java
@@ -44,7 +44,7 @@ public class CfpSubmissionServiceTest {
                 "The talk shares implementation patterns, anti-patterns and rollout steps.",
                 "intermediate",
                 "talk",
-                45,
+                30,
                 "en",
                 "platform-engineering-idp",
                 java.util.List.of("platform", "devops"),
@@ -106,6 +106,27 @@ public class CfpSubmissionServiceTest {
   }
 
   @Test
+  void createFailsWhenDurationDoesNotMatchFormat() {
+    assertThrows(
+        CfpSubmissionService.ValidationException.class,
+        () ->
+            cfpSubmissionService.create(
+                "member@example.com",
+                "Member",
+                new CfpSubmissionService.CreateRequest(
+                    EVENT_ID,
+                    "Talk",
+                    "Summary",
+                    "Abstract",
+                    "intermediate",
+                    "workshop",
+                    60,
+                    "en",
+                    "platform-engineering-idp",
+                    java.util.List.of(),
+                    java.util.List.of())));
+  }
+  @Test
   void statusTransitionUpdatesSubmission() {
     CfpSubmission created =
         cfpSubmissionService.create(
@@ -118,7 +139,7 @@ public class CfpSubmissionServiceTest {
                 "Long abstract for SRE topic.",
                 "advanced",
                 "workshop",
-                60,
+                90,
                 "en",
                 "cloud-native-security",
                 java.util.List.of("sre"),


### PR DESCRIPTION
## Summary
- fix CFP submit language handling so selected language values/labels are normalized server-side
- enforce duration by format (talk=30, workshop=90, panel=60, lightning-talk=15)
- lock duration selection in UI and auto-sync it from selected format
- move format-duration mapping to backend/config (`cfp.form.duration-by-format`)
- update Sessionize example in reference links placeholder
- add/adjust CFP tests for language normalization and duration mismatch validation

## Validation
- ./mvnw "-Dtest=CfpSubmissionApiResourceTest,CfpSubmissionServiceTest,EventCfpPageTest,AdminEventCfpPageTest" test