### PR TITLE
CFP Admin: persist moderation notes

### DIFF
--- a/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
@@ -437,6 +437,8 @@ Moderacion CFP · {event.title}
       note.placeholder = "Nota de moderacion (opcional)";
       note.id = "moderation-note-" + item.id;
       note.name = note.id;
+      // Ensure persisted moderation notes are visible after refresh/reload.
+      note.value = item.moderation_note || "";
       article.appendChild(note);
 
       const actions = document.createElement("div");
@@ -606,4 +608,3 @@ Moderacion CFP · {event.title}
 </script>
 {/body}
 {/include}
-

--- a/quarkus-app/src/test/java/com/scanales/eventflow/cfp/CfpSubmissionServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/cfp/CfpSubmissionServiceTest.java
@@ -160,6 +160,40 @@ public class CfpSubmissionServiceTest {
   }
 
   @Test
+  void updateStatusPersistsModerationNoteEvenWhenStatusIsUnchanged() {
+    CfpSubmission created =
+        cfpSubmissionService.create(
+            "member@example.com",
+            "Member",
+            new CfpSubmissionService.CreateRequest(
+                EVENT_ID,
+                "ADev baseline",
+                "Summary",
+                "Abstract",
+                "intermediate",
+                "talk",
+                30,
+                "en",
+                "platform-engineering-idp",
+                java.util.List.of(),
+                java.util.List.of()));
+
+    CfpSubmission first =
+        cfpSubmissionService.updateStatus(created.id(), CfpSubmissionStatus.UNDER_REVIEW, "admin@example.org", "triage");
+    CfpSubmission updated =
+        cfpSubmissionService.updateStatus(
+            created.id(), CfpSubmissionStatus.UNDER_REVIEW, "admin@example.org", "needs more details");
+    CfpSubmission noChange =
+        cfpSubmissionService.updateStatus(
+            created.id(), CfpSubmissionStatus.UNDER_REVIEW, "admin@example.org", "   ");
+
+    assertEquals(CfpSubmissionStatus.UNDER_REVIEW, first.status());
+    assertEquals(CfpSubmissionStatus.UNDER_REVIEW, updated.status());
+    assertEquals("needs more details", updated.moderationNote());
+    assertEquals("needs more details", noChange.moderationNote());
+  }
+
+  @Test
   void invalidTransitionIsRejected() {
     CfpSubmission created =
         cfpSubmissionService.create(


### PR DESCRIPTION
Fixes CFP admin moderation notes not being persisted or visible after refresh.

Changes:
- Admin UI pre-fills the moderation note input from API field moderation_note.
- Backend updateStatus persists note/by even when status is unchanged, and treats blank note as no-change (prevents accidental wipes).
- Added unit test to cover updating note with same status.

Tested:
- quarkus-app/mvnw test