### PR TITLE
perf(community-board): ultra-lite mode for discord users page

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityBoardResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityBoardResource.java
@@ -129,7 +129,7 @@ public class CommunityBoardResource {
             nextPageUrl,
             normalizeHighlightedMember(highlightedMember),
             slice.items());
-    return withLayoutData(template, "board");
+    return withLayoutData(template, "board").data("ultraLiteMode", group == CommunityBoardGroup.DISCORD_USERS);
   }
 
   private TemplateInstance withLayoutData(TemplateInstance template, String activeCommunitySubmenu) {

--- a/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
@@ -118,6 +118,15 @@
   </section>
 
   <style>
+    body.ultra-lite-mode *,
+    body.ultra-lite-mode *::before,
+    body.ultra-lite-mode *::after {
+      animation: none !important;
+      transition: none !important;
+      transform: none !important;
+      scroll-behavior: auto !important;
+    }
+
     .floating-shapes {
       display: none;
     }

--- a/quarkus-app/src/main/resources/templates/layout/main.html
+++ b/quarkus-app/src/main/resources/templates/layout/main.html
@@ -4,6 +4,7 @@
 {@ boolean noCharacterSheet = false}
 {@ String activePage = ""}
 {@ String mainClass = ""}
+{@ boolean ultraLiteMode = false}
 {@ boolean userAuthenticated = false}
 {@ String userName = ""}
 {@ String userInitial = ""}
@@ -44,8 +45,10 @@
   {#insert head}{/}
 </head>
 
-<body class="homedir-body">
+<body class="homedir-body{#if ultraLiteMode} ultra-lite-mode{/if}">
+  {#if !ultraLiteMode}
   {#include fragments/floating-shapes.html /}
+  {/if}
 
   <div class="app-container">
     {#if noNav != true}
@@ -64,16 +67,20 @@
   </div>
 
   {#include fragments/login-modal.html/}
+  {#if !ultraLiteMode}
   <script src="/js/homedir.js?v={app:version()}"></script>
+  {/if}
   <script>
     window.__EF_AUTH__ = { isAuth: { app: { userAuthenticated: {#if userAuthenticated}true{#else}false{/if} } } };
     window.userAuthenticated = window.__EF_AUTH__.isAuth.app.userAuthenticated;
     var userAuthenticated = window.userAuthenticated;
   </script>
+  {#if !ultraLiteMode}
   <script src="/js/app.js?v={app:version()}" defer></script>
   <script src="/js/notifications-adapter.js?v={app:version()}" defer></script>
   <script src="/js/notifications.js?v={app:version()}" defer></script>
   <script src="/js/global-notifications-ws.js?v={app:version()}" defer></script>
+  {/if}
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- add an `ultraLiteMode` layout flag
- disable floating shapes and global UI scripts when ultra-lite is active
- enable ultra-lite specifically for `/comunidad/board/discord-users`
- enforce no animation/transition/transform for all descendants in that ultra-lite page

## Validation
- `./mvnw.cmd -q "-Dtest=CommunityBoardResourceTest,CommunityContentApiResourceTest" test`
