### PR TITLE
feat(profile): unify public identity view for claimed accounts

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
@@ -1425,6 +1425,24 @@ public interface AppMessages {
     @Message("Public Profile CTA Button")
     String public_profile_cta_btn();
 
+    @Message("Connected accounts")
+    String public_profile_accounts_title();
+
+    @Message("HomeDir")
+    String public_profile_accounts_homedir();
+
+    @Message("GitHub")
+    String public_profile_accounts_github();
+
+    @Message("Discord")
+    String public_profile_accounts_discord();
+
+    @Message("Open profile")
+    String public_profile_accounts_discord_open();
+
+    @Message("No linked accounts yet.")
+    String public_profile_accounts_empty();
+
     @Message("Share Profile")
     String btn_share_profile();
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberResource.java
@@ -91,6 +91,9 @@ public class CommunityMemberResource {
         && member.handle().length() > 1) {
       return "/u/" + member.handle().substring(1);
     }
+    if (group == CommunityBoardGroup.HOMEDIR_USERS && member.id() != null && member.id().startsWith("hd-")) {
+      return "/u/" + member.id();
+    }
     return "/comunidad/board/" + group.path() + "?member=" + member.id();
   }
 
@@ -103,7 +106,7 @@ public class CommunityMemberResource {
     if (homedirId == null) {
       return null;
     }
-    return "/community/member/homedir-users/" + urlEncode(homedirId);
+    return "/u/" + urlEncode(homedirId);
   }
 
   private String titleFor(CommunityBoardGroup group) {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/PublicProfileResource.java
@@ -2,6 +2,7 @@ package com.scanales.eventflow.public_;
 
 import com.scanales.eventflow.model.CommunityMember;
 import com.scanales.eventflow.model.QuestProfile;
+import com.scanales.eventflow.model.UserProfile;
 import com.scanales.eventflow.service.CommunityService;
 import com.scanales.eventflow.service.QuestService;
 import com.scanales.eventflow.service.UserProfileService;
@@ -13,13 +14,17 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 @Path("/u")
 public class PublicProfileResource {
 
     @Inject
-    Template publicProfile; // maps to public-profile.qute.html
+    Template publicProfile;
 
     @Inject
     CommunityService communityService;
@@ -34,47 +39,211 @@ public class PublicProfileResource {
     @Path("/{username}")
     @Produces(MediaType.TEXT_HTML)
     public Response getPublicProfile(@PathParam("username") String username) {
-        // 1. Resolve Github handle to User ID (Email)
-        String userId = null;
-        Optional<CommunityMember> memberOpt = communityService.findByGithub(username);
-
-        if (memberOpt.isPresent()) {
-            userId = memberOpt.get().getUserId();
-        } else {
+        String requested = normalizeId(username);
+        if (requested == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
 
-        // 2. Fetch Quest Data using UserID
-        QuestProfile questProfile = questService.getProfile(userId);
+        Optional<ResolvedPublicProfile> resolvedOpt = resolveProfile(requested);
+        if (resolvedOpt.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        ResolvedPublicProfile resolved = resolvedOpt.get();
 
-        String questClassEmoji = "🌱"; // Placeholder
+        QuestProfile questProfile = questService.getProfile(resolved.userId());
+
+        String questClassEmoji = "🌱";
         int questsCompleted = questProfile.history != null ? questProfile.history.size() : 0;
         long xpPercentage = 0;
         if (questProfile.nextLevelXp > 0) {
             xpPercentage = Math.round(((double) questProfile.currentXp / (double) questProfile.nextLevelXp) * 100);
         }
 
-        // 3. Render Template
+        List<String> badges = resolved.badges() == null ? List.of() : resolved.badges();
+        boolean hasGithub = resolved.githubLogin() != null;
+        boolean hasDiscord = resolved.discordHandle() != null || resolved.discordProfileUrl() != null;
+
         return Response.ok(publicProfile
-                .data("pageTitle", memberOpt.get().getDisplayName() + " (@" + username + ")")
-                .data("username", username)
-                .data("displayName", memberOpt.get().getDisplayName())
-                .data("avatarUrl", memberOpt.get().getAvatarUrl())
-                .data("level", questProfile.level)
-                .data("currentXp", questProfile.currentXp)
-                .data("nextLevelXp", questProfile.nextLevelXp)
-                .data("xpPercentage", xpPercentage)
-                .data("questClass", "Novice")
-                .data("questClassEmoji", questClassEmoji)
-                .data("questsCompleted", questsCompleted)
-                .data("badges", memberOpt.map(CommunityMember::getBadges).orElse(java.util.List.of()))
-                .data("history",
-                        questProfile.history != null ? questProfile.history.stream().limit(5).toList()
-                                : java.util.List.of())
-                .data("ogTitle", memberOpt.get().getDisplayName() + " - Homedir Profile")
-                .data("ogDescription", "Check out " + username + "'s developer stats and quests.")
-                .data("ogImage", "https://og.scanales.com/api/og?title=" + username + "&subtitle=Level "
-                        + questProfile.level))
-                .build();
+            .data("pageTitle", resolved.displayName() + " (@" + resolved.canonicalUsername() + ")")
+            .data("username", resolved.canonicalUsername())
+            .data("displayName", resolved.displayName())
+            .data("avatarUrl", resolved.avatarUrl())
+            .data("level", questProfile.level)
+            .data("currentXp", questProfile.currentXp)
+            .data("nextLevelXp", questProfile.nextLevelXp)
+            .data("xpPercentage", xpPercentage)
+            .data("questClass", "Novice")
+            .data("questClassEmoji", questClassEmoji)
+            .data("questsCompleted", questsCompleted)
+            .data("badges", badges)
+            .data("history",
+                questProfile.history != null ? questProfile.history.stream().limit(5).toList() : List.of())
+            .data("githubLogin", resolved.githubLogin())
+            .data("githubProfileUrl", resolved.githubProfileUrl())
+            .data("discordHandle", resolved.discordHandle())
+            .data("discordProfileUrl", resolved.discordProfileUrl())
+            .data("homedirId", resolved.homedirId())
+            .data("hasGithub", hasGithub)
+            .data("hasDiscord", hasDiscord)
+            .data("hasLinkedAccounts", hasGithub || hasDiscord)
+            .data("ogTitle", resolved.displayName() + " - Homedir Profile")
+            .data("ogDescription", "Check out @" + resolved.canonicalUsername() + " and their community activity.")
+            .data("ogImage", "https://og.scanales.com/api/og?title=" + resolved.canonicalUsername() + "&subtitle=Level "
+                + questProfile.level))
+            .build();
+    }
+
+    private Optional<ResolvedPublicProfile> resolveProfile(String requestedUsername) {
+        Optional<ResolvedPublicProfile> direct = resolveFromUserProfiles(requestedUsername);
+        if (direct.isPresent()) {
+            return direct;
+        }
+
+        Optional<CommunityMember> memberOpt = communityService.findByGithub(requestedUsername);
+        if (memberOpt.isEmpty()) {
+            return Optional.empty();
+        }
+        CommunityMember member = memberOpt.get();
+        String githubLogin = normalizeId(member.getGithub());
+        String canonical = firstNonBlank(githubLogin, requestedUsername);
+        String userId = firstNonBlank(member.getUserId(), canonical);
+        String homedirId = homedirMemberId(member.getUserId(), null);
+        return Optional.of(new ResolvedPublicProfile(
+            canonical,
+            userId,
+            firstNonBlank(member.getDisplayName(), canonical),
+            member.getAvatarUrl(),
+            githubLogin,
+            firstNonBlank(member.getProfileUrl(), githubLogin != null ? "https://github.com/" + githubLogin : null),
+            null,
+            null,
+            homedirId,
+            member.getBadges() == null ? List.of() : member.getBadges()));
+    }
+
+    private Optional<ResolvedPublicProfile> resolveFromUserProfiles(String requestedUsername) {
+        for (UserProfile profile : userProfileService.allProfiles().values()) {
+            if (profile == null) {
+                continue;
+            }
+            String githubLogin = normalizeId(profile.getGithub() != null ? profile.getGithub().login() : null);
+            String homedirId = homedirMemberId(firstNonBlank(profile.getUserId(), profile.getEmail()), null);
+            boolean matchesGithub = githubLogin != null && githubLogin.equals(requestedUsername);
+            boolean matchesHomedir = homedirId != null && homedirId.equals(requestedUsername);
+            if (!matchesGithub && !matchesHomedir) {
+                continue;
+            }
+
+            String canonicalUsername = firstNonBlank(githubLogin, homedirId, requestedUsername);
+            String userId = firstNonBlank(profile.getUserId(), profile.getEmail(), canonicalUsername);
+            String displayName = firstNonBlank(
+                profile.getName(),
+                usernameFromEmail(profile.getEmail()),
+                githubLogin,
+                canonicalUsername);
+            String avatarUrl = firstNonBlank(
+                profile.getGithub() != null ? profile.getGithub().avatarUrl() : null,
+                profile.getDiscord() != null ? profile.getDiscord().avatarUrl() : null);
+            String githubProfileUrl = firstNonBlank(
+                profile.getGithub() != null ? profile.getGithub().profileUrl() : null,
+                githubLogin != null ? "https://github.com/" + githubLogin : null);
+            String discordId = normalizeId(profile.getDiscord() != null ? profile.getDiscord().id() : null);
+            String discordProfileUrl = firstNonBlank(
+                profile.getDiscord() != null ? profile.getDiscord().profileUrl() : null,
+                discordId != null ? "https://discord.com/users/" + discordId : null);
+            String discordHandle = firstNonBlank(
+                profile.getDiscord() != null ? profile.getDiscord().handle() : null,
+                discordId);
+            List<String> badges = communityService.findByUserId(userId).map(CommunityMember::getBadges).orElse(List.of());
+            if (badges == null) {
+                badges = List.of();
+            }
+
+            return Optional.of(new ResolvedPublicProfile(
+                canonicalUsername,
+                userId,
+                displayName,
+                avatarUrl,
+                githubLogin,
+                githubProfileUrl,
+                discordHandle,
+                discordProfileUrl,
+                homedirId,
+                badges));
+        }
+        return Optional.empty();
+    }
+
+    private static String normalizeId(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        String normalized = raw.trim().toLowerCase(Locale.ROOT);
+        return normalized.isBlank() ? null : normalized;
+    }
+
+    private static String usernameFromEmail(String email) {
+        String value = normalizeId(email);
+        if (value == null) {
+            return null;
+        }
+        int at = value.indexOf('@');
+        return at > 0 ? value.substring(0, at) : value;
+    }
+
+    private static String firstNonBlank(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (value == null) {
+                continue;
+            }
+            String trimmed = value.trim();
+            if (!trimmed.isEmpty()) {
+                return trimmed;
+            }
+        }
+        return null;
+    }
+
+    private static String homedirMemberId(String identitySeed, String githubLogin) {
+        String github = normalizeId(githubLogin);
+        if (github != null) {
+            return "gh-" + github;
+        }
+        String seed = normalizeId(identitySeed);
+        if (seed == null) {
+            return null;
+        }
+        return "hd-" + shortHash(seed, 16);
+    }
+
+    private static String shortHash(String value, int maxLength) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(hashed.length * 2);
+            for (byte b : hashed) {
+                hex.append(String.format("%02x", b));
+            }
+            int end = Math.min(hex.length(), Math.max(6, maxLength));
+            return hex.substring(0, end);
+        } catch (Exception e) {
+            return Integer.toHexString(value.hashCode());
+        }
+    }
+
+    private record ResolvedPublicProfile(
+        String canonicalUsername,
+        String userId,
+        String displayName,
+        String avatarUrl,
+        String githubLogin,
+        String githubProfileUrl,
+        String discordHandle,
+        String discordProfileUrl,
+        String homedirId,
+        List<String> badges) {
     }
 }

--- a/quarkus-app/src/main/resources/META-INF/resources/css/wrapped.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/wrapped.css
@@ -128,6 +128,16 @@
   margin-bottom: 1rem;
 }
 
