### PR TITLE
Persistence: coalescing + debounce for async writes

### DIFF
--- a/quarkus-app/src/main/resources/templates/AdminCapacityResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminCapacityResource/index.html
@@ -101,6 +101,10 @@
             <td>OK: {writes.writesOk} · Fallos: {writes.writesFail} · Reintentos: {writes.writesRetries}</td>
           </tr>
           <tr>
+            <th>Coalescing</th>
+            <td>Coalescidas: {writes.writesCoalesced} · Bypass: {writes.writesCoalesceBypassed}</td>
+          </tr>
+          <tr>
             <th>Descartados por capacidad</th>
             <td>{writes.droppedDueCapacity}</td>
           </tr>


### PR DESCRIPTION
PR2 of persistence hardening: introduce write coalescing/debounce to reduce write pressure under burst traffic.

What changed
- Added per-file debounce window for async writes (persist.coalesce.window-ms, default 350ms).
- Kept latest pending payload per file and coalesced intermediate writes.
- Added max pending-files guard (persist.coalesce.max-pending-files, default 4096) with bypass path.
- flush() now drains debounced pending writes before waiting for queue completion.
- Added queue metrics:
  - writesCoalesced
  - writesCoalesceBypassed
- Surfaced coalescing stats in Admin Capacity view.
- Added/updated unit tests in PersistenceServiceTest for debounced flush and coalescing behavior.

Validation
- quarkus-app/mvnw -Dtest=PersistenceServiceTest test
- quarkus-app/mvnw test