### PR TITLE
perf(community): enforce ultra-lite rendering for picks/board and reduce hover overhead

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityBoardResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityBoardResource.java
@@ -137,6 +137,7 @@ public class CommunityBoardResource {
     String name = currentUserName().orElse(null);
     return template
         .data("activePage", "comunidad")
+        .data("mainClass", "community-ultra-lite")
         .data("activeCommunitySubmenu", activeCommunitySubmenu)
         .data("userAuthenticated", authenticated)
         .data("userName", name)

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberResource.java
@@ -93,6 +93,7 @@ public class CommunityMemberResource {
     String name = currentUserName().orElse(null);
     return template
         .data("activePage", "comunidad")
+        .data("mainClass", "community-ultra-lite")
         .data("activeCommunitySubmenu", activeCommunitySubmenu)
         .data("userAuthenticated", authenticated)
         .data("userName", name)

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityResource.java
@@ -86,6 +86,7 @@ public class CommunityResource {
             summary.discordUsers());
     return template
         .data("activePage", "comunidad")
+        .data("mainClass", "community-ultra-lite")
         .data("activeCommunitySubmenu", activeSubmenu)
         .data("initialFilter", initialFilter)
         .data("userAuthenticated", authenticated)

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -2443,6 +2443,26 @@ footer {
   box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.25) inset;
 }
 
+/* Community ultra-lite mode for heavy lists (picks + board). */
+.homedir-main.community-ultra-lite .section-card,
+.homedir-main.community-ultra-lite .section-card:hover,
+.homedir-main.community-ultra-lite .btn-primary,
+.homedir-main.community-ultra-lite .btn-primary:hover,
+.homedir-main.community-ultra-lite .btn-primary:active,
+.homedir-main.community-ultra-lite .community-submenu-link,
+.homedir-main.community-ultra-lite .community-submenu-link:hover,
+.homedir-main.community-ultra-lite .community-submenu-link:active {
+  animation: none !important;
+  transition: none !important;
+  transform: none !important;
+  will-change: auto !important;
+}
+
+.homedir-main.community-ultra-lite .section-card::before,
+.homedir-main.community-ultra-lite .section-card:hover::before {
+  content: none !important;
+}
+
 @media (max-width: 900px) {
   .community-submenu {
     grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));

--- a/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
@@ -71,7 +71,7 @@
             <article class="board-member-card {#if highlightedMember == member.id}is-highlighted{/if}">
               <div class="board-member-main">
                 {#if member.avatarUrl}
-                  <img class="board-member-avatar" src="{member.avatarUrl}" alt="{member.displayName}" loading="lazy" />
+                  <img class="board-member-avatar" src="{member.avatarUrl}" alt="{member.displayName}" loading="lazy" decoding="async" fetchpriority="low" width="44" height="44" />
                 {#else}
                   <div class="board-member-avatar board-member-avatar-fallback">
                     {member.displayName.substring(0,1)}
@@ -146,6 +146,7 @@
       transform: none;
       animation: none;
       cursor: default;
+      will-change: auto;
     }
 
     .board-detail-shell::before,
@@ -206,6 +207,9 @@
       align-items: center;
       gap: 0.9rem;
       flex-wrap: wrap;
+      transition: none;
+      animation: none;
+      transform: none;
     }
 
     .board-member-card.is-highlighted {

--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -292,6 +292,13 @@
     box-shadow: 0 6px 0 rgba(0, 0, 0, 0.6);
   }
 
+  .community-shell-card *,
+  .community-shell-card *::before,
+  .community-shell-card *::after {
+    animation: none;
+    will-change: auto;
+  }
+
   .community-shell-card::before,
   .community-shell-card:hover::before {
     content: none;


### PR DESCRIPTION
## Summary
- enforce `community-ultra-lite` main class on Community, Community Board and Community Member pages
- disable expensive transitions/transform animations in ultra-lite mode for cards/buttons/submenu
- optimize board avatars with lazy decode and fixed dimensions
- harden board card styles to avoid hover-triggered jitter loops

## Validation
- mvn "-Dtest=CommunityBoardResourceTest,CommunityContentApiResourceTest" test

## Expected impact
- smoother navigation in `/comunidad?view=featured` and `/comunidad/board/discord-users`
- lower GPU/compositor pressure and fewer visual glitches on hover
