### PR TITLE
style(community): icons and clearer selected state on submenu tabs

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -2416,6 +2416,10 @@ footer {
 }
 
 .community-submenu-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.34rem;
   text-decoration: none;
   min-width: 0;
   padding: 0.42rem 0.55rem;
@@ -2426,6 +2430,19 @@ footer {
   letter-spacing: 0.8px;
   line-height: 1.15;
   box-shadow: 0 5px 0 rgba(0, 0, 0, 0.32), inset 0 0 14px rgba(255, 255, 255, 0.08);
+}
+
+.community-submenu-icon {
+  font-size: 0.86rem;
+  opacity: 0.88;
+  flex: 0 0 auto;
+}
+
+.community-submenu-label {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .community-submenu-link:hover {
@@ -2439,8 +2456,23 @@ footer {
 }
 
 .community-submenu-link-active {
-  filter: brightness(1.08);
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.25) inset;
+  filter: brightness(1.12);
+  border-color: rgba(255, 215, 0, 0.86);
+  background: linear-gradient(180deg, rgba(255, 215, 0, 0.19), rgba(0, 0, 0, 0.22));
+  box-shadow:
+    0 5px 0 rgba(0, 0, 0, 0.32),
+    0 0 0 2px rgba(255, 215, 0, 0.34) inset,
+    0 0 0 1px rgba(255, 255, 255, 0.35);
+}
+
+.community-submenu-link-active .community-submenu-icon {
+  color: #ffd700;
+  opacity: 1;
+}
+
+.community-submenu-link-active .community-submenu-label {
+  color: #fffdf1;
+  text-shadow: 0 0 8px rgba(255, 215, 0, 0.32);
 }
 
 /* Community ultra-lite mode for heavy lists (picks + board). */
@@ -2583,6 +2615,10 @@ footer {
     padding: 0.38rem 0.5rem;
     font-size: 0.58rem;
     letter-spacing: 0.7px;
+  }
+
+  .community-submenu-icon {
+    font-size: 0.78rem;
   }
 }
 

--- a/quarkus-app/src/main/resources/templates/fragments/community-submenu.html
+++ b/quarkus-app/src/main/resources/templates/fragments/community-submenu.html
@@ -2,17 +2,21 @@
 {@ boolean isAdmin = false}
 <nav class="community-submenu" aria-label="{i18n.community_submenu_aria_label}">
   <a href="/comunidad/picks" class="btn-primary community-submenu-link {#if activeCommunitySubmenu == 'picks'}community-submenu-link-active{/if}">
-    {i18n.community_submenu_picks}
+    <span class="material-symbols-outlined community-submenu-icon" aria-hidden="true">auto_awesome</span>
+    <span class="community-submenu-label">{i18n.community_submenu_picks}</span>
   </a>
   <a href="/comunidad/propose" class="btn-primary community-submenu-link {#if activeCommunitySubmenu == 'propose'}community-submenu-link-active{/if}">
-    {i18n.community_submenu_propose}
+    <span class="material-symbols-outlined community-submenu-icon" aria-hidden="true">edit_note</span>
+    <span class="community-submenu-label">{i18n.community_submenu_propose}</span>
   </a>
   <a href="/comunidad/board" class="btn-primary community-submenu-link {#if activeCommunitySubmenu == 'board'}community-submenu-link-active{/if}">
-    {i18n.community_submenu_board}
+    <span class="material-symbols-outlined community-submenu-icon" aria-hidden="true">groups</span>
+    <span class="community-submenu-label">{i18n.community_submenu_board}</span>
   </a>
   {#if isAdmin}
   <a href="/comunidad/moderation" class="btn-primary community-submenu-link {#if activeCommunitySubmenu == 'moderation'}community-submenu-link-active{/if}">
-    {i18n.community_submenu_moderation}
+    <span class="material-symbols-outlined community-submenu-icon" aria-hidden="true">gavel</span>
+    <span class="community-submenu-label">{i18n.community_submenu_moderation}</span>
   </a>
   {/if}
 </nav>


### PR DESCRIPTION
Summary
- add Material Symbols icons to Community submenu options (Picks, Propose, Board, Moderation)
- improve selected state contrast so active tab is clearly visible
- keep ultra-lite behavior and existing visual identity

Validation
- mvn -Dtest=CommunityBoardResourceTest,CommunityModerationPageTest,CommunityContentApiResourceTest test