### PR TITLE
Community: canonical redirect for legacy member share URLs

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberResource.java
@@ -4,50 +4,27 @@ import com.scanales.eventflow.community.CommunityBoardGroup;
 import com.scanales.eventflow.community.CommunityBoardMemberView;
 import com.scanales.eventflow.community.CommunityBoardService;
 import com.scanales.eventflow.service.UserProfileService;
-import io.quarkus.qute.CheckedTemplate;
-import io.quarkus.qute.TemplateInstance;
-import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Optional;
-import org.jboss.logging.Logger;
 
 @Path("/community/member")
 public class CommunityMemberResource {
-  private static final Logger LOG = Logger.getLogger(CommunityMemberResource.class);
-
-  @Inject SecurityIdentity identity;
   @Inject CommunityBoardService boardService;
   @Inject UserProfileService userProfileService;
-
-  @CheckedTemplate
-  static class Templates {
-    static native TemplateInstance profile(
-        boolean isAuthenticated,
-        String groupPath,
-        String groupTitle,
-        String displayName,
-        String handle,
-        String avatarUrl,
-        String memberSince,
-        String profileLink,
-        String boardLink);
-  }
 
   @GET
   @Path("/{group}/{id}")
   @PermitAll
-  @Produces(MediaType.TEXT_HTML)
-  public Response profile(@PathParam("group") String groupPath, @PathParam("id") String id) {
+  public Response profileRedirect(@PathParam("group") String groupPath, @PathParam("id") String id) {
     Optional<CommunityBoardGroup> groupOpt = CommunityBoardGroup.fromPath(groupPath);
     if (groupOpt.isEmpty()) {
       return Response.status(Response.Status.NOT_FOUND).build();
@@ -57,19 +34,11 @@ public class CommunityMemberResource {
     if (memberOpt.isEmpty()) {
       return Response.status(Response.Status.NOT_FOUND).build();
     }
-    CommunityBoardMemberView member = memberOpt.get();
-    TemplateInstance template =
-        Templates.profile(
-            isAuthenticated(),
-            group.path(),
-            titleFor(group),
-            member.displayName(),
-            member.handle(),
-            member.avatarUrl(),
-            member.memberSince(),
-            profileLinkFor(group, member),
-            "/comunidad/board/" + group.path());
-    return Response.ok(withLayoutData(template, "board")).build();
+    String target = profileLinkFor(group, memberOpt.get());
+    if (target == null || target.isBlank()) {
+      return Response.status(Response.Status.NOT_FOUND).build();
+    }
+    return Response.seeOther(URI.create(target)).build();
   }
 
   private String profileLinkFor(CommunityBoardGroup group, CommunityBoardMemberView member) {
@@ -107,57 +76,6 @@ public class CommunityMemberResource {
       return null;
     }
     return "/u/" + urlEncode(homedirId);
-  }
-
-  private String titleFor(CommunityBoardGroup group) {
-    return switch (group) {
-      case HOMEDIR_USERS -> "HomeDir users";
-      case GITHUB_USERS -> "GitHub users";
-      case DISCORD_USERS -> "Discord users";
-    };
-  }
-
-  private TemplateInstance withLayoutData(TemplateInstance template, String activeCommunitySubmenu) {
-    boolean authenticated = isAuthenticated();
-    String name = currentUserName().orElse(null);
-    return template
-        .data("activePage", "comunidad")
-        .data("mainClass", "community-ultra-lite")
-        .data("activeCommunitySubmenu", activeCommunitySubmenu)
-        .data("userAuthenticated", authenticated)
-        .data("userName", name)
-        .data("userInitial", initialFrom(name));
-  }
-
-  private Optional<String> currentUserName() {
-    if (!isAuthenticated()) {
-      return Optional.empty();
-    }
-    String name = identity.getAttribute("name");
-    if (name == null || name.isBlank()) {
-      name = identity.getPrincipal() != null ? identity.getPrincipal().getName() : null;
-    }
-    return Optional.ofNullable(name);
-  }
-
-  private boolean isAuthenticated() {
-    try {
-      return identity != null && !identity.isAnonymous();
-    } catch (Exception e) {
-      LOG.warn("Security identity check failed (treating as anonymous): " + e.getMessage());
-      return false;
-    }
-  }
-
-  private String initialFrom(String name) {
-    if (name == null) {
-      return null;
-    }
-    String trimmed = name.trim();
-    if (trimmed.isEmpty()) {
-      return null;
-    }
-    return trimmed.substring(0, 1).toUpperCase();
   }
 
   private static String urlEncode(String value) {

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
@@ -145,12 +145,13 @@ public class CommunityBoardResourceTest {
   @Test
   void memberSharePageRenders() {
     given()
+        .redirects()
+        .follow(false)
         .when()
         .get("/community/member/github-users/board-user")
         .then()
-        .statusCode(200)
-        .body(containsString("Board User"))
-        .body(containsString("Open profile"));
+        .statusCode(303)
+        .header("Location", containsString("/u/board-user"));
   }
 
   @Test
@@ -168,6 +169,30 @@ public class CommunityBoardResourceTest {
   @Test
   void unknownMemberSharePageReturnsNotFound() {
     given().when().get("/community/member/github-users/does-not-exist").then().statusCode(404);
+  }
+
+  @Test
+  void unclaimedDiscordMemberRedirectsToBoardHighlight() throws Exception {
+    Path discordFile = Path.of(System.getProperty("homedir.data.dir"), "community", "board", "discord-users.yml");
+    Files.writeString(
+        discordFile,
+        """
+        members:
+          - id: discord-unclaimed-001
+            display_name: Unclaimed Discord User
+            handle: unclaimed#1001
+            joined_at: "2026-01-10T00:00:00Z"
+        """);
+    boardService.resetDiscordCacheForTests();
+
+    given()
+        .redirects()
+        .follow(false)
+        .when()
+        .get("/community/member/discord-users/discord-unclaimed-001")
+        .then()
+        .statusCode(303)
+        .header("Location", containsString("/comunidad/board/discord-users?member=discord-unclaimed-001"));
   }
 
   @Test
@@ -207,10 +232,12 @@ public class CommunityBoardResourceTest {
     boardService.resetDiscordCacheForTests();
 
     given()
+        .redirects()
+        .follow(false)
         .when()
         .get("/community/member/discord-users/discord-001")
         .then()
-        .statusCode(200)
-        .body(containsString("/u/board-user"));
+        .statusCode(303)
+        .header("Location", containsString("/u/board-user"));
   }
 }


### PR DESCRIPTION
## Summary
- convert /community/member/{group}/{id} to a compatibility redirect endpoint
- redirect legacy member links to canonical profile URL (/u/...) when available
- keep fallback redirect to board highlight for unclaimed members
- update and extend CommunityBoardResourceTest for redirect behavior

## Validation
- mvn -Dtest=CommunityBoardResourceTest,ProfileResourceTest,PublicProfileResourceTest test