### PR TITLE
feat: CFP persistence schema versioning + legacy migration

### DIFF
--- a/docs/cfp-resilience.md
+++ b/docs/cfp-resilience.md
@@ -20,6 +20,17 @@ This document defines the no-data-loss strategy for CFP submissions in Homedir.
   3. Quarantine corrupted primary as `cfp-submissions.corrupt-<timestamp>.json`.
   4. Rebuild primary from recovered snapshot.
 
+## CFP schema compatibility baseline
+
+- Current persisted schema uses an envelope:
+  - `schema_version`
+  - `kind`
+  - `updated_at`
+  - `submissions` (map by id)
+- Backward compatibility is preserved:
+  - Legacy map-only payloads are still readable from primary, backups, and WAL frames.
+  - Legacy payloads are auto-migrated to the versioned envelope on successful load.
+
 ## Configuration
 
 - `cfp.persistence.backups.enabled=true`
@@ -37,6 +48,7 @@ This document defines the no-data-loss strategy for CFP submissions in Homedir.
 - PR1: durable CFP local snapshots + automatic recovery from corruption. (implemented)
 - PR2: portable CFP export/import bundle and recursive admin backup/restore checks. (implemented)
 - PR3: CFP storage observability endpoint for admin verification + restore drill checklist. (implemented)
+- PR4: CFP persistence schema versioning + automatic legacy migration across primary/WAL/backups. (implemented)
 
 ## Restore validation checklist
 


### PR DESCRIPTION
## Summary
- persist CFP submissions using a versioned envelope (schema_version, kind, updated_at, submissions)
- keep backward compatibility for legacy map-only payloads in primary file, backups, and WAL frames
- auto-migrate legacy payloads to the versioned envelope after successful load
- extend persistence tests with schema serialization/migration and legacy WAL recovery coverage
- document schema compatibility baseline in docs/cfp-resilience.md

## Validation
- ./mvnw.cmd -q -Dtest=PersistenceServiceTest test
- ./mvnw.cmd -q "-Dtest=PersistenceServiceTest,CfpSubmissionServiceTest" test
