### PR TITLE
feat(community-board): coverage metrics and stronger member search

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/community/CommunityBoardSummary.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/community/CommunityBoardSummary.java
@@ -7,6 +7,8 @@ public record CommunityBoardSummary(
     int githubUsers,
     int discordUsers,
     int discordListedUsers,
+    int discordLinkedProfiles,
+    int discordCoveragePercent,
     Integer discordOnlineUsers,
     String discordDataSource,
     Instant discordLastSyncAt) {}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
@@ -2013,8 +2013,17 @@ public interface AppMessages {
     @Message("People who joined our official OSSantiago Discord server.")
     String community_board_group_discord_desc();
 
+    @Message("Guild members: {count}")
+    String community_board_discord_guild_members(int count);
+
     @Message("Listed profiles: {count}")
     String community_board_discord_listed(int count);
+
+    @Message("Linked profiles: {count}")
+    String community_board_discord_linked_profiles(int count);
+
+    @Message("Coverage: {percent}%")
+    String community_board_discord_coverage(int percent);
 
     @Message("Online now: {count}")
     String community_board_discord_online_now(int count);
@@ -2055,7 +2064,7 @@ public interface AppMessages {
     @Message("Showing {from} to {to} of {total}")
     String community_board_pagination_status(int from, int to, int total);
 
-    @Message("Search by name, handle or email")
+    @Message("Search by name, username, handle or email")
     String community_board_search_placeholder();
 
     @Message("Search member")

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityBoardResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityBoardResource.java
@@ -43,6 +43,8 @@ public class CommunityBoardResource {
         int githubUsers,
         int discordUsers,
         int discordListedUsers,
+        int discordLinkedProfiles,
+        int discordCoveragePercent,
         Integer discordOnlineUsers,
         String discordSourceLabel,
         String discordLastSyncLabel);
@@ -78,6 +80,8 @@ public class CommunityBoardResource {
             summary.githubUsers(),
             summary.discordUsers(),
             summary.discordListedUsers(),
+            summary.discordLinkedProfiles(),
+            summary.discordCoveragePercent(),
             summary.discordOnlineUsers(),
             discordSourceLabel(summary.discordDataSource()),
             formatSyncTime(summary.discordLastSyncAt()));

--- a/quarkus-app/src/main/resources/i18n.properties
+++ b/quarkus-app/src/main/resources/i18n.properties
@@ -111,7 +111,11 @@ motivation_speaker=I know the speaker
 motivation_interesting=I found it interesting
 
 # --- Community Board Pagination ---
+community_board_discord_guild_members=Guild members: {count}
+community_board_discord_linked_profiles=Linked profiles: {count}
+community_board_discord_coverage=Coverage: {percent}%
 community_board_pagination_status=Showing {from} to {to} of {total}
+community_board_search_placeholder=Search by name, username, handle or email
 community_board_prev=Previous
 community_board_next=Next
 

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -318,7 +318,10 @@ events_cfp_admin_testing_saved=Guardado.
 events_cfp_admin_testing_error=No fue posible actualizar el modo de prueba en este momento.
 
 # --- Community Board (Discord integration) ---
+community_board_discord_guild_members=Miembros del servidor: {count}
 community_board_discord_listed=Perfiles listados: {count}
+community_board_discord_linked_profiles=Perfiles vinculados: {count}
+community_board_discord_coverage=Cobertura: {percent}%
 community_board_discord_online_now=En linea ahora: {count}
 community_board_discord_source=Fuente de datos: {source}
 community_board_discord_last_sync=Ultima sincronizacion: {timestamp}
@@ -330,6 +333,7 @@ community_board_discord_source_unavailable=No disponible
 community_board_discord_source_misconfigured=Configuracion faltante
 community_board_discord_source_disabled=Integracion deshabilitada
 community_board_pagination_status=Mostrando {from} a {to} de {total}
+community_board_search_placeholder=Busca por nombre, username, handle o email
 community_board_prev=Anterior
 community_board_next=Siguiente
 community_board_claim=Reclamar

--- a/quarkus-app/src/main/resources/templates/CommunityBoardResource/board.html
+++ b/quarkus-app/src/main/resources/templates/CommunityBoardResource/board.html
@@ -34,7 +34,10 @@
           <h2>{discordUsers}</h2>
           <p>{i18n.community_board_group_discord_desc}</p>
           <div class="board-discord-meta">
+            <p>{i18n.community_board_discord_guild_members(discordUsers)}</p>
             <p>{i18n.community_board_discord_listed(discordListedUsers)}</p>
+            <p>{i18n.community_board_discord_linked_profiles(discordLinkedProfiles)}</p>
+            <p>{i18n.community_board_discord_coverage(discordCoveragePercent)}</p>
             {#if discordOnlineUsers != null}
               <p>{i18n.community_board_discord_online_now(discordOnlineUsers)}</p>
             {/if}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
@@ -59,7 +59,10 @@ public class CommunityBoardResourceTest {
         .body(containsString("HomeDir users"))
         .body(containsString("GitHub users"))
         .body(containsString("Discord users"))
-        .body(containsString("Listed profiles: 1"));
+        .body(containsString("Guild members: 1"))
+        .body(containsString("Listed profiles: 1"))
+        .body(containsString("Linked profiles: "))
+        .body(containsString("Coverage: "));
   }
 
   @Test
@@ -294,5 +297,26 @@ public class CommunityBoardResourceTest {
         .body(containsString("Valid Discord User"))
         .body(org.hamcrest.Matchers.not(containsString("Alias Only")))
         .body(org.hamcrest.Matchers.not(containsString("Invalid Id")));
+  }
+
+  @Test
+  void discordBoardSearchMatchesUsernameFieldWhenHandleIsMissing() throws Exception {
+    Path discordFile = Path.of(System.getProperty("homedir.data.dir"), "community", "board", "discord-users.yml");
+    Files.writeString(
+        discordFile,
+        """
+        members:
+          - id: "555555555555555555"
+            display_name: Board Visible Name
+            username: hidden_user_name
+        """);
+    boardService.resetDiscordCacheForTests();
+
+    given()
+        .when()
+        .get("/comunidad/board/discord-users?q=hidden_user_name")
+        .then()
+        .statusCode(200)
+        .body(containsString("Board Visible Name"));
   }
 }


### PR DESCRIPTION
## Summary
- expose Community Board Discord coverage metrics on summary card:
  - `Guild members`
  - `Listed profiles`
  - `Linked profiles`
  - `Coverage %`
- compute coverage from current guild member count vs linked profile links (`/u/*`)
- improve Discord member ingest/search by accepting `username` and `global_name` fields from board file entries
- update board i18n strings (EN/ES)
- add regression tests for:
  - summary rendering of new coverage metrics
  - search by `username` when `handle` is missing

## Validation
- .\\mvnw.cmd -q "-Dtest=CommunityBoardResourceTest,CommunityContentApiResourceTest,CommunityVoteServiceTest" test

## Scope
Point 4 of the agreed product plan: coverage visibility + less confusing member search.