+.wrapped-avatar-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: 2.2rem;
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.08);
+}
+
 .wrapped-title {
   font-family: var(--font-display);
   font-size: 2.5rem;

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -55,6 +55,15 @@ agenda_day=Día {day}
 settings_language=Idioma
 settings_language_intro=Selecciona tu idioma preferido.
 settings_save=Guardar Preferencias
+public_profile_cta_title=Únete a la Comunidad
+public_profile_cta_desc=Crea tu perfil, sigue tu progreso y date a conocer.
+public_profile_cta_btn=Comenzar
+public_profile_accounts_title=Cuentas conectadas
+public_profile_accounts_homedir=HomeDir
+public_profile_accounts_github=GitHub
+public_profile_accounts_discord=Discord
+public_profile_accounts_discord_open=Abrir perfil
+public_profile_accounts_empty=Aún no hay cuentas conectadas.
 
 # --- Global Navigation ---
 nav_home=Inicio

--- a/quarkus-app/src/main/resources/messages.properties
+++ b/quarkus-app/src/main/resources/messages.properties
@@ -269,6 +269,12 @@ project_dashboard_relative_years={0}y ago
 public_profile_cta_title=Join the Community
 public_profile_cta_desc=Create your own profile, track your progress, and get discovered.
 public_profile_cta_btn=Get Started
+public_profile_accounts_title=Connected accounts
+public_profile_accounts_homedir=HomeDir
+public_profile_accounts_github=GitHub
+public_profile_accounts_discord=Discord
+public_profile_accounts_discord_open=Open profile
+public_profile_accounts_empty=No linked accounts yet.
 btn_share_profile=Share Profile
 
 # --- Home Page Refactor (New) ---

--- a/quarkus-app/src/main/resources/messages_es.properties
+++ b/quarkus-app/src/main/resources/messages_es.properties
@@ -266,6 +266,12 @@ project_dashboard_relative_years=hace {0}a
 public_profile_cta_title=Únete a la Comunidad
 public_profile_cta_desc=Crea tu perfil, sigue tu progreso y date a conocer.
 public_profile_cta_btn=Comenzar
+public_profile_accounts_title=Cuentas conectadas
+public_profile_accounts_homedir=HomeDir
+public_profile_accounts_github=GitHub
+public_profile_accounts_discord=Discord
+public_profile_accounts_discord_open=Abrir perfil
+public_profile_accounts_empty=Aún no hay cuentas conectadas.
 btn_share_profile=Compartir Perfil
 
 # --- Home Page Refactor (New) ---

--- a/quarkus-app/src/main/resources/templates/publicProfile.qute.html
+++ b/quarkus-app/src/main/resources/templates/publicProfile.qute.html
@@ -10,7 +10,11 @@
         <!-- Header Section -->
         <header class="wrapped-header">
             <div class="wrapped-avatar-container">
+                {#if avatarUrl}
                 <img src="{avatarUrl}" alt="{displayName}" class="wrapped-avatar">
+                {#else}
+                <div class="wrapped-avatar wrapped-avatar-fallback">{displayName.substring(0,1)}</div>
+                {/if}
                 <div class="wrapped-rank-badge">{questClass}</div>
             </div>
             <h1 class="wrapped-title">{displayName}</h1>
@@ -38,6 +42,42 @@
                 <span class="wrapped-stat-label">Quests Completed</span>
                 <span class="wrapped-stat-value purple">{questsCompleted}</span>
                 <p class="wrapped-subtext">Missions Accomplished</p>
+            </div>
+
+            <div class="wrapped-card wrapped-card-full">
+                <span class="wrapped-stat-label">{i18n.public_profile_accounts_title}</span>
+                <div class="wrapped-list-container">
+                    <div class="wrapped-list-item">
+                        <span class="wrapped-item-title">{i18n.public_profile_accounts_homedir}</span>
+                        <span class="wrapped-item-xp">{homedirId ?: username}</span>
+                    </div>
+                    {#if hasGithub}
+                    <div class="wrapped-list-item">
+                        <span class="wrapped-item-title">{i18n.public_profile_accounts_github}</span>
+                        {#if githubProfileUrl}
+                        <a href="{githubProfileUrl}" target="_blank" rel="noopener noreferrer"
+                            class="wrapped-item-xp">@{githubLogin}</a>
+                        {#else}
+                        <span class="wrapped-item-xp">@{githubLogin}</span>
+                        {/if}
+                    </div>
+                    {/if}
+                    {#if hasDiscord}
+                    <div class="wrapped-list-item">
+                        <span class="wrapped-item-title">{i18n.public_profile_accounts_discord}</span>
+                        {#if discordProfileUrl}
+                        <a href="{discordProfileUrl}" target="_blank" rel="noopener noreferrer" class="wrapped-item-xp">
+                            {discordHandle ?: i18n.public_profile_accounts_discord_open}
+                        </a>
+                        {#else}
+                        <span class="wrapped-item-xp">{discordHandle}</span>
+                        {/if}
+                    </div>
+                    {/if}
+                    {#if !hasLinkedAccounts}
+                    <p class="wrapped-empty-msg">{i18n.public_profile_accounts_empty}</p>
+                    {/if}
+                </div>
             </div>
 
             <!-- Card 3: Badges Collection -->

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
@@ -31,6 +31,7 @@ public class CommunityBoardResourceTest {
             "https://avatars.githubusercontent.com/u/12345",
             "12345",
             Instant.parse("2026-02-01T00:00:00Z")));
+    userProfileService.upsert("board.local@example.com", "Board Local", "board.local@example.com");
 
     Path discordFile = Path.of(System.getProperty("homedir.data.dir"), "community", "board", "discord-users.yml");
     Files.createDirectories(discordFile.getParent());
@@ -68,8 +69,18 @@ public class CommunityBoardResourceTest {
         .then()
         .statusCode(200)
         .body(containsString("board-user"))
-        .body(containsString("/community/member/github-users/board-user"))
+        .body(containsString("/u/board-user"))
         .body(containsString("Copy profile link"));
+  }
+
+  @Test
+  void homedirMembersWithoutGithubUseUnifiedPublicProfilePath() {
+    given()
+        .when()
+        .get("/comunidad/board/homedir-users")
+        .then()
+        .statusCode(200)
+        .body(containsString("/u/hd-"));
   }
 
   @Test

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/PublicProfileResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/PublicProfileResourceTest.java
@@ -1,0 +1,107 @@
+package com.scanales.eventflow.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import com.scanales.eventflow.model.UserProfile;
+import com.scanales.eventflow.service.UserProfileService;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class PublicProfileResourceTest {
+
+  @Inject UserProfileService userProfileService;
+
+  @BeforeEach
+  void setup() {
+    userProfileService.linkGithub(
+        "public.user@example.com",
+        "Public User",
+        "public.user@example.com",
+        new UserProfile.GithubAccount(
+            "public-user",
+            "https://github.com/public-user",
+            "https://avatars.githubusercontent.com/u/9001",
+            "9001",
+            Instant.parse("2026-02-01T00:00:00Z")));
+    userProfileService.linkDiscord(
+        "public.user@example.com",
+        "Public User",
+        "public.user@example.com",
+        new UserProfile.DiscordAccount(
+            "discord-public-1",
+            "public_user#1001",
+            "https://discord.com/users/discord-public-1",
+            "https://cdn.discordapp.com/avatars/discord-public-1.png",
+            Instant.parse("2026-02-10T00:00:00Z")));
+
+    userProfileService.upsert("homedir.user@example.com", "Homedir User", "homedir.user@example.com");
+    userProfileService.linkDiscord(
+        "homedir.user@example.com",
+        "Homedir User",
+        "homedir.user@example.com",
+        new UserProfile.DiscordAccount(
+            "discord-homedir-2",
+            "homedir_user#1002",
+            "https://discord.com/users/discord-homedir-2",
+            null,
+            Instant.parse("2026-02-10T00:00:00Z")));
+  }
+
+  @Test
+  void githubProfileShowsUnifiedAccounts() {
+    given()
+        .when()
+        .get("/u/public-user")
+        .then()
+        .statusCode(200)
+        .body(containsString("Public User"))
+        .body(containsString("@public-user"))
+        .body(containsString("public_user#1001"))
+        .body(containsString("Connected accounts"));
+  }
+
+  @Test
+  void homedirProfileWithoutGithubIsResolvable() {
+    String homedirId = homedirMemberId("homedir.user@example.com");
+    given()
+        .when()
+        .get("/u/" + homedirId)
+        .then()
+        .statusCode(200)
+        .body(containsString("Homedir User"))
+        .body(containsString(homedirId))
+        .body(containsString("homedir_user#1002"));
+  }
+
+  @Test
+  void unknownProfileReturnsNotFound() {
+    given().when().get("/u/does-not-exist").then().statusCode(404);
+  }
+
+  private static String homedirMemberId(String identitySeed) {
+    return "hd-" + shortHash(identitySeed.trim().toLowerCase(), 16);
+  }
+
+  private static String shortHash(String value, int maxLength) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hashed = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+      StringBuilder hex = new StringBuilder(hashed.length * 2);
+      for (byte b : hashed) {
+        hex.append(String.format("%02x", b));
+      }
+      int end = Math.min(hex.length(), Math.max(6, maxLength));
+      return hex.substring(0, end);
+    } catch (Exception e) {
+      return Integer.toHexString(value.hashCode());
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- unify public profile routing under `/u/{id}` for GitHub and HomeDir identities
- make Community Board links for HomeDir/GitHub use canonical public profile URLs
- keep Discord claim flow cache-based and route claimed profiles to unified identity
- extend public profile page with linked-account visibility (HomeDir, GitHub, Discord)
- add i18n keys for connected account labels and fallback avatar style
- add regression tests for unified board links and public profile resolution

## Validation
- `mvn "-Dtest=CommunityBoardResourceTest,ProfileResourceTest,PublicProfileResourceTest" test`
