### PR TITLE
style(ui): compact empty states + subtle separators

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -2523,6 +2523,57 @@ footer {
   content: none !important;
 }
 
+.homedir-body.ultra-lite-mode .section-header {
+  position: relative;
+  padding-bottom: 0.18rem;
+}
+
+.homedir-body.ultra-lite-mode .section-header::after {
+  content: "";
+  display: block;
+  width: min(240px, 65%);
+  height: 1px;
+  margin-top: 0.38rem;
+  background: linear-gradient(90deg, rgba(255, 215, 0, 0.5), rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0));
+  opacity: 0.78;
+}
+
+.homedir-body.ultra-lite-mode .community-empty,
+.homedir-body.ultra-lite-mode .errors-empty-state,
+.homedir-body.ultra-lite-mode .project-hd-empty,
+.homedir-body.ultra-lite-mode .hd-empty-state {
+  border: 1px dashed rgba(255, 255, 255, 0.34);
+  border-radius: 10px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(0, 0, 0, 0.18));
+  padding: 0.58rem 0.72rem;
+}
+
+.homedir-body.ultra-lite-mode .hd-empty-callout {
+  border: 1px dashed rgba(255, 255, 255, 0.34);
+  border-radius: 10px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(0, 0, 0, 0.18));
+  padding: 0.58rem 0.72rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.homedir-body.ultra-lite-mode .hd-empty-callout::before {
+  font-family: "Material Symbols Outlined";
+  content: "info";
+  font-size: 1.12rem;
+  line-height: 1;
+  opacity: 0.82;
+}
+
+.homedir-body.ultra-lite-mode .community-empty p,
+.homedir-body.ultra-lite-mode .errors-empty-state,
+.homedir-body.ultra-lite-mode .project-hd-empty,
+.homedir-body.ultra-lite-mode .hd-empty-state,
+.homedir-body.ultra-lite-mode .hd-empty-callout p {
+  margin: 0;
+}
+
 @media (max-width: 900px) {
   .community-submenu {
     grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));

--- a/quarkus-app/src/main/resources/templates/EventsDirectoryResource/eventos.html
+++ b/quarkus-app/src/main/resources/templates/EventsDirectoryResource/eventos.html
@@ -37,7 +37,7 @@
 
   {#if upcoming.isEmpty()}
   <div class="section-card events-full-width">
-    <p>{i18n.events_empty_upcoming}</p>
+    <p class="hd-empty-callout">{i18n.events_empty_upcoming}</p>
   </div>
   {#else}
   <div class="events-upcoming-strip events-full-width">
@@ -135,7 +135,7 @@
 
   {#if past.isEmpty()}
   <div class="section-card events-full-width">
-    <p>{i18n.events_empty_past}</p>
+    <p class="hd-empty-callout">{i18n.events_empty_past}</p>
   </div>
   {#else}
   <div class="events-past-strip events-full-width">

--- a/quarkus-app/src/main/resources/templates/events.qute.html
+++ b/quarkus-app/src/main/resources/templates/events.qute.html
@@ -39,7 +39,7 @@
 
   {#if upcomingEvents.isEmpty()}
   <div class="section-card events-full-width">
-    <p>{i18n.events_empty_upcoming}</p>
+    <p class="hd-empty-callout">{i18n.events_empty_upcoming}</p>
   </div>
   {#else}
   <div class="events-grid events-full-width">
@@ -68,7 +68,7 @@
 
   {#if pastEvents.isEmpty()}
   <div class="section-card events-full-width">
-    <p>{i18n.events_empty_past}</p>
+    <p class="hd-empty-callout">{i18n.events_empty_past}</p>
   </div>
   {#else}
   <div class="events-list events-full-width">


### PR DESCRIPTION
Summary
- introduce lightweight empty-state callout style for ultra-lite mode
- apply callout utility to Events empty states (both templates)
- add subtle section-header separators to reduce flat whitespace perception
- keep static rendering only (no new JS/animations)

Validation
- mvn -Dtest=CommunityBoardResourceTest,PublicPagesResourceTest test