### PR TITLE
fix(community): remove visual lag and hover flicker in picks

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/community-content.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/community-content.js
@@ -15,6 +15,7 @@
     const raw = String(root.dataset.initialMedia || "all").toLowerCase();
     return raw === "video_story" || raw === "podcast" || raw === "article_blog" ? raw : "all";
   })();
+  const ultraLiteMode = String(root.dataset.ultraLite || "false") === "true";
 
   const listEl = document.getElementById("community-list");
   const skeletonEl = document.getElementById("community-skeleton");
@@ -263,6 +264,11 @@
     if (!interestSectionEl || !interestListEl) {
       return;
     }
+    if (ultraLiteMode) {
+      interestSectionEl.classList.add("hidden");
+      interestListEl.textContent = "";
+      return;
+    }
     interestListEl.textContent = "";
 
     if (!Array.isArray(items) || items.length === 0) {
@@ -305,6 +311,11 @@
 
   function renderTagRadar(items) {
     if (!radarSectionEl || !radarListEl) {
+      return;
+    }
+    if (ultraLiteMode) {
+      radarSectionEl.classList.add("hidden");
+      radarListEl.textContent = "";
       return;
     }
     radarListEl.textContent = "";
@@ -375,6 +386,11 @@
 
   function renderHotItems(items) {
     if (!hotSectionEl || !hotListEl) {
+      return;
+    }
+    if (ultraLiteMode) {
+      hotSectionEl.classList.add("hidden");
+      hotListEl.textContent = "";
       return;
     }
     hotListEl.textContent = "";
@@ -649,7 +665,8 @@
     const frame = document.createElement("div");
     frame.className = "community-media-frame";
 
-    if (thumbUrl) {
+    const loadThumbnail = Boolean(thumbUrl) && !ultraLiteMode;
+    if (loadThumbnail) {
       const image = document.createElement("img");
       image.className = "community-media-image";
       image.loading = "lazy";
@@ -1104,6 +1121,7 @@
     if (state.openPreviews.has(key)) {
       state.openPreviews.delete(key);
     } else {
+      state.openPreviews.clear();
       state.openPreviews.add(key);
     }
     renderItems();

--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -20,7 +20,7 @@
   <section class="page-grid">
     {#if activeCommunitySubmenu == 'picks'}
     <div class="section-card events-full-width community-shell-card">
-      <div id="community-content-root" data-authenticated="{isAuthenticated}" data-page-size="10" data-cache-ttl-ms="60000" data-initial-view="{initialView}" data-initial-filter="{initialFilter ?: 'all'}" data-initial-media="{initialMedia ?: 'all'}"
+      <div id="community-content-root" data-authenticated="{isAuthenticated}" data-page-size="10" data-cache-ttl-ms="60000" data-ultra-lite="true" data-initial-view="{initialView}" data-initial-filter="{initialFilter ?: 'all'}" data-initial-media="{initialMedia ?: 'all'}"
         data-i18n-empty-filtered="{i18n.community_js_empty_filtered}"
         data-i18n-empty-generic="{i18n.community_js_empty_generic}"
         data-i18n-items-unit="{i18n.community_js_items_unit}"
@@ -296,6 +296,40 @@
   /* Community page runs in low-motion mode to prevent scroll flicker and repaint spikes. */
   .floating-shapes {
     display: none;
+  }
+
+  /* Hard ultra-lite: prevent repaint loops and hover jitter inside picks content. */
+  #community-content-root,
+  #community-content-root *,
+  #community-content-root *::before,
+  #community-content-root *::after {
+    animation: none !important;
+    transition: none !important;
+    transform: none !important;
+    will-change: auto !important;
+    filter: none !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    text-shadow: none !important;
+  }
+
+  #community-content-root .community-item-card:hover,
+  #community-content-root .community-pulse-card:hover,
+  #community-content-root .community-hot-item:hover,
+  #community-content-root .community-media-btn:hover,
+  #community-content-root .community-topic-btn:hover,
+  #community-content-root .community-preview-toggle:hover,
+  #community-content-root .community-open-source-link:hover,
+  #community-content-root .community-summary-toggle:hover,
+  #community-content-root .community-tag-btn:hover {
+    transform: none !important;
+  }
+
+  #community-content-root .community-item-title,
+  #community-content-root .community-item-meta,
+  #community-content-root .community-item-summary,
+  #community-content-root .community-topic-hint {
+    opacity: 1 !important;
   }
 
   .community-shell-card,


### PR DESCRIPTION
## Summary
- force Community Picks into hard ultra-lite mode to remove hover/animation repaint churn
- disable heavy helper sections (interest/radar/hot) in ultra-lite mode
- avoid loading remote thumbnails by default in ultra-lite (keeps lightweight media placeholders + preview on demand)
- ensure only one inline preview can be open at a time

## Validation
- ./mvnw -q -DskipTests compile