### PR TITLE
perf: speed up community board with cached snapshots and 10-item paging

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
@@ -1860,6 +1860,9 @@ public interface AppMessages {
     @Message("{count} members")
     String community_board_members_count(int count);
 
+    @Message("Showing {from} to {to} of {total}")
+    String community_board_pagination_status(int from, int to, int total);
+
     @Message("Search by name, handle or email")
     String community_board_search_placeholder();
 
@@ -1868,6 +1871,12 @@ public interface AppMessages {
 
     @Message("Search")
     String community_board_search();
+
+    @Message("Previous")
+    String community_board_prev();
+
+    @Message("Next")
+    String community_board_next();
 
     @Message("No members found with current filter.")
     String community_board_no_members();

--- a/quarkus-app/src/main/resources/i18n.properties
+++ b/quarkus-app/src/main/resources/i18n.properties
@@ -109,3 +109,8 @@ motivation_work=Relevant to my work
 motivation_learning=I want to learn about this
 motivation_speaker=I know the speaker
 motivation_interesting=I found it interesting
+
+# --- Community Board Pagination ---
+community_board_pagination_status=Showing {from} to {to} of {total}
+community_board_prev=Previous
+community_board_next=Next

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -313,3 +313,6 @@ community_board_discord_source_file=Archivo del community board
 community_board_discord_source_unavailable=No disponible
 community_board_discord_source_misconfigured=Configuracion faltante
 community_board_discord_source_disabled=Integracion deshabilitada
+community_board_pagination_status=Mostrando {from} a {to} de {total}
+community_board_prev=Anterior
+community_board_next=Siguiente

--- a/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
@@ -44,6 +44,9 @@
     <div class="section-card events-full-width board-detail-shell">
       <div class="board-detail-head">
         <p class="section-subtitle">{i18n.community_board_members_count(total)}</p>
+        {#if total > 0}
+          <p class="section-subtitle">{i18n.community_board_pagination_status(pageStart, pageEnd, total)}</p>
+        {/if}
       </div>
 
       <form class="search-form board-search-form" method="get" action="/comunidad/board/{groupPath}">
@@ -96,6 +99,19 @@
               </div>
             </article>
           {/for}
+        {/if}
+      </div>
+
+      <div class="board-pagination">
+        {#if hasPreviousPage}
+          <a class="btn-primary" href="{previousPageUrl}">{i18n.community_board_prev}</a>
+        {#else}
+          <span class="btn-primary board-page-disabled">{i18n.community_board_prev}</span>
+        {/if}
+        {#if hasNextPage}
+          <a class="btn-primary" href="{nextPageUrl}">{i18n.community_board_next}</a>
+        {#else}
+          <span class="btn-primary board-page-disabled">{i18n.community_board_next}</span>
         {/if}
       </div>
     </div>
@@ -196,6 +212,20 @@
       gap: 0.6rem;
       align-items: center;
       flex-wrap: wrap;
+    }
+
+    .board-pagination {
+      margin-top: 1rem;
+      display: flex;
+      gap: 0.6rem;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    .board-page-disabled {
+      opacity: 0.5;
+      pointer-events: none;
+      user-select: none;
     }
 
     .board-copy-btn.is-done {

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
@@ -73,6 +73,30 @@ public class CommunityBoardResourceTest {
   }
 
   @Test
+  void boardDetailPagePaginatesInBlocksOfTen() throws Exception {
+    Path discordFile = Path.of(System.getProperty("homedir.data.dir"), "community", "board", "discord-users.yml");
+    StringBuilder yaml = new StringBuilder("members:\n");
+    for (int i = 1; i <= 12; i++) {
+      yaml.append("  - id: discord-").append(String.format("%03d", i)).append('\n');
+      yaml.append("    display_name: Discord User ").append(i).append('\n');
+      yaml.append("    handle: discord_user_").append(i).append("#1001\n");
+      yaml.append("    joined_at: \"2026-01-10T00:00:00Z\"\n");
+    }
+    Files.writeString(discordFile, yaml.toString());
+    boardService.resetDiscordCacheForTests();
+
+    given()
+        .when()
+        .get("/comunidad/board/discord-users")
+        .then()
+        .statusCode(200)
+        .body(containsString("Showing 1 to 10 of 12"))
+        .body(containsString("limit=10"))
+        .body(containsString("offset=10"))
+        .body(containsString("Next"));
+  }
+
+  @Test
   void englishCommunityAliasRedirectsToLocalizedBoardPath() {
     given()
         .redirects()


### PR DESCRIPTION
## Summary
- add in-memory snapshot + async refresh for `CommunityBoardService` (same strategy used in Community Picks)
- add short response cache for board list slices to avoid recomputing filters/pagination in hot paths
- paginate board members by default in blocks of 10 (`default-page-size=10`) with prev/next controls
- add i18n messages and integration test for 10-per-page pagination

## Notes
- Community Picks already uses `limit=10` and `Load more` in blocks of 10 (`data-page-size=10` + API default limit=10), so no extra code change was required there.

## Validation
- `./mvnw.cmd -q "-Dtest=CommunityBoardResourceTest,DiscordGuildStatsServiceTest,CommunityContentApiResourceTest" test`
