### PR TITLE
feat(cfp): testing mode notice (admin toggle + i18n)

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/cfp/CfpConfig.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/cfp/CfpConfig.java
@@ -1,0 +1,24 @@
+package com.scanales.eventflow.cfp;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+
+/** Small persisted config for the CFP module (kept out of the submissions file). */
+public record CfpConfig(
+    @JsonProperty("max_submissions_per_user_per_event") int maxSubmissionsPerUserPerEvent,
+    @JsonProperty("testing_mode_enabled") boolean testingModeEnabled,
+    @JsonProperty("updated_at") Instant updatedAt) {
+
+  public static CfpConfig defaults(int maxSubmissionsPerUserPerEvent, boolean testingModeEnabled) {
+    return new CfpConfig(maxSubmissionsPerUserPerEvent, testingModeEnabled, Instant.now());
+  }
+
+  public CfpConfig withMaxSubmissionsPerUserPerEvent(int value) {
+    return new CfpConfig(value, testingModeEnabled, Instant.now());
+  }
+
+  public CfpConfig withTestingModeEnabled(boolean enabled) {
+    return new CfpConfig(maxSubmissionsPerUserPerEvent, enabled, Instant.now());
+  }
+}
+

--- a/quarkus-app/src/main/java/com/scanales/eventflow/cfp/CfpConfigService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/cfp/CfpConfigService.java
@@ -1,0 +1,137 @@
+package com.scanales.eventflow.cfp;
+
+import com.scanales.eventflow.service.PersistenceService;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Optional;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class CfpConfigService {
+
+  @Inject PersistenceService persistenceService;
+
+  @ConfigProperty(name = "cfp.submissions.max-per-user-per-event", defaultValue = "2")
+  int configuredMaxSubmissionsPerUserPerEvent;
+
+  // Default to true: the module is new and should warn users until explicitly disabled by admins.
+  @ConfigProperty(name = "cfp.testing.enabled", defaultValue = "true")
+  boolean configuredTestingModeEnabled;
+
+  private final Object lock = new Object();
+  private volatile long lastKnownMtime = Long.MIN_VALUE;
+  private volatile CfpConfig runtime;
+
+  @PostConstruct
+  void init() {
+    synchronized (lock) {
+      refreshFromDisk(true);
+      if (runtime == null) {
+        runtime =
+            CfpConfig.defaults(
+                normalizeMaxSubmissions(configuredMaxSubmissionsPerUserPerEvent),
+                configuredTestingModeEnabled);
+      }
+    }
+  }
+
+  public CfpConfig current() {
+    synchronized (lock) {
+      refreshFromDisk(false);
+      return runtime;
+    }
+  }
+
+  public int currentMaxSubmissionsPerUserPerEvent() {
+    return current().maxSubmissionsPerUserPerEvent();
+  }
+
+  public boolean isTestingModeEnabled() {
+    return current().testingModeEnabled();
+  }
+
+  public int updateMaxSubmissionsPerUserPerEvent(int requestedLimit) {
+    synchronized (lock) {
+      refreshFromDisk(false);
+      int normalized = normalizeMaxSubmissions(requestedLimit);
+      runtime = runtime == null ? CfpConfig.defaults(normalized, configuredTestingModeEnabled) : runtime.withMaxSubmissionsPerUserPerEvent(normalized);
+      persistenceService.saveCfpConfigSync(runtime);
+      lastKnownMtime = persistenceService.cfpConfigLastModifiedMillis();
+      return runtime.maxSubmissionsPerUserPerEvent();
+    }
+  }
+
+  public boolean updateTestingModeEnabled(boolean enabled) {
+    synchronized (lock) {
+      refreshFromDisk(false);
+      runtime = runtime == null ? CfpConfig.defaults(normalizeMaxSubmissions(configuredMaxSubmissionsPerUserPerEvent), enabled) : runtime.withTestingModeEnabled(enabled);
+      persistenceService.saveCfpConfigSync(runtime);
+      lastKnownMtime = persistenceService.cfpConfigLastModifiedMillis();
+      return runtime.testingModeEnabled();
+    }
+  }
+
+  public CfpConfig update(Integer requestedLimit, Boolean requestedTestingModeEnabled) {
+    synchronized (lock) {
+      refreshFromDisk(false);
+      CfpConfig next = runtime;
+      if (next == null) {
+        next =
+            CfpConfig.defaults(
+                normalizeMaxSubmissions(configuredMaxSubmissionsPerUserPerEvent),
+                configuredTestingModeEnabled);
+      }
+      if (requestedLimit != null) {
+        next = next.withMaxSubmissionsPerUserPerEvent(normalizeMaxSubmissions(requestedLimit));
+      }
+      if (requestedTestingModeEnabled != null) {
+        next = next.withTestingModeEnabled(requestedTestingModeEnabled);
+      }
+      runtime = next;
+      persistenceService.saveCfpConfigSync(runtime);
+      lastKnownMtime = persistenceService.cfpConfigLastModifiedMillis();
+      return runtime;
+    }
+  }
+
+  // Used by Quarkus tests to avoid cross-test leakage through the persisted config file.
+  void resetForTests() {
+    synchronized (lock) {
+      runtime =
+          CfpConfig.defaults(
+              normalizeMaxSubmissions(configuredMaxSubmissionsPerUserPerEvent),
+              configuredTestingModeEnabled);
+      persistenceService.saveCfpConfigSync(runtime);
+      lastKnownMtime = persistenceService.cfpConfigLastModifiedMillis();
+    }
+  }
+
+  private void refreshFromDisk(boolean force) {
+    long mtime = persistenceService.cfpConfigLastModifiedMillis();
+    if (!force && mtime == lastKnownMtime) {
+      return;
+    }
+    Optional<CfpConfig> loaded = persistenceService.loadCfpConfig();
+    if (loaded.isPresent()) {
+      runtime = loaded.get();
+    } else if (runtime == null) {
+      runtime =
+          CfpConfig.defaults(
+              normalizeMaxSubmissions(configuredMaxSubmissionsPerUserPerEvent),
+              configuredTestingModeEnabled);
+    }
+    lastKnownMtime = mtime;
+  }
+
+  private static int normalizeMaxSubmissions(int rawValue) {
+    if (rawValue <= 0) {
+      return 2;
+    }
+    if (rawValue < CfpSubmissionService.MIN_SUBMISSIONS_PER_USER_PER_EVENT) {
+      return CfpSubmissionService.MIN_SUBMISSIONS_PER_USER_PER_EVENT;
+    }
+    return Math.min(rawValue, CfpSubmissionService.MAX_SUBMISSIONS_PER_USER_PER_EVENT);
+  }
+}
+

