### PR TITLE
fix(deploy): harden auto-deploy with fallback timer + v-tag normalization

### DIFF
--- a/platform/env.example
+++ b/platform/env.example
@@ -4,6 +4,11 @@
 IMAGE_REPO=quay.io/sergio_canales_e/homedir
 # Optional fallback tag if you run homedir-update.service manually (webhook passes the tag)
 # DEPLOY_TAG=v2.2.19
+# Fallback polling deploy (recommended as backup when webhooks fail)
+AUTO_DEPLOY_ENABLED=true
+AUTO_DEPLOY_TAG_LIMIT=100
+AUTO_DEPLOY_TIMEOUT_SECONDS=15
+AUTO_DEPLOY_LOGFILE=/var/log/homedir-auto-deploy.log
 
 # Container ports
 HOST_PORT=8080

--- a/platform/scripts/homedir-auto-deploy.sh
+++ b/platform/scripts/homedir-auto-deploy.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${ENV_FILE:-/etc/homedir.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+  set +a
+fi
+
+AUTO_DEPLOY_ENABLED="${AUTO_DEPLOY_ENABLED:-true}"
+if [[ "${AUTO_DEPLOY_ENABLED,,}" != "true" ]]; then
+  exit 0
+fi
+
+IMAGE_REPO="${IMAGE_REPO:-quay.io/sergio_canales_e/homedir}"
+UPDATE_SCRIPT="${UPDATE_SCRIPT:-/usr/local/bin/homedir-update.sh}"
+AUTO_LOGFILE="${AUTO_DEPLOY_LOGFILE:-/var/log/homedir-auto-deploy.log}"
+AUTO_DEPLOY_TAG_LIMIT="${AUTO_DEPLOY_TAG_LIMIT:-100}"
+AUTO_DEPLOY_TIMEOUT_SECONDS="${AUTO_DEPLOY_TIMEOUT_SECONDS:-15}"
+
+log() {
+  echo "$(date -Iseconds): $*" >> "$AUTO_LOGFILE"
+}
+
+if [[ ! "$IMAGE_REPO" =~ ^quay\.io/([^/]+)/([^/:]+)$ ]]; then
+  log "invalid IMAGE_REPO format: ${IMAGE_REPO}"
+  exit 1
+fi
+
+repo_namespace="${BASH_REMATCH[1]}"
+repo_name="${BASH_REMATCH[2]}"
+
+latest_tag="$(
+  python3 - "$repo_namespace" "$repo_name" "$AUTO_DEPLOY_TAG_LIMIT" "$AUTO_DEPLOY_TIMEOUT_SECONDS" <<'PY'
+import json
+import re
+import sys
+import urllib.request
+
+namespace, repo, limit_raw, timeout_raw = sys.argv[1:5]
+limit = max(1, min(int(limit_raw), 500))
+timeout = max(5, min(int(timeout_raw), 60))
+
+url = (
+    f"https://quay.io/api/v1/repository/{namespace}/{repo}/tag/"
+    f"?onlyActiveTags=true&limit={limit}&page=1"
+)
+with urllib.request.urlopen(url, timeout=timeout) as resp:
+    payload = json.load(resp)
+
+semver = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+best_key = None
+best_tag = ""
+
+for tag in payload.get("tags", []):
+    name = (tag or {}).get("name", "").strip()
+    if not name or name == "latest":
+        continue
+    match = semver.fullmatch(name)
+    if not match:
+        continue
+    key = tuple(int(part) for part in match.groups())
+    if best_key is None or key > best_key:
+        best_key = key
+        best_tag = name[1:] if name.startswith("v") else name
+
+print(best_tag, end="")
+PY
+)"
+
+if [[ -z "${latest_tag:-}" ]]; then
+  log "no semver tag resolved for repo=${IMAGE_REPO}"
+  exit 1
+fi
+
+current_tag="$(
+  podman ps --filter "name=${CONTAINER_NAME:-homedir}" --format '{{.Image}}' \
+    | sed -n '1s/.*://p'
+)"
+
+if [[ "${current_tag:-}" == "$latest_tag" ]]; then
+  log "up-to-date current_tag=${current_tag}"
+  exit 0
+fi
+
+log "detected new tag current_tag=${current_tag:-none} latest_tag=${latest_tag}"
+if "$UPDATE_SCRIPT" "$latest_tag"; then
+  log "auto-deploy success tag=${latest_tag}"
+  exit 0
+fi
+
+log "auto-deploy failed tag=${latest_tag}"
+exit 1

--- a/platform/scripts/homedir-update.sh
+++ b/platform/scripts/homedir-update.sh
@@ -15,6 +15,10 @@ if [[ -z "$TAG" ]]; then
   echo "usage: homedir-update.sh <tag> (or set DEPLOY_TAG in env)" >&2
   exit 1
 fi
+RAW_TAG="$TAG"
+if [[ "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  TAG="${TAG#v}"
+fi
 
 REPO="${IMAGE_REPO:-quay.io/sergio_canales_e/homedir}"
 IMAGE="${REPO}:${TAG}"
@@ -95,6 +99,9 @@ start_container() {
 }
 
 log "starting update for tag=${TAG}"
+if [[ "$RAW_TAG" != "$TAG" ]]; then
+  log "normalized incoming tag raw=${RAW_TAG} normalized=${TAG}"
+fi
 log "runtime data dir configured as ${HOMEDIR_DATA_DIR} (volume=${DATA_VOLUME})"
 log "runtime limits memory=${CONTAINER_MEMORY_LIMIT:-none} cpus=${CONTAINER_CPU_LIMIT:-none} pids=${CONTAINER_PIDS_LIMIT:-none}"
 prepare_community_storage

--- a/platform/systemd/homedir-auto-deploy.service
+++ b/platform/systemd/homedir-auto-deploy.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Auto-deploy latest HomeDir image tag from Quay
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/homedir.env
+ExecStart=/usr/local/bin/homedir-auto-deploy.sh
+StandardOutput=journal
+StandardError=journal
+User=root

--- a/platform/systemd/homedir-auto-deploy.timer
+++ b/platform/systemd/homedir-auto-deploy.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Periodic fallback for HomeDir auto-deploy from Quay
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- normalize v-prefixed tags (for example v3.361.0) in homedir-update.sh to avoid manifest lookup failures
- add homedir-auto-deploy.sh fallback poller that reads latest semver tag from Quay and triggers deploy when needed
- add homedir-auto-deploy.service + homedir-auto-deploy.timer (5-minute fallback)
- document fallback and new env knobs in platform/README.md and platform/env.example

## Why
Production webhook delivery stopped receiving events intermittently, which leaves deployments stuck on an older image tag.

## Validation
- bash -n platform/scripts/homedir-update.sh
- bash -n platform/scripts/homedir-auto-deploy.sh
- python -m py_compile platform/scripts/homedir-webhook.py
- VPS manual validation:
  - webhook receives POST https://int.opensourcesantiago.io/
  - fallback timer active and logging up-to-date current_tag=...