### PR TITLE
fix(deploy): stabilize fallback auto-deploy checks

### DIFF
--- a/platform/systemd/homedir-auto-deploy.service
+++ b/platform/systemd/homedir-auto-deploy.service
@@ -5,6 +5,7 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
+KillMode=process
 EnvironmentFile=-/etc/homedir.env
 ExecStart=/usr/local/bin/homedir-auto-deploy.sh
 StandardOutput=journal


### PR DESCRIPTION
## Summary
- keep fallback auto-deploy service stable under systemd by setting `KillMode=process`
- avoid unnecessary redeploy loops by comparing Quay manifest digest vs running container digest
- keep existing tag comparison behavior as fallback when digest is unavailable

## Validation
- `bash -n platform/scripts/homedir-auto-deploy.sh`
- manual VPS run: `systemctl start homedir-auto-deploy.service` finishes cleanly and logs `up-to-date digest=...`