### PR TITLE
Fix Discord board identity consistency (id-only matching)

### DIFF
--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/DiscordGuildStatsServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/DiscordGuildStatsServiceTest.java
@@ -71,4 +71,23 @@ class DiscordGuildStatsServiceTest {
     var node = JSON.readTree("{\"approximate_member_count\":220}");
     assertTrue(DiscordGuildStatsService.parseMemberSamples(node).isEmpty());
   }
+
+  @Test
+  void parseMemberSamplesSkipsEntriesWithoutValidDiscordId() throws Exception {
+    var node =
+        JSON.readTree(
+            """
+            {
+              "members": [
+                { "username": "missing-id" },
+                { "id": "not-a-discord-id", "username": "alias-id" },
+                { "id": "456", "username": "valid-id" }
+              ]
+            }
+            """);
+    var members = DiscordGuildStatsService.parseMemberSamples(node);
+    assertEquals(1, members.size());
+    assertEquals("456", members.get(0).id());
+    assertEquals("valid-id", members.get(0).handle());
+  }
 }


### PR DESCRIPTION
## Summary
- require valid Discord member ids for Community Board ingest/fallback (no alias/display-name fallback)
- deduplicate Discord board rows by canonical Discord id
- sanitize legacy handles ending in #000/#0000
- add regression tests for invalid Discord ids in widget/file sources

## Why
This fixes false matches and duplicate-looking members after Discord OAuth claim. Identity matching now depends on Discord unique id, not mutable aliases.

## Validation
- ./mvnw -q ""-Dtest=DiscordGuildStatsServiceTest,CommunityBoardResourceTest"" test