### PR TITLE
feat: CFP storage health telemetry for WAL/checksum

### DIFF
--- a/docs/cfp-resilience.md
+++ b/docs/cfp-resilience.md
@@ -33,6 +33,13 @@ This document defines the no-data-loss strategy for CFP submissions in Homedir.
   - Legacy payloads are auto-migrated to the versioned envelope on successful load.
   - Envelope payloads missing checksum are auto-hydrated on successful load.
 
+## Operational observability
+
+- `GET /api/events/{eventId}/cfp/submissions/storage` (admin-only) includes:
+  - primary/backups paths and sizes
+  - WAL status and counters (`wal_enabled`, `wal_size_bytes`, `wal_appends`, `wal_compactions`, `wal_recoveries`)
+  - checksum status and counters (`checksum_enabled`, `checksum_required`, `checksum_mismatches`, `checksum_hydrations`)
+
 ## Configuration
 
 - `cfp.persistence.backups.enabled=true`
@@ -54,6 +61,7 @@ This document defines the no-data-loss strategy for CFP submissions in Homedir.
 - PR3: CFP storage observability endpoint for admin verification + restore drill checklist. (implemented)
 - PR4: CFP persistence schema versioning + automatic legacy migration across primary/WAL/backups. (implemented)
 - PR5: checksum-based CFP integrity guard + auto-hydration and recovery fallback. (implemented)
+- PR6: admin storage telemetry expanded with WAL/checksum counters for live operational verification. (implemented)
 
 ## Restore validation checklist
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CfpSubmissionApiResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CfpSubmissionApiResource.java
@@ -136,7 +136,18 @@ public class CfpSubmissionApiResource {
                 info.backupCount(),
                 info.latestBackupName(),
                 info.latestBackupSizeBytes(),
-                info.latestBackupLastModifiedMillis()))
+                info.latestBackupLastModifiedMillis(),
+                info.walEnabled(),
+                info.walPath(),
+                info.walSizeBytes(),
+                info.walLastModifiedMillis(),
+                info.walAppends(),
+                info.walCompactions(),
+                info.walRecoveries(),
+                info.checksumEnabled(),
+                info.checksumRequired(),
+                info.checksumMismatches(),
+                info.checksumHydrations()))
         .build();
   }
 
@@ -624,7 +635,18 @@ public class CfpSubmissionApiResource {
       @JsonProperty("backup_count") int backupCount,
       @JsonProperty("latest_backup_name") String latestBackupName,
       @JsonProperty("latest_backup_size_bytes") long latestBackupSizeBytes,
-      @JsonProperty("latest_backup_last_modified_ms") long latestBackupLastModifiedMillis) {}
+      @JsonProperty("latest_backup_last_modified_ms") long latestBackupLastModifiedMillis,
+      @JsonProperty("wal_enabled") boolean walEnabled,
+      @JsonProperty("wal_path") String walPath,
+      @JsonProperty("wal_size_bytes") long walSizeBytes,
+      @JsonProperty("wal_last_modified_ms") long walLastModifiedMillis,
+      @JsonProperty("wal_appends") long walAppends,
+      @JsonProperty("wal_compactions") long walCompactions,
+      @JsonProperty("wal_recoveries") long walRecoveries,
+      @JsonProperty("checksum_enabled") boolean checksumEnabled,
+      @JsonProperty("checksum_required") boolean checksumRequired,
+      @JsonProperty("checksum_mismatches") long checksumMismatches,
+      @JsonProperty("checksum_hydrations") long checksumHydrations) {}
   public record SubmissionLimitConfigResponse(
       @JsonProperty("max_per_user") int maxPerUser,
       @JsonProperty("min_allowed") int minAllowed,
@@ -658,4 +680,3 @@ public class CfpSubmissionApiResource {
       @JsonProperty("rating_content_impact") Integer ratingContentImpact,
       @JsonProperty("rating_weighted") Double ratingWeighted) {}
 }
-

--- a/quarkus-app/src/test/java/com/scanales/eventflow/cfp/CfpSubmissionApiResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/cfp/CfpSubmissionApiResourceTest.java
@@ -573,7 +573,13 @@ public class CfpSubmissionApiResourceTest {
         .statusCode(200)
         .body("primary_path", org.hamcrest.Matchers.notNullValue())
         .body("backups_path", org.hamcrest.Matchers.notNullValue())
-        .body("backup_count", org.hamcrest.Matchers.greaterThanOrEqualTo(0));
+        .body("backup_count", org.hamcrest.Matchers.greaterThanOrEqualTo(0))
+        .body("wal_enabled", org.hamcrest.Matchers.notNullValue())
+        .body("wal_path", org.hamcrest.Matchers.notNullValue())
+        .body("checksum_enabled", org.hamcrest.Matchers.notNullValue())
+        .body("checksum_required", org.hamcrest.Matchers.notNullValue())
+        .body("checksum_mismatches", org.hamcrest.Matchers.greaterThanOrEqualTo(0))
+        .body("checksum_hydrations", org.hamcrest.Matchers.greaterThanOrEqualTo(0));
   }
 
   @Test

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/PersistenceServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/PersistenceServiceTest.java
@@ -196,6 +196,7 @@ public class PersistenceServiceTest {
 
     var migrated = cfpJsonMapper().readTree(primary.toFile());
     assertEquals(64, migrated.path("checksum_sha256").asText().length());
+    assertEquals(1, service.cfpStorageInfo().checksumHydrations());
   }
 
   @Test
@@ -270,6 +271,7 @@ public class PersistenceServiceTest {
     Map<String, CfpSubmission> recovered = service.loadCfpSubmissions();
     assertEquals(1, recovered.size());
     assertEquals("Checksum mismatch recovery", recovered.get(submission.id()).title());
+    assertEquals(1, service.cfpStorageInfo().checksumMismatches());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- expand CFP storage health payload with WAL and checksum telemetry counters
- expose runtime integrity signals: checksum mismatches and checksum hydrations
- preserve backward compatibility in storage endpoint while adding observability fields
- extend tests for storage endpoint and persistence counters
- document operational observability in CFP resilience baseline

## Validation
- ./mvnw.cmd -q "-Dtest=PersistenceServiceTest,CfpSubmissionApiResourceTest,CfpSubmissionServiceTest" test
