### PR TITLE
docs(community): add Community Picks generation playbook + prompts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,4 @@ Select your language:
 ## Architecture
 
 - [Persistencia](es/architecture/README.md)
+- [Community Picks Playbook](community-picks-playbook.md)

--- a/docs/community-content.md
+++ b/docs/community-content.md
@@ -2,6 +2,9 @@
 
 This module powers `/comunidad` with curated content loaded from files and community voting.
 
+Operational curation guide:
+- `docs/community-picks-playbook.md`
+
 ## Overview
 - Content source: filesystem (not DB), generated externally by a curator CLI.
 - Votes: persisted in an embedded DB table (`content_vote`) with upsert semantics.

--- a/docs/community-picks-playbook.md
+++ b/docs/community-picks-playbook.md
@@ -1,0 +1,178 @@
+# Community Picks Playbook
+
+Last update: 2026-02-20
+
+This document defines the official process to generate and publish Community Picks in Homedir.
+
+## 1. Objective
+
+Establish a repeatable curation workflow that is:
+
+- High signal for developers and platform teams.
+- Operationally lightweight (file-based ingest + cache).
+- Safe and auditable (clear criteria, schema, and moderation path).
+
+## 2. Runtime Architecture
+
+- Source of truth for curated content: filesystem (`*.yml`), not DB.
+- Production directory: `/work/data/community/content`
+- Runtime alias: `${homedir.data.dir}/community/content`
+- Read path in app: `COMMUNITY_CONTENT_DIR` (default `${homedir.data.dir}/community/content`)
+- App behavior:
+  - Loads files asynchronously.
+  - Keeps in-memory cache (TTL 1h).
+  - Exposes ranked views (`featured`, `new`).
+  - Stores votes in DB (`content_vote`), not filesystem.
+
+## 3. End-to-End Workflow
+
+### Step A. Curate candidates
+
+Run the curator:
+
+```bash
+python3 tools/community-curator/curate_from_web.py \
+  --output-dir ./tools/community-curator/out/run-$(date +%Y%m%d-%H%M%S) \
+  --api-base https://homedir.opensourcesantiago.io
+```
+
+### Step B. Review generated pack
+
+Validate:
+
+- `manifest.json` exists.
+- Distribution across media types makes sense.
+- No duplicated URLs/titles.
+- Tags and summaries are coherent.
+
+### Step C. Deploy to VPS
+
+```bash
+bash tools/community-curator/deploy.sh <host> <user> ./tools/community-curator/out/<run-dir>
+```
+
+### Step D. Validate in production
+
+- API check:
+  - `GET /api/community/content?view=new&limit=10`
+  - `GET /api/community/content?view=featured&limit=10`
+- UI check:
+  - `/comunidad?view=new`
+  - `/comunidad?view=featured`
+
+### Step E. Persist curation memory
+
+State file:
+
+- `tools/community-curator/state/history.json`
+
+This enables deduplication and historical bias.
+
+## 4. Curation Criteria
+
+A pick should satisfy most of the following:
+
+- Relevance:
+  - AI engineering, Platform Engineering, Cloud Native, Security, or Developer Experience.
+- Actionability:
+  - Adds practical guidance, decision insight, or implementation knowledge.
+- Source quality:
+  - Prefer official docs, engineering blogs, maintainers, recognized technical media.
+- Freshness:
+  - Prefer recent content unless older content is still highly relevant.
+- Diversity:
+  - Keep a healthy mix of video, podcast, and article/blog.
+- Safety/compliance:
+  - No malicious/phishing links.
+  - No low-quality clickbait.
+  - Avoid duplicate coverage of the exact same announcement.
+
+## 5. Scoring Model (Curator Script)
+
+`tools/community-curator/curate_from_web.py` computes:
+
+- `base`: topic-term hits.
+- `recency_bonus`: up to 1.2 based on publication date.
+- `source_bonus`: trusted source map.
+- `hn_bonus`: Hacker News points normalization.
+- `eval_bonus`: historical tag bias (from votes on existing content).
+
+Formula:
+
+`total = base + recency_bonus + source_bonus + hn_bonus + eval_bonus`
+
+## 6. Official Topic Taxonomy
+
+Market-aligned taxonomy used by Community UI:
+
+- `ai`
+- `platform_engineering`
+- `cloud_native`
+- `security`
+
+Curator generation tags (content metadata) use:
+
+- `ai-engineering`
+- `platform-engineering`
+- `cloud-native`
+- `security`
+- `developer-experience`
+
+Compatibility is intentionally kept with legacy tags (`devops`, `opensource`, `platform`) in UI inference.
+
+## 7. File Structure and Schema
+
+Naming:
+
+- `<YYYYMMDD>-<slug>-<id>.yml`
+
+Required fields:
+
+- `id`
+- `title`
+- `url` (`http/https`)
+- `summary`
+- `source`
+- `created_at` (ISO-8601)
+
+Optional fields:
+
+- `published_at`
+- `media_type` (`video_story|podcast|article_blog`)
+- `thumbnail_url`
+- `tags`
+- `author`
+
+Example:
+
+```yaml
+id: "515535afcc14"
+title: "Kubernetes intro spotlight"
+url: "https://www.youtube.com/watch?v=X48VuDVv0do"
+summary: "Short video primer for Kubernetes concepts used by platform teams."
+source: "youtube.com"
+created_at: "2026-02-20T11:41:51Z"
+media_type: "video_story"
+thumbnail_url: "https://i.ytimg.com/vi/X48VuDVv0do/hqdefault.jpg"
+tags:
+  - "kubernetes"
+  - "platform-engineering"
+  - "cloud-native"
+```
+
+## 8. Prompt Templates (LLM-assisted Curation)
+
+Prompt templates are versioned in:
+
+- `tools/community-curator/prompts/system-curator.md`
+- `tools/community-curator/prompts/user-curation-batch.md`
+- `tools/community-curator/prompts/user-normalize-item.md`
+
+Use these prompts when curation is done with an agent before running deployment scripts.
+
+## 9. Operational Guardrails
+
+- Never commit secrets/tokens in repo.
+- Keep generated output directories (`tools/community-curator/out/...`) out of commits unless explicitly needed for fixtures.
+- Validate API/UI after each deploy.
+- If quality drops, rollback by re-deploying last known-good content pack.

