### PR TITLE
feat(persistence): admin CFP storage repair (PR8)

### DIFF
--- a/docs/cfp-resilience.md
+++ b/docs/cfp-resilience.md
@@ -41,6 +41,11 @@ This document defines the no-data-loss strategy for CFP submissions in Homedir.
   - backup validation counters (`backup_valid_count`, `backup_invalid_count`, `backup_missing_checksum_count`, `latest_backup_valid`)
   - WAL status and counters (`wal_enabled`, `wal_size_bytes`, `wal_appends`, `wal_compactions`, `wal_recoveries`)
   - checksum status and counters (`checksum_enabled`, `checksum_required`, `checksum_mismatches`, `checksum_hydrations`)
+- `POST /api/events/{eventId}/cfp/submissions/storage/repair?dry_run=true|false` (admin-only):
+  - scans primary + backup snapshots
+  - repairs checksum-missing snapshots
+  - quarantines corrupted backups (`*.corrupt-<timestamp>.json`)
+  - supports dry-run mode for safe audits before mutating files
 
 ## Configuration
 
@@ -65,6 +70,7 @@ This document defines the no-data-loss strategy for CFP submissions in Homedir.
 - PR5: checksum-based CFP integrity guard + auto-hydration and recovery fallback. (implemented)
 - PR6: admin storage telemetry expanded with WAL/checksum counters for live operational verification. (implemented)
 - PR7: storage telemetry now validates primary/backups and reports backup integrity counters. (implemented)
+- PR8: admin storage repair endpoint with dry-run/execute modes for checksum hydration + corrupted backup quarantine. (implemented)
 
 ## Restore validation checklist
 

--- a/quarkus-app/src/test/java/com/scanales/eventflow/cfp/CfpSubmissionApiResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/cfp/CfpSubmissionApiResourceTest.java
@@ -563,6 +563,18 @@ public class CfpSubmissionApiResourceTest {
   }
 
   @Test
+  @TestSecurity(user = "member@example.com")
+  void nonAdminCannotRunStorageRepair() {
+    given()
+        .accept("application/json")
+        .when()
+        .post("/api/events/" + EVENT_ID + "/cfp/submissions/storage/repair?dry_run=true")
+        .then()
+        .statusCode(403)
+        .body("error", equalTo("admin_required"));
+  }
+
+  @Test
   @TestSecurity(user = "admin@example.org")
   void adminCanReadStorageStatus() {
     given()
@@ -585,6 +597,23 @@ public class CfpSubmissionApiResourceTest {
         .body("checksum_required", org.hamcrest.Matchers.notNullValue())
         .body("checksum_mismatches", org.hamcrest.Matchers.greaterThanOrEqualTo(0))
         .body("checksum_hydrations", org.hamcrest.Matchers.greaterThanOrEqualTo(0));
+  }
+
+  @Test
+  @TestSecurity(user = "admin@example.org")
+  void adminCanRunStorageRepairDryRun() {
+    given()
+        .accept("application/json")
+        .when()
+        .post("/api/events/" + EVENT_ID + "/cfp/submissions/storage/repair?dry_run=true")
+        .then()
+        .statusCode(200)
+        .body("dry_run", equalTo(true))
+        .body("backups_scanned", org.hamcrest.Matchers.greaterThanOrEqualTo(0))
+        .body("backups_valid", org.hamcrest.Matchers.greaterThanOrEqualTo(0))
+        .body("backups_needing_repair", org.hamcrest.Matchers.greaterThanOrEqualTo(0))
+        .body("backups_quarantine_candidates", org.hamcrest.Matchers.greaterThanOrEqualTo(0))
+        .body("errors", org.hamcrest.Matchers.greaterThanOrEqualTo(0));
   }
 
   @Test


### PR DESCRIPTION
Adds admin CFP storage repair endpoint with dry-run support, backup checksum hydration/quarantine logic, tests, and docs update.