### PR TITLE
feat(cfp): portable and safe backup restore flow

### DIFF
--- a/docs/cfp-resilience.md
+++ b/docs/cfp-resilience.md
@@ -35,7 +35,7 @@ This document defines the no-data-loss strategy for CFP submissions in Homedir.
 ## Iteration roadmap
 
 - PR1: durable CFP local snapshots + automatic recovery from corruption. (implemented)
-- PR2: portable CFP export/import bundle and recursive admin backup/restore checks.
+- PR2: portable CFP export/import bundle and recursive admin backup/restore checks. (implemented)
 - PR3: automated scheduled offsite backup (object storage) + restore drill checklist.
 
 ## Restore validation checklist

--- a/quarkus-app/src/main/java/com/scanales/eventflow/cfp/CfpSubmissionService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/cfp/CfpSubmissionService.java
@@ -286,6 +286,12 @@ public class CfpSubmissionService {
     }
   }
 
+  public void reloadFromDisk() {
+    synchronized (submissionsLock) {
+      refreshFromDisk(true);
+    }
+  }
+
   public int currentMaxSubmissionsPerUserPerEvent() {
     return runtimeMaxSubmissionsPerUserPerEvent;
   }
@@ -538,6 +544,4 @@ public class CfpSubmissionService {
     }
   }
 }
