### PR TITLE
feat(capacity): concurrency hardening for expected 400 users

### DIFF
--- a/docs/development/capacity-assessment-2026-02-17.md
+++ b/docs/development/capacity-assessment-2026-02-17.md
@@ -119,3 +119,14 @@ Con el estado actual, el despliegue soporta holgadamente el tráfico observado h
   - Nueva propiedad: `rate.limit.api.community-content.limit` (default `600 req/min`).
 - Se mejoró la identificación de cliente detrás de proxy/CDN:
   - Nuevo fallback a `CF-Connecting-IP` cuando `X-Forwarded-For` no está presente.
+- Se optimizó `GET /api/community/content` para concurrencia:
+  - `view=new`: calcula agregados de votos solo para la página solicitada.
+  - `view=featured`: calcula agregados solo para candidatos de ventana destacada (7 días por default).
+- Se agregó telemetría de rate limiting en admin metrics:
+  - `GET /private/admin/metrics/persistence` ahora incluye `rateLimit` (totales + buckets).
+- Se agregaron límites runtime configurables en deploy script:
+  - `CONTAINER_MEMORY_LIMIT` (default `2g`)
+  - `CONTAINER_CPU_LIMIT` (default `3`)
+  - `CONTAINER_PIDS_LIMIT` (default `2048`)
+- Se agregó herramienta reproducible de carga:
+  - `tools/load-test/community_capacity_probe.py`

--- a/platform/README.md
+++ b/platform/README.md
@@ -26,3 +26,7 @@ Configs and scripts to provision the VPS that runs HomeDir. All secrets are stri
 - Nginx returns the maintenance page when the backend is down, avoiding default 502/Cloudflare responses.
 - Persistence path must be consistent across deploys: set `HOMEDIR_DATA_DIR` and keep `JAVA_TOOL_OPTIONS=-Dhomedir.data.dir=<same-path>` in `/etc/homedir.env`.
 - The default volume mapping (`/work/data:/work/data:Z`) and data-dir env vars must point to the same in-container path.
+- For concurrency hardening, set explicit container limits in `/etc/homedir.env`:
+  - `CONTAINER_MEMORY_LIMIT` (recommended `2g`)
+  - `CONTAINER_CPU_LIMIT` (recommended `3`)
+  - `CONTAINER_PIDS_LIMIT` (recommended `2048`)

--- a/platform/env.example
+++ b/platform/env.example
@@ -14,6 +14,11 @@ LOGFILE=/var/log/homedir-update.log
 DATA_VOLUME=/work/data:/work/data:Z
 ENV_FILE=/etc/homedir.env
 
+# Runtime limits (recommended baseline for ~400 concurrent users)
+CONTAINER_MEMORY_LIMIT=2g
+CONTAINER_CPU_LIMIT=3
+CONTAINER_PIDS_LIMIT=2048
+
 # Application secrets (replace with real values)
 # Data dir consumed by Quarkus config
 HOMEDIR_DATA_DIR=/work/data

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
@@ -4,6 +4,7 @@ import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.model.Scenario;
 import com.scanales.eventflow.model.Speaker;
 import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.security.RateLimitingFilter;
 import com.scanales.eventflow.service.EventService;
 import com.scanales.eventflow.service.SpeakerService;
 import com.scanales.eventflow.service.UsageMetricsService;
