### PR TITLE
feat(capacity): cache community vote aggregates for featured reads

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -159,6 +159,7 @@ community.content.refresh-interval=15m
 community.content.featured.window-days=7
 community.content.ranking.decay-enabled=true
 community.votes.daily-limit=100
+community.votes.aggregate-cache-ttl=PT10S
 community.submissions.daily-limit=5
 community.submissions.max-title-length=140
 community.submissions.max-summary-length=360

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityVoteServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityVoteServiceTest.java
@@ -1,6 +1,7 @@
 package com.scanales.eventflow.community;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -34,5 +35,21 @@ public class CommunityVoteServiceTest {
     assertEquals(0L, aggregate.notForMe());
     assertEquals(CommunityVoteType.MUST_SEE, aggregate.myVote());
   }
-}
 
+  @Test
+  void anonymousAggregatesReflectLatestVotesAfterUpsert() {
+    String contentId = "item-cache-1";
+
+    voteService.upsertVote("a@example.com", contentId, CommunityVoteType.RECOMMENDED);
+    CommunityVoteAggregate first = voteService.getAggregates(List.of(contentId), null).get(contentId);
+    assertNotNull(first);
+    assertEquals(1L, first.recommended());
+    assertEquals(0L, first.mustSee());
+
+    voteService.upsertVote("b@example.com", contentId, CommunityVoteType.MUST_SEE);
+    CommunityVoteAggregate second = voteService.getAggregates(List.of(contentId), null).get(contentId);
+    assertNotNull(second);
+    assertEquals(1L, second.recommended());
+    assertEquals(1L, second.mustSee());
+  }
+}


### PR DESCRIPTION
## Summary
- add short in-memory aggregate cache for community vote counts
- invalidate cache on vote upsert and test reset paths
- keep `myVote` per-user query while reusing cached counts
- document latest capacity validation and next hardening steps

## Validation
- `./mvnw.cmd -q "-Dtest=CommunityVoteServiceTest,CommunityContentApiResourceTest" test`
