### PR TITLE
CFP: fix submitting overlay initial visibility

### DIFF
--- a/quarkus-app/src/main/resources/templates/EventResource/cfp.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/cfp.html
@@ -179,6 +179,11 @@
     backdrop-filter: blur(6px);
   }
 
+  /* Ensure HTML `hidden` works even if we define display:flex above. */
+  .cfp-submitting-overlay[hidden] {
+    display: none;
+  }
+
   .cfp-submitting-modal {
     width: min(520px, 100%);
     display: grid;


### PR DESCRIPTION
Fixes the submitting overlay showing immediately on page load.

Root cause: author CSS was overriding the browser's default [hidden]{display:none}.
Fix: add .cfp-submitting-overlay[hidden]{display:none}.