@@ -165,6 +166,9 @@ public class AdminMetricsResource {
   @Inject
   com.scanales.eventflow.service.PersistenceService persistenceService;
 
+  @Inject
+  RateLimitingFilter rateLimitingFilter;
+
   @GET
   @Authenticated
   @Produces(MediaType.TEXT_HTML)
@@ -258,6 +262,7 @@ public class AdminMetricsResource {
     stats.put("queue", persistenceService.getQueueStats());
     stats.put("diskUsagePct", persistenceService.getDiskUsage());
     stats.put("lowDiskSpace", persistenceService.isLowDiskSpace());
+    stats.put("rateLimit", rateLimitingFilter.stats());
     return Response.ok(stats).build();
   }
 

--- a/tools/load-test/README.md
+++ b/tools/load-test/README.md
@@ -1,0 +1,34 @@
+# Load Test Utilities
+
+This folder provides lightweight, dependency-free scripts to validate HomeDir concurrency capacity.
+
+## `community_capacity_probe.py`
+
+Quick synthetic probe that simulates logged-out traffic patterns for:
+
+- `/`
+- `/comunidad`
+- `/api/community/content?view=featured&limit=10`
+
+### Usage
+
+```bash
+python3 tools/load-test/community_capacity_probe.py --base-url http://127.0.0.1:8080 --users 400 --duration 180
+```
+
+### Recommended runbook
+
+1. Run against staging first (`--users 200`, then `--users 400`).
+2. Confirm:
+   - `error_rate` near `0%`
+   - no significant `429` spikes on Community API
+   - acceptable `p95_ms` for HTML/API endpoints
+3. Repeat after any change to:
+   - rate limiting
+   - community API query logic
+   - infrastructure runtime limits
+
+### Notes
+
+- This tool intentionally uses only Python stdlib (no k6/wrk dependency).
+- For production, prefer off-peak windows and a lower first pass (`--users 100`) before full load.

--- a/tools/load-test/community_capacity_probe.py
+++ b/tools/load-test/community_capacity_probe.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Simple concurrency probe for HomeDir public/community traffic.
+
+No external dependencies required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from statistics import mean
+
+
+@dataclass
+class EndpointStats:
+    latencies_ms: list[float] = field(default_factory=list)
+    status_counts: Counter = field(default_factory=Counter)
+
+    def record(self, status: int, latency_ms: float) -> None:
+        self.status_counts[status] += 1
+        self.latencies_ms.append(latency_ms)
+
+
+class ProbeRunner:
+    def __init__(self, base_url: str, users: int, duration_s: int, timeout_s: float, think_ms: int) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.users = max(1, users)
+        self.duration_s = max(1, duration_s)
+        self.timeout_s = max(1.0, timeout_s)
+        self.think_ms = max(0, think_ms)
+        self.stop_at = time.monotonic() + self.duration_s
+        self.lock = threading.Lock()
+        self.stats: dict[str, EndpointStats] = defaultdict(EndpointStats)
+        self.total_requests = 0
+        self.total_errors = 0
+
+        self.sequence = [
+            ("/", 1.0),
+            ("/comunidad", 1.0),
+            ("/api/community/content?view=featured&limit=10", 2.0),
+        ]
+
+    def run(self) -> None:
+        threads = [threading.Thread(target=self._vu_loop, name=f"vu-{i}", daemon=True) for i in range(self.users)]
+        start = time.monotonic()
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        elapsed = max(0.001, time.monotonic() - start)
+        self._print_summary(elapsed)
+
+    def _vu_loop(self) -> None:
+        while time.monotonic() < self.stop_at:
+            for path, _weight in self.sequence:
+                if time.monotonic() >= self.stop_at:
+                    return
+                self._request(path)
+            if self.think_ms > 0:
+                sleep_ms = random.randint(int(self.think_ms * 0.5), int(self.think_ms * 1.5))
+                time.sleep(sleep_ms / 1000.0)
+
+    def _request(self, path: str) -> None:
+        url = urllib.parse.urljoin(self.base_url + "/", path.lstrip("/"))
+        t0 = time.perf_counter()
+        status = -1
+        try:
+            req = urllib.request.Request(
+                url=url,
+                headers={
+                    "User-Agent": "homedir-capacity-probe/1.0",
+                    "Accept": "application/json,text/html,*/*",
+                },
+            )
+            with urllib.request.urlopen(req, timeout=self.timeout_s) as res:
+                res.read(1024)
+                status = int(res.status)
+        except urllib.error.HTTPError as ex:
+            status = int(ex.code)
+        except Exception:
+            status = -1
+        latency_ms = (time.perf_counter() - t0) * 1000.0
+        with self.lock:
+            self.stats[path].record(status, latency_ms)
+            self.total_requests += 1
+            if status < 200 or status >= 400:
+                self.total_errors += 1
+
+    def _print_summary(self, elapsed_s: float) -> None:
+        print("=== HomeDir Community Capacity Probe ===")
+        print(f"base_url={self.base_url}")
+        print(f"users={self.users} duration_s={self.duration_s} timeout_s={self.timeout_s:.1f}")
+        print(f"total_requests={self.total_requests} elapsed_s={elapsed_s:.2f} rps={self.total_requests / elapsed_s:.2f}")
+        print(f"error_rate={(self.total_errors / max(1, self.total_requests)) * 100:.2f}%")
+        print("")
+        for path in sorted(self.stats.keys()):
+            s = self.stats[path]
+            lat = sorted(s.latencies_ms)
+            p50 = _pct(lat, 50)
+            p95 = _pct(lat, 95)
+            p99 = _pct(lat, 99)
+            avg = mean(lat) if lat else 0.0
+            status_str = ", ".join(f"{k}:{v}" for k, v in sorted(s.status_counts.items(), key=lambda x: x[0]))
+            print(
+                f"path={path} count={len(lat)} avg_ms={avg:.1f} p50_ms={p50:.1f} p95_ms={p95:.1f} p99_ms={p99:.1f} status=[{status_str}]"
+            )
+
+
+def _pct(values: list[float], pct: int) -> float:
+    if not values:
+        return 0.0
+    idx = int((pct / 100.0) * len(values))
+    if idx >= len(values):
+        idx = len(values) - 1
+    return values[idx]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Synthetic concurrency probe for HomeDir Community.")
+    p.add_argument("--base-url", default="http://127.0.0.1:8080", help="Base URL to target.")
+    p.add_argument("--users", type=int, default=100, help="Concurrent virtual users.")
+    p.add_argument("--duration", type=int, default=120, help="Duration in seconds.")
+    p.add_argument("--timeout", type=float, default=8.0, help="Per-request timeout in seconds.")
+    p.add_argument("--think-ms", type=int, default=500, help="Average think time between user loops.")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    runner = ProbeRunner(
+        base_url=args.base_url,
+        users=args.users,
+        duration_s=args.duration,
+        timeout_s=args.timeout,
+        think_ms=args.think_ms,
+    )
+    runner.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- optimize `GET /api/community/content` for concurrency by limiting vote aggregate queries to requested page/candidate window
- extend rate limit telemetry with runtime counters per bucket and expose them in admin persistence metrics
- add Cloudflare-aware client IP fallback and preserve dedicated Community API bucket
- add runtime container limits support to `platform/scripts/homedir-update.sh` (`CONTAINER_MEMORY_LIMIT`, `CONTAINER_CPU_LIMIT`, `CONTAINER_PIDS_LIMIT`)
- add reproducible probe tool for 400-user concurrency validation (`tools/load-test/community_capacity_probe.py`)
- update capacity documentation and platform docs/env baseline

## Validation
- `./mvnw.cmd -q "-Dtest=RateLimitingFilterTest,CommunityContentApiResourceTest,AdminMetricsExportTest" test`
- `python tools/load-test/community_capacity_probe.py --base-url https://homedir.opensourcesantiago.io --users 5 --duration 5`
