### PR TITLE
fix(community-board): stabilize ultra-lite rendering for discord users

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -63,6 +63,7 @@ const SELECTORS = {
 // Funciones de ayuda para seleccionar elementos utilizando los selectores centralizados.
 const $ = (key) => document.querySelector(SELECTORS[key]);
 const $$ = (key) => document.querySelectorAll(SELECTORS[key]);
+const isUltraLiteMode = () => document.body && document.body.classList.contains('ultra-lite-mode');
 
 function adjustLayout() {
     const toggle = $('menuToggle');
@@ -204,6 +205,9 @@ function setupViewFullAgenda() {
 }
 
 function bannerParallax() {
+    if (isUltraLiteMode()) {
+        return;
+    }
     const banner = $('banner');
     if (banner) {
         banner.style.backgroundPositionX = (window.scrollY * 0.3) + 'px';
@@ -311,7 +315,9 @@ function onDomContentLoaded() {
     setupAgendaToggle();
     setupViewFullAgenda();
     adjustLayout();
-    bannerParallax();
+    if (!isUltraLiteMode()) {
+        bannerParallax();
+    }
     handleForms();
     highlightNav();
     handleNotificationsFromUrl();
@@ -336,14 +342,16 @@ function initListeners() {
     resizeHandler = adjustLayout;
     window.addEventListener('resize', resizeHandler);
 
-    scrollHandler = bannerParallax;
-    window.addEventListener('scroll', scrollHandler);
+    if (!isUltraLiteMode()) {
+        scrollHandler = bannerParallax;
+        window.addEventListener('scroll', scrollHandler);
 
-    beforeUnloadHandler = () => showLoading('la página', false);
-    window.addEventListener('beforeunload', beforeUnloadHandler);
+        beforeUnloadHandler = () => showLoading('la página', false);
+        window.addEventListener('beforeunload', beforeUnloadHandler);
 
-    unloadHandler = () => removeListeners();
-    window.addEventListener('unload', unloadHandler);
+        unloadHandler = () => removeListeners();
+        window.addEventListener('unload', unloadHandler);
+    }
 }
 
 function removeListeners() {

--- a/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
@@ -118,15 +118,25 @@
   </section>
 
   <style>
-    body.ultra-lite-mode *,
-    body.ultra-lite-mode *::before,
-    body.ultra-lite-mode *::after {
+    body.ultra-lite-mode .board-detail-shell,
+    body.ultra-lite-mode .board-detail-shell *,
+    body.ultra-lite-mode .board-detail-shell *::before,
+    body.ultra-lite-mode .board-detail-shell *::after {
       animation: none !important;
       transition: none !important;
       transform: none !important;
-      scroll-behavior: auto !important;
+      will-change: auto !important;
     }
 
+    body.ultra-lite-mode .board-detail-shell,
+    body.ultra-lite-mode .board-members-grid,
+    body.ultra-lite-mode .board-member-card,
+    body.ultra-lite-mode .board-member-main,
+    body.ultra-lite-mode .board-member-text,
+    body.ultra-lite-mode .board-member-actions {
+      opacity: 1 !important;
+      visibility: visible !important;
+    }
     .floating-shapes {
       display: none;
     }

--- a/quarkus-app/src/main/resources/templates/layout/main.html
+++ b/quarkus-app/src/main/resources/templates/layout/main.html
@@ -46,9 +46,7 @@
 </head>
 
 <body class="homedir-body{#if ultraLiteMode} ultra-lite-mode{/if}">
-  {#if !ultraLiteMode}
   {#include fragments/floating-shapes.html /}
-  {/if}
 
   <div class="app-container">
     {#if noNav != true}
@@ -67,20 +65,16 @@
   </div>
 
   {#include fragments/login-modal.html/}
-  {#if !ultraLiteMode}
   <script src="/js/homedir.js?v={app:version()}"></script>
-  {/if}
   <script>
     window.__EF_AUTH__ = { isAuth: { app: { userAuthenticated: {#if userAuthenticated}true{#else}false{/if} } } };
     window.userAuthenticated = window.__EF_AUTH__.isAuth.app.userAuthenticated;
     var userAuthenticated = window.userAuthenticated;
   </script>
-  {#if !ultraLiteMode}
   <script src="/js/app.js?v={app:version()}" defer></script>
   <script src="/js/notifications-adapter.js?v={app:version()}" defer></script>
   <script src="/js/notifications.js?v={app:version()}" defer></script>
   <script src="/js/global-notifications-ws.js?v={app:version()}" defer></script>
-  {/if}
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- fix `discord-users` ultra-lite rendering regression where cards/content could appear invisible
- scope ultra-lite animation reset only to board container (not global `*`)
- force visible state for board content blocks (`opacity`/`visibility`)
- keep base scripts loaded for layout consistency and disable only heavy listeners in `app.js` when `ultra-lite-mode` is active

## Validation
- `./mvnw.cmd -q "-Dtest=CommunityBoardResourceTest" test`
