### PR TITLE
perf(community): simplify hover effects in picks and board views

### DIFF
--- a/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
@@ -118,11 +118,31 @@
   </section>
 
   <style>
+    .floating-shapes {
+      display: none;
+    }
+
     .board-detail-shell,
     .board-detail-shell:hover {
       transform: none;
       animation: none;
       cursor: default;
+    }
+
+    .board-detail-shell::before,
+    .board-detail-shell:hover::before {
+      content: none;
+    }
+
+    .board-detail-shell .btn-primary,
+    .board-detail-shell .btn-primary:hover,
+    .board-detail-shell .btn-primary:active,
+    .board-detail-shell .board-member-card,
+    .board-detail-shell .board-member-card:hover {
+      transform: none !important;
+      animation: none !important;
+      transition: none !important;
+      will-change: auto !important;
     }
 
     .board-detail-head {
@@ -161,6 +181,7 @@
       border-radius: 10px;
       padding: 0.85rem;
       background: rgba(0, 0, 0, 0.35);
+      box-shadow: none;
       display: flex;
       justify-content: space-between;
       align-items: center;

--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -297,6 +297,38 @@
     content: none;
   }
 
+  .community-shell-card .btn-primary,
+  .community-shell-card .btn-primary:hover,
+  .community-shell-card .btn-primary:active,
+  .community-shell-card .community-vote-btn,
+  .community-shell-card .community-vote-btn:hover,
+  .community-shell-card .community-vote-btn:active,
+  .community-shell-card .community-topic-btn,
+  .community-shell-card .community-topic-btn:hover,
+  .community-shell-card .community-topic-btn:active,
+  .community-shell-card .community-tag-btn,
+  .community-shell-card .community-tag-btn:hover,
+  .community-shell-card .community-tag-btn:active,
+  .community-shell-card .community-summary-toggle,
+  .community-shell-card .community-summary-toggle:hover,
+  .community-shell-card .community-summary-toggle:active,
+  .community-shell-card .community-clear-filters-btn,
+  .community-shell-card .community-clear-filters-btn:hover,
+  .community-shell-card .community-clear-filters-btn:active,
+  .community-shell-card .community-interest-card,
+  .community-shell-card .community-interest-card:hover,
+  .community-shell-card .community-radar-chip,
+  .community-shell-card .community-radar-chip:hover,
+  .community-shell-card .community-hot-item,
+  .community-shell-card .community-hot-item:hover,
+  .community-shell-card .community-pulse-card,
+  .community-shell-card .community-pulse-card:hover {
+    transform: none !important;
+    animation: none !important;
+    transition: none !important;
+    will-change: auto !important;
+  }
+
   .community-feedback {
     margin-bottom: 1rem;
     padding: 0.75rem;


### PR DESCRIPTION
## Summary
- disable floating background shapes on `Community Board` detail pages
- neutralize hover/active transforms and transitions on dense interactive controls in:
  - `/comunidad/board/*`
  - `/comunidad?view=featured` (Community Picks)
- remove `section-card` sweep pseudo-effect from board detail shell to avoid repaint spikes

## Validation
- `./mvnw.cmd -q "-Dtest=CommunityBoardResourceTest,CommunityContentApiResourceTest" test`