--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
@@ -391,6 +391,36 @@ public interface AppMessages {
     @Message("Not selected for this edition.")
     String events_cfp_status_desc_rejected();
 
+    @Message("Testing")
+    String events_cfp_testing_badge();
+
+    @Message("Testing mode")
+    String events_cfp_testing_title();
+
+    @Message("This CFP flow is currently in testing mode. Submissions are considered test data and are not part of a formal process for this event.")
+    String events_cfp_testing_desc();
+
+    @Message("CFP testing notice")
+    String events_cfp_testing_aria();
+
+    @Message("CFP: testing mode")
+    String events_cfp_admin_testing_title();
+
+    @Message("Toggle a public warning on the CFP submission form so attendees know this is a test flow.")
+    String events_cfp_admin_testing_desc();
+
+    @Message("Show testing notice")
+    String events_cfp_admin_testing_toggle_label();
+
+    @Message("Save")
+    String events_cfp_admin_testing_save();
+
+    @Message("Saved.")
+    String events_cfp_admin_testing_saved();
+
+    @Message("Could not update testing mode right now.")
+    String events_cfp_admin_testing_error();
+
     // --- Projects Page ---
     @Message("Projects · HomeDir")
     String projects_title();

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventResource.java
@@ -1,6 +1,7 @@
 package com.scanales.eventflow.public_;
 
 import com.scanales.eventflow.cfp.CfpFormCatalog;
+import com.scanales.eventflow.cfp.CfpConfigService;
 import com.scanales.eventflow.cfp.CfpFormOptionsService;
 import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.service.EventService;
@@ -38,6 +39,8 @@ public class EventResource {
 
   @Inject CfpFormOptionsService cfpFormOptionsService;
 
+  @Inject CfpConfigService cfpConfigService;
+
   @GET
   @Path("{id}")
   @PermitAll
@@ -64,7 +67,8 @@ public class EventResource {
       @jakarta.ws.rs.core.Context io.vertx.ext.web.RoutingContext context) {
     metrics.recordPageView("/event/cfp", headers, context);
     Event event = eventService.getEvent(id);
-    return withLayoutData(Templates.cfp(event, cfpFormOptionsService.catalog(), cfpFormOptionsService.durationByFormat()), "eventos");
+    return withLayoutData(Templates.cfp(event, cfpFormOptionsService.catalog(), cfpFormOptionsService.durationByFormat()), "eventos")
+        .data("cfpTestingModeEnabled", cfpConfigService != null && cfpConfigService.isTestingModeEnabled());
   }
 
   private TemplateInstance withLayoutData(TemplateInstance templateInstance, String activePage) {

--- a/quarkus-app/src/main/resources/i18n.properties
+++ b/quarkus-app/src/main/resources/i18n.properties
@@ -38,6 +38,18 @@ progress_novice=Novice
 progress_contributor=Contributor
 progress_mentor=Mentor
 progress_legend=Legend
+
+# --- Events CFP Testing Mode ---
+events_cfp_testing_badge=Testing
+events_cfp_testing_title=Testing mode
+events_cfp_testing_desc=This CFP flow is currently in testing mode. Submissions are considered test data and are not part of a formal process for this event.
+events_cfp_testing_aria=CFP testing notice
+events_cfp_admin_testing_title=CFP: testing mode
+events_cfp_admin_testing_desc=Toggle a public warning on the CFP submission form so attendees know this is a test flow.
+events_cfp_admin_testing_toggle_label=Show testing notice
+events_cfp_admin_testing_save=Save
+events_cfp_admin_testing_saved=Saved.
+events_cfp_admin_testing_error=Could not update testing mode right now.
 identity_guild=Your Guild (Quest Class)
 identity_intro=Choose your archetype so the community knows your main role.
 community_initiatives={count} active initiatives and open collaborations.

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -287,4 +287,16 @@ events_cfp_status_desc_under_review=El equipo del evento esta revisando tu propu
 events_cfp_status_desc_accepted=Seleccionada para la agenda del evento.
 events_cfp_status_desc_rejected=No seleccionada para esta edicion.
 
+# --- Events CFP Testing Mode ---
+events_cfp_testing_badge=Prueba
+events_cfp_testing_title=Modo de prueba
+events_cfp_testing_desc=Este flujo de CFP está en modo de prueba. La información enviada se considerará de test y no forma parte de un proceso formal para este evento.
+events_cfp_testing_aria=Aviso de prueba CFP
+events_cfp_admin_testing_title=CFP: modo de prueba
+events_cfp_admin_testing_desc=Activa un aviso público en el formulario CFP para que las personas sepan que es un flujo de prueba.
+events_cfp_admin_testing_toggle_label=Mostrar aviso de prueba
+events_cfp_admin_testing_save=Guardar
+events_cfp_admin_testing_saved=Guardado.
+events_cfp_admin_testing_error=No fue posible actualizar el modo de prueba en este momento.
+
 

--- a/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
@@ -25,6 +25,23 @@ Moderacion CFP · {event.title}
   <div class="card" style="margin-bottom: 1rem;">
     <div style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 0.8rem;">
       <div>
+        <h2 class="card-title" style="margin: 0;">{i18n.events_cfp_admin_testing_title}</h2>
+        <p class="form-hint" style="margin-top: 0.35rem;">{i18n.events_cfp_admin_testing_desc}</p>
+      </div>
+      <div class="action-group" style="gap: 0.5rem;">
+        <label class="form-hint" style="display: inline-flex; align-items: center; gap: 0.45rem; margin: 0;">
+          <input id="cfpTestingToggle" type="checkbox" style="transform: translateY(1px);">
+          <span>{i18n.events_cfp_admin_testing_toggle_label}</span>
+        </label>
+        <button id="cfpTestingSaveBtn" type="button" class="btn btn-secondary">{i18n.events_cfp_admin_testing_save}</button>
+      </div>
+    </div>
+    <p id="cfpTestingFeedback" class="form-hint" style="margin-top: 0.6rem;" hidden></p>
+  </div>
+
+  <div class="card" style="margin-bottom: 1rem;">
+    <div style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 0.8rem;">
+      <div>
         <h2 class="card-title" style="margin: 0;">Cola de propuestas</h2>
         <p class="form-hint" style="margin-top: 0.35rem;">Evalua propuestas con rating tecnico y prioriza con score ponderado.</p>
       </div>
@@ -178,9 +195,13 @@ Moderacion CFP · {event.title}
   (() => {
     const eventId = "{event.id}";
     const baseEndpoint = "/api/events/" + encodeURIComponent(eventId) + "/cfp/submissions";
+    const configEndpoint = baseEndpoint + "/config";
     const listEl = document.getElementById("cfpQueueList");
     const reloadBtn = document.getElementById("reloadCfpBtn");
     const exportBtn = document.getElementById("exportCsvBtn");
+    const testingToggle = document.getElementById("cfpTestingToggle");
+    const testingSaveBtn = document.getElementById("cfpTestingSaveBtn");
+    const testingFeedback = document.getElementById("cfpTestingFeedback");
     const filterButtons = Array.from(document.querySelectorAll(".cfp-filter-btn"));
     const sortButtons = Array.from(document.querySelectorAll(".cfp-sort-btn"));
     let activeStatus = "pending";
@@ -520,6 +541,45 @@ Moderacion CFP · {event.title}
       }
     }
 
+    function showTestingFeedback(message, isError) {
+      if (!testingFeedback) return;
+      testingFeedback.hidden = false;
+      testingFeedback.textContent = message;
+      testingFeedback.style.color = isError ? "var(--color-danger, #ff8b8b)" : "var(--color-accent, #ffd54f)";
+    }
+
+    async function loadTestingConfig() {
+      if (!testingToggle) return;
+      try {
+        const response = await fetch(configEndpoint, { headers: { Accept: "application/json" } });
+        if (!response.ok) return;
+        const payload = await response.json();
+        testingToggle.checked = !!payload.testing_mode_enabled;
+      } catch (e) {
+      }
+    }
+
+    async function saveTestingConfig() {
+      if (!testingToggle || !testingSaveBtn) return;
+      testingSaveBtn.disabled = true;
+      try {
+        const response = await fetch(configEndpoint, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json", Accept: "application/json" },
+          body: JSON.stringify({ testing_mode_enabled: !!testingToggle.checked })
+        });
+        if (!response.ok) {
+          showTestingFeedback("{i18n.events_cfp_admin_testing_error}", true);
+          return;
+        }
+        showTestingFeedback("{i18n.events_cfp_admin_testing_saved}", false);
+      } catch (e) {
+        showTestingFeedback("{i18n.events_cfp_admin_testing_error}", true);
+      } finally {
+        testingSaveBtn.disabled = false;
+      }
+    }
+
     filterButtons.forEach((button) => {
       button.addEventListener("click", () => {
         const status = button.dataset.status || "pending";
@@ -537,8 +597,10 @@ Moderacion CFP · {event.title}
     });
 
     reloadBtn?.addEventListener("click", loadList);
+    testingSaveBtn?.addEventListener("click", saveTestingConfig);
     setActiveFilter(activeStatus);
     setActiveSort(activeSort);
+    loadTestingConfig();
     loadList();
   })();
 </script>

--- a/quarkus-app/src/main/resources/templates/EventResource/cfp.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/cfp.html
@@ -2,6 +2,7 @@
 {@java.lang.Boolean userAuthenticated}
 {@java.lang.String userName}
 {@com.scanales.eventflow.cfp.CfpFormCatalog cfpCatalog}
+{@java.lang.Boolean cfpTestingModeEnabled}
 {#title}
 {#if event}
 {i18n.events_cfp_page_title(event.title)}
@@ -32,6 +33,16 @@
   <article id="cfpSectionNew" class="section-card" style="grid-column: 1 / -1;">
     <h2 style="margin-top: 0;">{i18n.events_cfp_submit_title}</h2>
     <p class="section-subtitle" style="margin-bottom: 1rem;">{i18n.events_cfp_submit_desc}</p>
+
+    {#if cfpTestingModeEnabled}
+    <div class="cfp-testing-banner" role="note" aria-label="{i18n.events_cfp_testing_aria}">
+      <span class="cfp-testing-badge">{i18n.events_cfp_testing_badge}</span>
+      <div>
+        <p class="cfp-testing-title">{i18n.events_cfp_testing_title}</p>
+        <p class="cfp-testing-desc">{i18n.events_cfp_testing_desc}</p>
+      </div>
+    </div>
+    {/if}
 
     {#if userAuthenticated}
     <form id="cfpForm" data-user-scope="{userName}">
@@ -236,6 +247,43 @@
     display: flex;
     gap: 0.5rem;
     flex-wrap: wrap;
+  }
+
+  .cfp-testing-banner {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.75rem;
+    align-items: start;
+    padding: 0.75rem;
+    margin: 0 0 1rem 0;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(255, 213, 79, 0.45);
+    background: rgba(255, 213, 79, 0.08);
+  }
+
+  .cfp-testing-badge {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 999px;
+    padding: 0.15rem 0.55rem;
+    border: 1px solid rgba(255, 213, 79, 0.7);
+    background: rgba(255, 213, 79, 0.14);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    height: fit-content;
+    margin-top: 0.1rem;
+  }
+
+  .cfp-testing-title {
+    margin: 0;
+    font-weight: 700;
+  }
+
+  .cfp-testing-desc {
+    margin: 0.25rem 0 0;
+    font-size: 0.9rem;
+    opacity: 0.9;
   }
 </style>
 


### PR DESCRIPTION
Adds a CFP testing-mode flag persisted to disk, surfaces a public notice on the CFP submission page, and lets admins toggle it from the CFP moderation page. Includes EN/ES i18n keys.