-
-
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/BackupArchiveService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/BackupArchiveService.java
@@ -1,0 +1,142 @@
+package com.scanales.eventflow.service;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+@ApplicationScoped
+public class BackupArchiveService {
+
+  public byte[] createArchive(Path dataDir, String appVersion) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
+      List<Path> files = new ArrayList<>();
+      if (Files.exists(dataDir)) {
+        try (var stream = Files.walk(dataDir)) {
+          stream
+              .filter(Files::isRegularFile)
+              .sorted(Comparator.comparing(Path::toString))
+              .forEach(files::add);
+        }
+      }
+
+      for (Path file : files) {
+        String entryName = toEntryName(dataDir.relativize(file));
+        ZipEntry entry = new ZipEntry(entryName);
+        zos.putNextEntry(entry);
+        try (InputStream in = Files.newInputStream(file)) {
+          in.transferTo(zos);
+        }
+        zos.closeEntry();
+      }
+
+      String manifest =
+          "{\n"
+              + "  \"generated_at\": \""
+              + Instant.now()
+              + "\",\n"
+              + "  \"app_version\": \""
+              + escapeJson(appVersion)
+              + "\",\n"
+              + "  \"files\": "
+              + files.size()
+              + "\n"
+              + "}\n";
+      ZipEntry manifestEntry = new ZipEntry("backup-manifest.json");
+      zos.putNextEntry(manifestEntry);
+      zos.write(manifest.getBytes(StandardCharsets.UTF_8));
+      zos.closeEntry();
+    }
+    return baos.toByteArray();
+  }
+
+  public int restoreArchive(InputStream zipInput, Path dataDir) throws IOException {
+    Files.createDirectories(dataDir);
+    int restoredFiles = 0;
+    try (ZipInputStream zis = new ZipInputStream(zipInput, StandardCharsets.UTF_8)) {
+      ZipEntry entry;
+      while ((entry = zis.getNextEntry()) != null) {
+        String rawName = entry.getName() == null ? "" : entry.getName().trim();
+        if (rawName.isBlank()) {
+          zis.closeEntry();
+          continue;
+        }
+        if ("backup-manifest.json".equals(rawName)) {
+          zis.closeEntry();
+          continue;
+        }
+
+        Path target = safeResolve(dataDir, rawName);
+        if (entry.isDirectory()) {
+          Files.createDirectories(target);
+          zis.closeEntry();
+          continue;
+        }
+
+        Path parent = target.getParent();
+        if (parent != null) {
+          Files.createDirectories(parent);
+        }
+        Files.copy(zis, target, StandardCopyOption.REPLACE_EXISTING);
+        restoredFiles++;
+        zis.closeEntry();
+      }
+    }
+    return restoredFiles;
+  }
+
+  static Path safeResolve(Path dataDir, String entryName) throws IOException {
+    String normalized = entryName.replace('\\', '/');
+    boolean hadLeadingSlash = normalized.startsWith("/");
+    while (normalized.startsWith("/")) {
+      normalized = normalized.substring(1);
+    }
+    if (hadLeadingSlash) {
+      throw new IOException("zip_absolute_path_detected");
+    }
+    if (normalized.isBlank()) {
+      throw new IOException("invalid_entry_name");
+    }
+    if (normalized.contains("../") || normalized.contains("..\\") || normalized.startsWith("..")) {
+      throw new IOException("zip_path_traversal_detected");
+    }
+    if (normalized.matches("^[A-Za-z]:.*")) {
+      throw new IOException("zip_absolute_path_detected");
+    }
+
+    Path target = dataDir.resolve(normalized).normalize();
+    Path root = dataDir.normalize();
+    if (!target.startsWith(root)) {
+      throw new IOException("zip_outside_data_dir");
+    }
+    return target;
+  }
+
+  private static String toEntryName(Path relativePath) {
+    String name = relativePath.toString().replace('\\', '/');
+    while (name.startsWith("/")) {
+      name = name.substring(1);
+    }
+    return name;
+  }
+
+  private static String escapeJson(String raw) {
+    if (raw == null) {
+      return "";
+    }
+    return raw.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+}
+

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/BackupArchiveServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/BackupArchiveServiceTest.java
@@ -1,0 +1,69 @@
+package com.scanales.eventflow.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class BackupArchiveServiceTest {
+
+  @TempDir Path tempDir;
+
+  private final BackupArchiveService service = new BackupArchiveService();
+
+  @Test
+  void createArchiveIncludesNestedFilesAndManifest() throws Exception {
+    Path dataDir = tempDir.resolve("data");
+    Files.createDirectories(dataDir.resolve("nested").resolve("deep"));
+    Files.writeString(dataDir.resolve("events.json"), "{}", StandardCharsets.UTF_8);
+    Files.writeString(dataDir.resolve("nested").resolve("deep").resolve("cfp-submissions.json"), "{}", StandardCharsets.UTF_8);
+
+    byte[] zip = service.createArchive(dataDir, "3.338.0");
+    assertTrue(zip.length > 0);
+
+    Path restoreDir = tempDir.resolve("restore");
+    int restored = service.restoreArchive(new ByteArrayInputStream(zip), restoreDir);
+
+    assertEquals(2, restored);
+    assertTrue(Files.exists(restoreDir.resolve("events.json")));
+    assertTrue(Files.exists(restoreDir.resolve("nested").resolve("deep").resolve("cfp-submissions.json")));
+  }
+
+  @Test
+  void safeResolveRejectsPathTraversal() {
+    assertThrows(Exception.class, () -> BackupArchiveService.safeResolve(tempDir, "../secrets.txt"));
+    assertThrows(Exception.class, () -> BackupArchiveService.safeResolve(tempDir, "..\\secrets.txt"));
+    assertThrows(Exception.class, () -> BackupArchiveService.safeResolve(tempDir, "/etc/passwd"));
+  }
+
+  @Test
+  void restoreArchiveRejectsZipSlipEntries() throws Exception {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
+      zos.putNextEntry(new ZipEntry("../escape.txt"));
+      zos.write("bad".getBytes(StandardCharsets.UTF_8));
+      zos.closeEntry();
+    }
+
+    byte[] zip = baos.toByteArray();
+    Path restoreDir = tempDir.resolve("restore");
+    Files.createDirectories(restoreDir);
+
+    Exception error =
+        assertThrows(
+            Exception.class,
+            () -> service.restoreArchive(new ByteArrayInputStream(zip), restoreDir));
+    assertNotNull(error.getMessage());
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated backup archive service for recursive zip export/import
- harden restore against zip-slip/path traversal
- include nested data files in admin backup downloads
- reload CFP in-memory state immediately after restore
- update CFP resilience doc iteration status

## Validation
- ./mvnw.cmd "-Dtest=BackupArchiveServiceTest,PersistenceServiceTest,CfpSubmissionServiceTest" test
