### PR TITLE
fix(community-board): prevent blank page on view-members navigation

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/community-board.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/community-board.js
@@ -30,9 +30,8 @@
     }
     currentMain.className = nextMain.className;
     currentMain.innerHTML = nextMain.innerHTML;
-    if (nextDocument.body && typeof nextDocument.body.className === "string") {
-      document.body.className = nextDocument.body.className;
-    }
+    // Keep runtime classes managed by global scripts (e.g. `loaded`).
+    // Replacing body.className here causes invisible page until hard refresh.
     if (nextDocument.title) {
       document.title = nextDocument.title;
     }


### PR DESCRIPTION
Summary
- fix partial board navigation to avoid resetting body runtime classes
- keep global runtime classes (e.g. loaded) so content remains visible after fetch swap

Root cause
- community-board.js replaced document.body.className during HTML swap
- that removed the loaded class required by styles.css (body loaded state), causing invisible page until refresh

Validation
- mvn -Dtest=CommunityBoardResourceTest,CommunityContentApiResourceTest test