--- a/tools/community-curator/README.md
+++ b/tools/community-curator/README.md
@@ -2,6 +2,10 @@
 
 This folder contains scripts to curate and deploy filesystem-based community content for `/comunidad`.
 
+## Related Docs
+- `docs/community-picks-playbook.md` (official process, criteria, schema, prompts).
+- `tools/community-curator/prompts/` (LLM prompt templates for assisted curation).
+
 ## Goal
 - Generate one YAML file per curated item.
 - Keep a local curation history to avoid duplicates in future runs.
@@ -60,6 +64,11 @@ curl "https://homedir.opensourcesantiago.io/api/community/content?view=new&limit
 - `generate_preview_mix.py`
   - creates a deterministic 10-item preview pack for production validation.
   - distribution: `video_story=3`, `podcast=3`, `article_blog=4`.
+
+## Prompt Templates (LLM-assisted)
+- `prompts/system-curator.md`
+- `prompts/user-curation-batch.md`
+- `prompts/user-normalize-item.md`
 
 ## Deploy Command Reference
 ```bash

--- a/tools/community-curator/prompts/README.md
+++ b/tools/community-curator/prompts/README.md
@@ -1,0 +1,16 @@
+# Community Curator Prompts
+
+Prompt templates for LLM-assisted Community Picks curation.
+
+## Files
+
+- `system-curator.md`: system-level operating constraints.
+- `user-curation-batch.md`: batch discovery + ranking prompt.
+- `user-normalize-item.md`: single-item normalization into Homedir YAML schema.
+
+## Usage
+
+1. Start with `system-curator.md`.
+2. Use `user-curation-batch.md` to build a candidate set.
+3. Use `user-normalize-item.md` per selected item.
+4. Save YAML files and validate with the regular curator/deploy flow.

--- a/tools/community-curator/prompts/system-curator.md
+++ b/tools/community-curator/prompts/system-curator.md
@@ -1,0 +1,29 @@
+You are a technical content curator for HomeDir Community Picks.
+
+Mission:
+- Select high-signal content for software practitioners.
+- Prioritize practical value over hype.
+- Produce structured outputs compatible with Homedir filesystem ingest.
+
+Constraints:
+- Focus domains:
+  - AI engineering
+  - Platform Engineering
+  - Cloud Native
+  - Security
+  - Developer Experience
+- Prefer primary/official sources when possible.
+- Avoid duplicates and near-duplicates.
+- Reject low-quality clickbait.
+- Keep summaries short, factual, and actionable.
+- Return valid `http/https` URLs only.
+
+Output expectations:
+- For each accepted item provide:
+  - title
+  - url
+  - summary (1-3 lines)
+  - source
+  - published_at (optional)
+  - media_type (`video_story|podcast|article_blog`)
+  - tags (prefer: `ai-engineering`, `platform-engineering`, `cloud-native`, `security`, `developer-experience`, `trending-tech`)

--- a/tools/community-curator/prompts/user-curation-batch.md
+++ b/tools/community-curator/prompts/user-curation-batch.md
@@ -1,0 +1,41 @@
+Task: generate a candidate batch for HomeDir Community Picks.
+
+Input:
+- Time window: last 14 days preferred.
+- Desired volume: 20 candidates.
+- Desired output mix:
+  - 30% video_story
+  - 30% podcast
+  - 40% article_blog
+
+Selection criteria:
+- Relevance to at least one target domain:
+  - AI engineering
+  - Platform Engineering
+  - Cloud Native
+  - Security
+  - Developer Experience
+- Prefer sources with clear technical depth and practical outcomes.
+- Exclude duplicates by URL and title intent.
+- Exclude paywalled links unless summary value is still clear and source is strong.
+
+Return JSON array with this shape:
+
+```json
+[
+  {
+    "title": "string",
+    "url": "https://...",
+    "summary": "1-3 lines",
+    "source": "domain or source name",
+    "published_at": "ISO-8601 or null",
+    "media_type": "video_story|podcast|article_blog",
+    "tags": ["ai-engineering", "platform-engineering"]
+  }
+]
+```
+
+Additional rules:
+- Keep summary under 320 chars.
+- Keep max 6 tags.
+- Use lowercase kebab-case tags.

--- a/tools/community-curator/prompts/user-normalize-item.md
+++ b/tools/community-curator/prompts/user-normalize-item.md
@@ -1,0 +1,43 @@
+Normalize the following candidate into Homedir Community YAML.
+
+Input object:
+
+```json
+{
+  "title": "...",
+  "url": "...",
+  "summary": "...",
+  "source": "...",
+  "published_at": "...",
+  "media_type": "...",
+  "tags": ["..."]
+}
+```
+
+Rules:
+- Ensure URL is canonical `http/https`.
+- Keep summary concise and factual (<= 320 chars).
+- Keep tags lowercase kebab-case.
+- Keep at most 6 tags.
+- Allowed `media_type`: `video_story`, `podcast`, `article_blog`.
+- Add `created_at` in UTC ISO-8601.
+- Add deterministic id as first 12 chars of SHA-1(url).
+- Optionally include `thumbnail_url` if known and valid.
+
+Return YAML with this exact structure:
+
+```yaml
+id: "<id>"
+title: "<title>"
+url: "<url>"
+summary: "<summary>"
+source: "<source>"
+published_at: "<iso-or-omit>"
+created_at: "<iso-utc>"
+media_type: "<video_story|podcast|article_blog>"
+thumbnail_url: "<optional>"
+tags:
+  - "<tag1>"
+  - "<tag2>"
+author: "<optional>"
+```


### PR DESCRIPTION
Add official documentation for Community Picks process, criteria, file structure, and reusable prompts for LLM-assisted curation.