### PR TITLE
Persistence: atomic writes + JSON verification

### DIFF
--- a/quarkus-app/src/main/resources/templates/AdminCapacityResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminCapacityResource/index.html
@@ -104,6 +104,12 @@
             <th>Descartados por capacidad</th>
             <td>{writes.droppedDueCapacity}</td>
           </tr>
+          {#if writes.lastWriteAtMillis > 0}
+          <tr>
+            <th>Última escritura</th>
+            <td>{writes.lastWriteFile} · {writes.lastWriteBytes} bytes · {writes.lastWriteDurationMs} ms · t={writes.lastWriteAtMillis}</td>
+          </tr>
+          {/if}
           {#if writes.lastError}
           <tr>
             <th>Último error</th>


### PR DESCRIPTION
PR1 (Persistence hardening): make JSON persistence more robust without changing any caller APIs.

Changes
- Writes now serialize to bytes, optionally validate JSON in-memory, then write to a temp file and atomically move into place.
- Added fsync knobs:
  - persist.fsync.sync.enabled (default true)
  - persist.fsync.async.enabled (default false)
- Added basic write telemetry to queue stats (last file/bytes/duration/ts) and surfaced it in Admin Capacity.

Why
- Prevents invalid/corrupted JSON from ever being persisted due to partial writes.
- Adds observability for disk write behavior under load.

Test
- quarkus-app/mvnw test