### PR TITLE
Community: emit relative Location headers on member redirects

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberAliasResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberAliasResource.java
@@ -5,7 +5,6 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.core.Response;
-import java.net.URI;
 
 @Path("/comunidad/member")
 @PermitAll
@@ -14,6 +13,8 @@ public class CommunityMemberAliasResource {
   @GET
   @Path("/{group}/{id}")
   public Response redirect(@PathParam("group") String group, @PathParam("id") String id) {
-    return Response.seeOther(URI.create("/community/member/" + group + "/" + id)).build();
+    return Response.status(Response.Status.SEE_OTHER)
+        .header("Location", "/community/member/" + group + "/" + id)
+        .build();
   }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityMemberResource.java
@@ -10,7 +10,6 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.core.Response;
-import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -38,7 +37,7 @@ public class CommunityMemberResource {
     if (target == null || target.isBlank()) {
       return Response.status(Response.Status.NOT_FOUND).build();
     }
-    return Response.seeOther(URI.create(target)).build();
+    return redirectRelative(target);
   }
 
   private String profileLinkFor(CommunityBoardGroup group, CommunityBoardMemberView member) {
@@ -131,5 +130,9 @@ public class CommunityMemberResource {
     } catch (Exception e) {
       return Integer.toHexString(value.hashCode());
     }
+  }
+
+  private static Response redirectRelative(String path) {
+    return Response.status(Response.Status.SEE_OTHER).header("Location", path).build();
   }
 }

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
@@ -2,6 +2,7 @@ package com.scanales.eventflow.community;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
 
 import com.scanales.eventflow.model.UserProfile;
 import com.scanales.eventflow.service.UserProfileService;
@@ -151,7 +152,7 @@ public class CommunityBoardResourceTest {
         .get("/community/member/github-users/board-user")
         .then()
         .statusCode(303)
-        .header("Location", containsString("/u/board-user"));
+        .header("Location", startsWith("/u/board-user"));
   }
 
   @Test
@@ -163,7 +164,7 @@ public class CommunityBoardResourceTest {
         .get("/comunidad/member/github-users/board-user")
         .then()
         .statusCode(303)
-        .header("Location", containsString("/community/member/github-users/board-user"));
+        .header("Location", startsWith("/community/member/github-users/board-user"));
   }
 
   @Test
@@ -192,7 +193,7 @@ public class CommunityBoardResourceTest {
         .get("/community/member/discord-users/discord-unclaimed-001")
         .then()
         .statusCode(303)
-        .header("Location", containsString("/comunidad/board/discord-users?member=discord-unclaimed-001"));
+        .header("Location", startsWith("/comunidad/board/discord-users?member=discord-unclaimed-001"));
   }
 
   @Test
@@ -238,6 +239,6 @@ public class CommunityBoardResourceTest {
         .get("/community/member/discord-users/discord-001")
         .then()
         .statusCode(303)
-        .header("Location", containsString("/u/board-user"));
+        .header("Location", startsWith("/u/board-user"));
   }
 }


### PR DESCRIPTION
## Summary
- return `303` redirects for member routes using relative `Location` headers
- avoid absolute `http://...` locations when running behind reverse proxy
- apply same behavior to `/comunidad/member/{group}/{id}` alias
- harden redirect assertions in community board tests with `startsWith(...)`

## Validation
- mvn -Dtest=CommunityBoardResourceTest,ProfileResourceTest,PublicProfileResourceTest test