### PR TITLE
fix: integrate #337 with test coverage and webhook tag hardening

### DIFF
--- a/scripts/enforce_severity.py
+++ b/scripts/enforce_severity.py
@@ -26,7 +26,8 @@ def iter_results(sarif):
     for run in sarif.get("runs", []):
         for result in run.get("results", []):
             rule = result.get("ruleId")
-            loc = result.get("locations", [{}])[0]
+            locations = result.get("locations")
+            loc = locations[0] if locations else {}
             phys = loc.get("physicalLocation", {})
             file = phys.get("artifactLocation", {}).get("uri")
             line = phys.get("region", {}).get("startLine")

--- a/tests/test_enforce_severity.py
+++ b/tests/test_enforce_severity.py
@@ -18,7 +18,22 @@ def _get_load_sarif():
     return namespace["load_sarif"]
 
 
+def _get_iter_results():
+    """Load iter_results from the script without running module side effects."""
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "enforce_severity.py"
+    source = script_path.read_text()
+    module = ast.parse(source, filename=str(script_path))
+    func_node = next(
+        n for n in module.body if isinstance(n, ast.FunctionDef) and n.name == "iter_results"
+    )
+    module_code = ast.Module(body=[func_node], type_ignores=[])
+    namespace = {}
+    exec(compile(module_code, filename=str(script_path), mode="exec"), namespace)
+    return namespace["iter_results"]
+
+
 load_sarif = _get_load_sarif()
+iter_results = _get_iter_results()
 
 
 def test_load_sarif_invalid_json(tmp_path, capsys):
@@ -31,3 +46,28 @@ def test_load_sarif_invalid_json(tmp_path, capsys):
     captured = capsys.readouterr()
     assert result == {"runs": []}
     assert "Failed to parse SARIF file" in captured.err
+
+
+def test_iter_results_handles_empty_locations():
+    """iter_results should not crash when SARIF result locations is an empty list."""
+    sarif = {
+        "runs": [
+            {
+                "results": [
+                    {
+                        "ruleId": "example.rule",
+                        "locations": [],
+                        "message": {"text": "example"},
+                    }
+                ]
+            }
+        ]
+    }
+
+    rows = list(iter_results(sarif))
+    assert len(rows) == 1
+    rule, file, line, result = rows[0]
+    assert rule == "example.rule"
+    assert file is None
+    assert line is None
+    assert result["message"]["text"] == "example"


### PR DESCRIPTION
## Summary
- fix SARIF parsing when locations is present but empty ([])
- add regression test for empty locations in iter_results
- validate webhook tag format before invoking update script
- keep webhook comments concise and technical

## Why
This integrates the useful parts of #337 with the requested adjustments: robustness + cleaner production code style.

## Validation
- python -m pytest tests/test_enforce_severity.py -q

Closes #337