### PR TITLE
fix: populate Discord board members from cached widget data

### DIFF
--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/DiscordGuildStatsServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/DiscordGuildStatsServiceTest.java
@@ -1,9 +1,12 @@
 package com.scanales.eventflow.community;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class DiscordGuildStatsServiceTest {
@@ -33,7 +36,39 @@ class DiscordGuildStatsServiceTest {
   void snapshotResolveMemberCountFallsBackToFileCount() {
     var snapshot =
         new DiscordGuildStatsService.DiscordGuildSnapshot(
-            true, true, null, 21, "widget_api", null, null, true);
+            true, true, null, 21, "widget_api", List.of(), null, null, true);
     assertEquals(9, snapshot.resolveMemberCount(9));
+  }
+
+  @Test
+  void parseMemberSamplesReadsWidgetMembers() throws Exception {
+    var node =
+        JSON.readTree(
+            """
+            {
+              "members": [
+                {
+                  "id": "123",
+                  "username": "alice",
+                  "global_name": "Alice Dev",
+                  "discriminator": "0001",
+                  "avatar_url": "https://cdn.discordapp.com/a.png"
+                }
+              ]
+            }
+            """);
+    var members = DiscordGuildStatsService.parseMemberSamples(node);
+    assertEquals(1, members.size());
+    var first = members.get(0);
+    assertEquals("123", first.id());
+    assertEquals("Alice Dev", first.displayName());
+    assertEquals("alice#0001", first.handle());
+    assertNotNull(first.avatarUrl());
+  }
+
+  @Test
+  void parseMemberSamplesReturnsEmptyWhenMembersMissing() throws Exception {
+    var node = JSON.readTree("{\"approximate_member_count\":220}");
+    assertTrue(DiscordGuildStatsService.parseMemberSamples(node).isEmpty());
   }
 }


### PR DESCRIPTION
## Summary
- parse `members` from Discord `widget.json` and keep them in the Discord integration cache snapshot
- use cached Discord member samples as fallback for `/comunidad/board/discord-users` when `discord-users.yml` is missing/empty
- add unit tests for widget member parsing and updated snapshot constructor

## Why
Production currently shows aggregate Discord counts but `Listed profiles: 0` and empty search because the detail view depends only on a local file that is not present on VPS.

## Validation
- `./mvnw.cmd -q "-Dtest=DiscordGuildStatsServiceTest,CommunityBoardResourceTest" test`
