### PR TITLE
fix(ui): restore full click area for CFP language dropdown

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -581,6 +581,11 @@ footer {
   will-change: background-color, box-shadow, border-color;
 }
 
+/* Decorative overlay from theme must never block form controls inside cards. */
+.section-card::before {
+  pointer-events: none;
+}
+
 .section-card:hover {
   transform: none;
   box-shadow: 0 6px 0 rgba(0, 0, 0, 0.6), inset 0 0 0 1px rgba(255, 215, 0, 0.18);


### PR DESCRIPTION
## Summary
- prevent `.section-card::before` decorative overlay from intercepting pointer events
- keeps existing visual effect but restores full click area for form controls (including `Language` select)

## Why
On CFP page, the language dropdown was only clickable in part of its visible area due to overlay hit-testing.

## Validation
- CSS-only change, verified rendered markup and selector scope