### PR TITLE
feat(community-board): secure Discord integration + enriched board metrics

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/community/CommunityBoardSummary.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/community/CommunityBoardSummary.java
@@ -1,3 +1,12 @@
 package com.scanales.eventflow.community;
 
-public record CommunityBoardSummary(int homedirUsers, int githubUsers, int discordUsers) {}
+import java.time.Instant;
+
+public record CommunityBoardSummary(
+    int homedirUsers,
+    int githubUsers,
+    int discordUsers,
+    int discordListedUsers,
+    Integer discordOnlineUsers,
+    String discordDataSource,
+    Instant discordLastSyncAt) {}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/community/DiscordGuildStatsService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/community/DiscordGuildStatsService.java
@@ -1,0 +1,343 @@
+package com.scanales.eventflow.community;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class DiscordGuildStatsService {
+  private static final Logger LOG = Logger.getLogger(DiscordGuildStatsService.class);
+  private static final Duration DEFAULT_CACHE_TTL = Duration.ofHours(1);
+  private static final Duration DEFAULT_RETRY_INTERVAL = Duration.ofMinutes(5);
+  private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+
+  @Inject ObjectMapper objectMapper;
+
+  @ConfigProperty(name = "community.board.discord.integration.enabled", defaultValue = "false")
+  boolean integrationEnabled;
+
+  @ConfigProperty(name = "community.board.discord.guild-id")
+  Optional<String> guildIdConfig;
+
+  @ConfigProperty(name = "community.board.discord.bot-token")
+  Optional<String> botTokenConfig;
+
+  @ConfigProperty(name = "community.board.discord.cache-ttl", defaultValue = "PT1H")
+  Duration cacheTtl;
+
+  @ConfigProperty(name = "community.board.discord.retry-interval", defaultValue = "PT5M")
+  Duration retryInterval;
+
+  @ConfigProperty(name = "community.board.discord.request-timeout", defaultValue = "PT5S")
+  Duration requestTimeout;
+
+  private final HttpClient httpClient = HttpClient.newBuilder().connectTimeout(DEFAULT_TIMEOUT).build();
+
+  private final AtomicReference<DiscordGuildSnapshot> snapshot =
+      new AtomicReference<>(DiscordGuildSnapshot.disabled(null));
+  private final AtomicBoolean refreshInProgress = new AtomicBoolean(false);
+  private final ExecutorService refreshExecutor =
+      Executors.newSingleThreadExecutor(
+          new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable runnable) {
+              Thread thread = new Thread(runnable, "discord-board-refresh");
+              thread.setDaemon(true);
+              return thread;
+            }
+          });
+
+  @PostConstruct
+  void init() {
+    triggerRefreshAsync(true, "startup");
+  }
+
+  @PreDestroy
+  void shutdown() {
+    refreshExecutor.shutdownNow();
+  }
+
+  @Scheduled(every = "{community.board.discord.refresh-interval:30m}")
+  void scheduledRefresh() {
+    triggerRefreshAsync(true, "schedule");
+  }
+
+  public DiscordGuildSnapshot snapshot() {
+    triggerRefreshAsync(false, "on-demand");
+    return snapshot.get();
+  }
+
+  void resetForTests() {
+    snapshot.set(DiscordGuildSnapshot.disabled(null));
+  }
+
+  private void triggerRefreshAsync(boolean force, String reason) {
+    DiscordGuildSnapshot current = snapshot.get();
+    Instant now = Instant.now();
+    if (!force && !shouldRefresh(current, now)) {
+      return;
+    }
+    if (!refreshInProgress.compareAndSet(false, true)) {
+      return;
+    }
+    refreshExecutor.submit(
+        () -> {
+          try {
+            refresh(reason, now);
+          } finally {
+            refreshInProgress.set(false);
+          }
+        });
+  }
+
+  private boolean shouldRefresh(DiscordGuildSnapshot current, Instant now) {
+    if (!integrationEnabled) {
+      return false;
+    }
+    if (current.loadedAt() != null && now.isBefore(current.loadedAt().plus(effectiveCacheTtl()))) {
+      return false;
+    }
+    if (current.lastAttemptAt() == null) {
+      return true;
+    }
+    return now.isAfter(current.lastAttemptAt().plus(effectiveRetryInterval()));
+  }
+
+  private void refresh(String reason, Instant attemptedAt) {
+    DiscordGuildSnapshot previous = snapshot.get();
+
+    if (!integrationEnabled) {
+      snapshot.set(DiscordGuildSnapshot.disabled(attemptedAt));
+      return;
+    }
+
+    String guildId = trimToNull(guildIdConfig.orElse(null));
+    if (guildId == null) {
+      snapshot.set(DiscordGuildSnapshot.misconfigured(attemptedAt));
+      LOG.warn("Discord board integration enabled but community.board.discord.guild-id is missing");
+      return;
+    }
+
+    Optional<DiscordFetchResult> loaded = fetchFromDiscord(guildId);
+    if (loaded.isPresent()) {
+      DiscordFetchResult result = loaded.get();
+      snapshot.set(
+          new DiscordGuildSnapshot(
+              true,
+              true,
+              result.memberCount(),
+              result.onlineCount(),
+              result.sourceCode(),
+              attemptedAt,
+              attemptedAt,
+              true));
+      LOG.infov(
+          "Discord board stats refreshed reason={0} source={1} members={2} online={3}",
+          reason,
+          result.sourceCode(),
+          result.memberCount(),
+          result.onlineCount());
+      return;
+    }
+
+    if (previous.loadedAt() != null
+        && (previous.memberCount() != null || previous.onlineCount() != null)
+        && previous.configured()) {
+      snapshot.set(previous.withFailedAttempt(attemptedAt));
+      LOG.warnv(
+          "Discord board refresh failed reason={0}; keeping cached source={1}",
+          reason,
+          previous.sourceCode());
+      return;
+    }
+
+    snapshot.set(DiscordGuildSnapshot.unavailable(attemptedAt));
+    LOG.warnv("Discord board refresh failed reason={0}; no data available", reason);
+  }
+
+  private Optional<DiscordFetchResult> fetchFromDiscord(String guildId) {
+    String token = trimToNull(botTokenConfig.orElse(null));
+    if (token != null) {
+      Optional<DiscordFetchResult> botResult =
+          fetchJson(
+              "https://discord.com/api/v10/guilds/"
+                  + url(guildId)
+                  + "?with_counts=true",
+              "Bot " + token,
+              "bot_api");
+      if (botResult.isPresent()) {
+        return botResult;
+      }
+    }
+
+    Optional<DiscordFetchResult> previewResult =
+        fetchJson(
+            "https://discord.com/api/v10/guilds/" + url(guildId) + "/preview",
+            null,
+            "preview_api");
+    if (previewResult.isPresent()) {
+      return previewResult;
+    }
+
+    return fetchJson(
+        "https://discord.com/api/guilds/" + url(guildId) + "/widget.json",
+        null,
+        "widget_api");
+  }
+
+  private Optional<DiscordFetchResult> fetchJson(String url, String authorization, String sourceCode) {
+    try {
+      HttpRequest.Builder builder = HttpRequest.newBuilder()
+          .uri(URI.create(url))
+          .timeout(effectiveRequestTimeout())
+          .header("Accept", "application/json")
+          .header("User-Agent", "homedir-community-board");
+      if (authorization != null && !authorization.isBlank()) {
+        builder.header("Authorization", authorization);
+      }
+      HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() >= 400) {
+        LOG.debugv("Discord {0} request failed with status={1}", sourceCode, response.statusCode());
+        return Optional.empty();
+      }
+      JsonNode root = objectMapper.readTree(response.body());
+      Integer memberCount = firstInt(root, "approximate_member_count", "member_count");
+      Integer onlineCount = firstInt(root, "approximate_presence_count", "presence_count");
+      if (memberCount == null && onlineCount == null) {
+        return Optional.empty();
+      }
+      return Optional.of(new DiscordFetchResult(memberCount, onlineCount, sourceCode));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.warnv("Discord {0} request interrupted", sourceCode);
+      return Optional.empty();
+    } catch (Exception e) {
+      LOG.warnv("Discord {0} request failed: {1}", sourceCode, e.getClass().getSimpleName());
+      return Optional.empty();
+    }
+  }
+
+  static Integer firstInt(JsonNode root, String... keys) {
+    if (root == null || keys == null) {
+      return null;
+    }
+    for (String key : keys) {
+      if (key == null || key.isBlank()) {
+        continue;
+      }
+      JsonNode node = root.path(key);
+      if (node.isMissingNode() || node.isNull()) {
+        continue;
+      }
+      if (node.isInt() || node.isLong()) {
+        return node.asInt();
+      }
+      String text = trimToNull(node.asText(null));
+      if (text == null) {
+        continue;
+      }
+      try {
+        return Integer.parseInt(text);
+      } catch (Exception ignored) {
+      }
+    }
+    return null;
+  }
+
+  private Duration effectiveCacheTtl() {
+    if (cacheTtl == null || cacheTtl.isNegative() || cacheTtl.isZero()) {
+      return DEFAULT_CACHE_TTL;
+    }
+    return cacheTtl;
+  }
+
+  private Duration effectiveRetryInterval() {
+    if (retryInterval == null || retryInterval.isNegative() || retryInterval.isZero()) {
+      return DEFAULT_RETRY_INTERVAL;
+    }
+    return retryInterval;
+  }
+
+  private Duration effectiveRequestTimeout() {
+    if (requestTimeout == null || requestTimeout.isNegative() || requestTimeout.isZero()) {
+      return DEFAULT_TIMEOUT;
+    }
+    return requestTimeout;
+  }
+
+  private static String url(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  private record DiscordFetchResult(Integer memberCount, Integer onlineCount, String sourceCode) {}
+
+  public record DiscordGuildSnapshot(
+      boolean integrationEnabled,
+      boolean configured,
+      Integer memberCount,
+      Integer onlineCount,
+      String sourceCode,
+      Instant loadedAt,
+      Instant lastAttemptAt,
+      boolean lastAttemptSucceeded) {
+
+    static DiscordGuildSnapshot disabled(Instant attempt) {
+      return new DiscordGuildSnapshot(false, false, null, null, "disabled", null, attempt, false);
+    }
+
+    static DiscordGuildSnapshot misconfigured(Instant attempt) {
+      return new DiscordGuildSnapshot(true, false, null, null, "misconfigured", null, attempt, false);
+    }
+
+    static DiscordGuildSnapshot unavailable(Instant attempt) {
+      return new DiscordGuildSnapshot(true, true, null, null, "unavailable", null, attempt, false);
+    }
+
+    DiscordGuildSnapshot withFailedAttempt(Instant attempt) {
+      return new DiscordGuildSnapshot(
+          integrationEnabled,
+          configured,
+          memberCount,
+          onlineCount,
+          sourceCode,
+          loadedAt,
+          attempt,
+          false);
+    }
+
+    public int resolveMemberCount(int fallback) {
+      if (memberCount != null && memberCount > 0) {
+        return memberCount;
+      }
+      return Math.max(0, fallback);
+    }
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
@@ -1821,6 +1821,39 @@ public interface AppMessages {
     @Message("People who joined our official OSSantiago Discord server.")
     String community_board_group_discord_desc();
 
+    @Message("Listed profiles: {count}")
+    String community_board_discord_listed(int count);
+
+    @Message("Online now: {count}")
+    String community_board_discord_online_now(int count);
+
+    @Message("Data source: {source}")
+    String community_board_discord_source(String source);
+
+    @Message("Last sync: {timestamp}")
+    String community_board_discord_last_sync(String timestamp);
+
+    @Message("Discord API (bot token)")
+    String community_board_discord_source_bot_api();
+
+    @Message("Discord API (guild preview)")
+    String community_board_discord_source_preview_api();
+
+    @Message("Discord API (server widget)")
+    String community_board_discord_source_widget_api();
+
+    @Message("Community board file")
+    String community_board_discord_source_file();
+
+    @Message("Unavailable")
+    String community_board_discord_source_unavailable();
+
+    @Message("Missing configuration")
+    String community_board_discord_source_misconfigured();
+
+    @Message("Integration disabled")
+    String community_board_discord_source_disabled();
+
     @Message("View members")
     String community_board_view_members();
 

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -169,6 +169,13 @@ community.submissions.max-summary-length=360
 community.submissions.max-tags=8
 community.board.cache-ttl=PT1H
 # community.board.discord.file=/var/lib/homedir/community/board/discord-users.yml
+community.board.discord.integration.enabled=${COMMUNITY_BOARD_DISCORD_INTEGRATION_ENABLED:false}
+community.board.discord.guild-id=${COMMUNITY_BOARD_DISCORD_GUILD_ID:}
+community.board.discord.bot-token=${COMMUNITY_BOARD_DISCORD_BOT_TOKEN:}
+community.board.discord.cache-ttl=PT1H
+community.board.discord.retry-interval=PT5M
+community.board.discord.refresh-interval=30m
+community.board.discord.request-timeout=PT5S
 
 # Home project contributors cache
 home.project.github.repo-owner=os-santiago

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -301,3 +301,15 @@ events_cfp_admin_testing_save=Guardar
 events_cfp_admin_testing_saved=Guardado.
 events_cfp_admin_testing_error=No fue posible actualizar el modo de prueba en este momento.
 
+# --- Community Board (Discord integration) ---
+community_board_discord_listed=Perfiles listados: {count}
+community_board_discord_online_now=En linea ahora: {count}
+community_board_discord_source=Fuente de datos: {source}
+community_board_discord_last_sync=Ultima sincronizacion: {timestamp}
+community_board_discord_source_bot_api=API de Discord (token bot)
+community_board_discord_source_preview_api=API de Discord (preview del servidor)
+community_board_discord_source_widget_api=API de Discord (widget del servidor)
+community_board_discord_source_file=Archivo del community board
+community_board_discord_source_unavailable=No disponible
+community_board_discord_source_misconfigured=Configuracion faltante
+community_board_discord_source_disabled=Integracion deshabilitada

--- a/quarkus-app/src/main/resources/templates/CommunityBoardResource/board.html
+++ b/quarkus-app/src/main/resources/templates/CommunityBoardResource/board.html
@@ -33,6 +33,16 @@
           <p class="section-subtitle">{i18n.community_board_group_discord}</p>
           <h2>{discordUsers}</h2>
           <p>{i18n.community_board_group_discord_desc}</p>
+          <div class="board-discord-meta">
+            <p>{i18n.community_board_discord_listed(discordListedUsers)}</p>
+            {#if discordOnlineUsers != null}
+              <p>{i18n.community_board_discord_online_now(discordOnlineUsers)}</p>
+            {/if}
+            <p>{i18n.community_board_discord_source(discordSourceLabel)}</p>
+            {#if discordLastSyncLabel}
+              <p>{i18n.community_board_discord_last_sync(discordLastSyncLabel)}</p>
+            {/if}
+          </div>
           <a class="btn-primary" href="/comunidad/board/discord-users">{i18n.community_board_view_members}</a>
         </article>
       </div>
@@ -70,6 +80,13 @@
 
     .board-summary-card p {
       margin: 0;
+    }
+
+    .board-discord-meta {
+      display: grid;
+      gap: 0.2rem;
+      font-size: 0.88rem;
+      opacity: 0.9;
     }
 
     @media (max-width: 980px) {

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
@@ -56,7 +56,8 @@ public class CommunityBoardResourceTest {
         .body(containsString("Community Board"))
         .body(containsString("HomeDir users"))
         .body(containsString("GitHub users"))
-        .body(containsString("Discord users"));
+        .body(containsString("Discord users"))
+        .body(containsString("Listed profiles: 1"));
   }
 
   @Test

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/DiscordGuildStatsServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/DiscordGuildStatsServiceTest.java
@@ -1,0 +1,39 @@
+package com.scanales.eventflow.community;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class DiscordGuildStatsServiceTest {
+
+  private static final ObjectMapper JSON = new ObjectMapper();
+
+  @Test
+  void firstIntReadsNumericFields() throws Exception {
+    var node = JSON.readTree("{\"approximate_member_count\":1234,\"presence_count\":77}");
+    assertEquals(1234, DiscordGuildStatsService.firstInt(node, "approximate_member_count", "member_count"));
+    assertEquals(77, DiscordGuildStatsService.firstInt(node, "approximate_presence_count", "presence_count"));
+  }
+
+  @Test
+  void firstIntReadsNumericStringFields() throws Exception {
+    var node = JSON.readTree("{\"member_count\":\"42\"}");
+    assertEquals(42, DiscordGuildStatsService.firstInt(node, "approximate_member_count", "member_count"));
+  }
+
+  @Test
+  void firstIntReturnsNullForMissingValues() throws Exception {
+    var node = JSON.readTree("{\"name\":\"ossantiago\"}");
+    assertNull(DiscordGuildStatsService.firstInt(node, "approximate_member_count", "member_count"));
+  }
+
+  @Test
+  void snapshotResolveMemberCountFallsBackToFileCount() {
+    var snapshot =
+        new DiscordGuildStatsService.DiscordGuildSnapshot(
+            true, true, null, 21, "widget_api", null, null, true);
+    assertEquals(9, snapshot.resolveMemberCount(9));
+  }
+}


### PR DESCRIPTION
Discord integration (optional and secure) for Community Board counters with cache + fallback, plus UI metadata and docs.