### PR TITLE
feat(capacity): community API rate-limit tuning for 400 users

### DIFF
--- a/docs/development/capacity-assessment-2026-02-17.md
+++ b/docs/development/capacity-assessment-2026-02-17.md
@@ -1,0 +1,121 @@
+# Capacity Assessment - 2026-02-17 (v3.348.0)
+
+## Contexto
+
+- Entorno evaluado: producción `homedir.opensourcesantiago.io`.
+- Versión desplegada: `3.348.0` (commit `0f37f1b`).
+- Fecha/hora base del levantamiento: `2026-02-17 15:20 UTC`.
+
+## Snapshot actual (producción)
+
+### Host VPS
+
+- CPU: `4 vCPU`
+- RAM: `15.99 GB` totales (`~1.03 GB` usados al momento del snapshot)
+- Swap: `0`
+- Disco `/`: `193 GB` total, `21 GB` usados (`11%`)
+- Load average: `0.03 / 0.02 / 0.00`
+
+### Contenedor `homedir`
+
+- Imagen: `quay.io/sergio_canales_e/homedir:3.348.0`
+- Límite de memoria/CPU en contenedor: **sin límite explícito** (`mem_limit=0`, `nano_cpus=0`)
+- Política de reinicio: `always`
+- Límite de procesos: `2048`
+- Memoria estable (idle reciente): `~273-316 MB`
+- Memoria luego de prueba de carga: `~520 MB` (`memory.peak ~522 MB`)
+- Proceso JVM observado:
+  - `VmRSS ~527 MB` (post stress)
+  - `Threads` de `~44` a `~118` durante carga
+
+## Tráfico observado
+
+Muestra sobre últimas `1200` líneas de `nginx/access.log`:
+
+- `653` requests a `/ws/global-notifications` (handshake websocket, `101`)
+- `202` requests no-websocket
+- Top rutas no-websocket:
+  - `/` (`38`)
+  - `/about` (`15`)
+  - `/comunidad` (`12`)
+  - `/api/community/content` (`10`)
+- Códigos HTTP:
+  - `200: 159`
+  - `301/302/303: 35`
+  - `404: 6`
+  - `400: 2`
+  - `101: 653` (websocket upgrade)
+
+## Pruebas rápidas de rendimiento (interna al contenedor)
+
+### Latencia base (sin concurrencia alta)
+
+- `GET /` -> p50 `5.8ms`, p95 `10.2ms`
+- `GET /comunidad` -> p50 `6.7ms`, p95 `9.1ms`
+- `GET /api/community/content?view=featured&limit=10` -> p50 `214.3ms`, p95 `221.3ms`
+
+### Throughput de landing (`/`) con concurrencia
+
+Prueba: `12000` requests, concurrencia `120`:
+
+- Resultado: `12000 OK`, `0 fail`
+- Tiempo total: `8.534s`
+- CPU consumida por cgroup del contenedor: `16.416 CPU-seconds`
+- Consumo promedio durante prueba: `1.924 cores` (sobre 4 vCPU = `48.1%`)
+
+## Hallazgos críticos para escalar a 400 usuarios
+
+1. Existe rate limit API global por IP:
+   - `rate.limit.api.limit = 120` requests/min (ventana 60s).
+   - Bajo prueba intensa a `/api/community/content` aparecieron `429 Too Many Requests`.
+2. No hay límites explícitos de CPU/MEM del contenedor.
+3. `/api/community/content` es significativamente más costoso que páginas públicas.
+
+## Proyección para 400 usuarios concurrentes
+
+Supuestos para estimación:
+
+- 1 websocket por usuario conectado.
+- Mezcla de tráfico: navegación pública + consumo de APIs (`community/events/cfp`).
+- Escenarios por tasa promedio de requests por usuario:
+  - Conservador: `0.05 rps/user`
+  - Medio: `0.10 rps/user`
+  - Alto: `0.20 rps/user`
+
+| Escenario | RPS total (400 users) | CPU estimada | RAM estimada | Riesgo principal |
+|---|---:|---:|---:|---|
+| Conservador | 20 rps | 15-25% de 4 vCPU | 0.7-0.9 GB | Bajo |
+| Medio | 40 rps | 25-45% de 4 vCPU | 0.9-1.2 GB | Medio (API bursts) |
+| Alto | 80 rps | 45-75% de 4 vCPU | 1.2-1.8 GB | Alto (429/latencia API) |
+
+Notas:
+
+- La landing tiene margen alto (>= 1k rps internos en prueba puntual), pero no representa todo el mix real.
+- El límite de `120 req/min` por IP puede bloquear tráfico legítimo si muchos usuarios quedan detrás de la misma IP efectiva para backend.
+
+## Recomendaciones operativas inmediatas
+
+1. Ajustar rate limiting por endpoint y por tipo de cliente:
+   - Mantener agresivo para auth.
+   - Subir bucket API público o separar bucket para `/api/community/content`.
+2. Fijar límites de contenedor para estabilidad:
+   - Ejemplo inicial: `--memory=2g --cpus=3` (o equivalente systemd/podman).
+3. Activar benchmark reproducible en staging (k6/oha/wrk) con escenario de 400 usuarios.
+4. Monitorear permanentemente:
+   - p95/p99 por endpoint
+   - tasa de `429`
+   - `memory.current`, `memory.peak`, `cpu.stat`
+   - cola de persistencia (`writesOk/writesFail/depth`) desde admin metrics.
+
+## Conclusión
+
+Con el estado actual, el despliegue soporta holgadamente el tráfico observado hoy y debería sostener `400` usuarios concurrentes en escenario conservador/medio, pero requiere ajuste de rate limiting API y validación formal con prueba de carga realista para evitar rechazos `429` y degradación en picos.
+
+## Cambios aplicados después del análisis
+
+- Se creó release formal: `v3.348.0`.
+- Se ajustó el rate limiting para Community API:
+  - Nuevo bucket dedicado para `/api/community/content`.
+  - Nueva propiedad: `rate.limit.api.community-content.limit` (default `600 req/min`).
+- Se mejoró la identificación de cliente detrás de proxy/CDN:
+  - Nuevo fallback a `CF-Connecting-IP` cuando `X-Forwarded-For` no está presente.

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -145,6 +145,7 @@ rate.limit.window-seconds=60
 rate.limit.auth.limit=30
 rate.limit.logout.limit=30
 rate.limit.api.limit=120
+rate.limit.api.community-content.limit=600
 
 # Global notifications
 notifications.global.enabled=true


### PR DESCRIPTION
## Summary
- add dedicated rate-limit bucket for `/api/community/content` via `rate.limit.api.community-content.limit` (default 600/min)
- improve client IP extraction by honoring `CF-Connecting-IP` fallback when `X-Forwarded-For` is absent
- add unit tests for community bucket and Cloudflare header fallback
- add capacity assessment doc with current production snapshot and 400-user projection

## Validation
- `./mvnw.cmd -q "-Dtest=RateLimitingFilterTest" test`

## Operational context
- release `v3.348.0` was published before this tuning
