### PR TITLE
test(slo): add public experience smoke guards

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,3 +9,4 @@ Select your language:
 
 - [Persistencia](es/architecture/README.md)
 - [Community Picks Playbook](community-picks-playbook.md)
+- [Experience SLO](development/experience-slo.md)

--- a/docs/development/experience-slo.md
+++ b/docs/development/experience-slo.md
@@ -1,0 +1,49 @@
+# Experience SLO and Regression Guardrails
+
+This document defines lightweight experience SLO targets for the public pages with the highest traffic.
+
+## Goals
+
+- Keep first render stable and predictable for users.
+- Prevent known regressions before merge (missing auth bootstrap, missing CSS, legacy asset references).
+- Keep HTML payload size controlled to reduce visual jank and avoid heavy startup work.
+
+## Current SLO Targets
+
+| Page | HTML budget (bytes) | Availability target |
+| --- | ---: | --- |
+| `/` (Home) | 120,000 | 99.9% |
+| `/comunidad` (Community) | 240,000 | 99.9% |
+| `/comunidad/board/discord-users` | 200,000 | 99.9% |
+
+Notes:
+
+- Budgets are for server-side HTML payload only. Assets are validated separately.
+- These are conservative limits meant to catch accidental bloat, not to optimize for synthetic benchmark scores.
+
+## CI Smoke Coverage
+
+`PublicExperienceSmokeTest` validates:
+
+- Key public pages return `200`.
+- `window.userAuthenticated` bootstrap is present.
+- Legacy broken reference patterns are absent (e.g. `canva-theme-v2.css`).
+- Critical assets return `200` and non-empty payload:
+  - `/css/homedir.css`
+  - `/css/retro-theme.css`
+  - `/js/homedir.js`
+  - `/js/app.js`
+
+## How to run locally
+
+From `quarkus-app/`:
+
+```bash
+./mvnw -Dtest=PublicExperienceSmokeTest test
+```
+
+On Windows PowerShell:
+
+```powershell
+.\mvnw.cmd "-Dtest=PublicExperienceSmokeTest" test
+```

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/PublicExperienceSmokeTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/PublicExperienceSmokeTest.java
@@ -1,0 +1,63 @@
+package com.scanales.eventflow.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class PublicExperienceSmokeTest {
+
+  private static final int HOME_HTML_BUDGET_BYTES = 120_000;
+  private static final int COMMUNITY_HTML_BUDGET_BYTES = 240_000;
+  private static final int COMMUNITY_BOARD_HTML_BUDGET_BYTES = 200_000;
+
+  @Test
+  void homePageAvoidsKnownRuntimeRegressionPatterns() {
+    String html = fetchHtmlWithBudget("/", HOME_HTML_BUDGET_BYTES);
+    assertTrue(html.contains("window.userAuthenticated"));
+    assertFalse(html.contains("canva-theme-v2.css"));
+    assertFalse(html.contains("/js/retro-theme.js"));
+  }
+
+  @Test
+  void communityPageAvoidsKnownRuntimeRegressionPatterns() {
+    String html = fetchHtmlWithBudget("/comunidad", COMMUNITY_HTML_BUDGET_BYTES);
+    assertTrue(html.contains("window.userAuthenticated"));
+    assertFalse(html.contains("canva-theme-v2.css"));
+    assertFalse(html.contains("/js/retro-theme.js"));
+  }
+
+  @Test
+  void discordBoardPageStaysWithinBudgetAndUsesCurrentLayout() {
+    String html =
+        fetchHtmlWithBudget("/comunidad/board/discord-users", COMMUNITY_BOARD_HTML_BUDGET_BYTES);
+    assertTrue(html.contains("window.userAuthenticated"));
+    assertFalse(html.contains("canva-theme-v2.css"));
+  }
+
+  @Test
+  void criticalCssAssetsReturnSuccess() {
+    given().when().get("/css/homedir.css").then().statusCode(200).body(not(isEmptyOrNullString()));
+    given().when().get("/css/retro-theme.css").then().statusCode(200).body(not(isEmptyOrNullString()));
+  }
+
+  @Test
+  void criticalJavascriptAssetsReturnSuccess() {
+    given().when().get("/js/homedir.js").then().statusCode(200).body(not(isEmptyOrNullString()));
+    given().when().get("/js/app.js").then().statusCode(200).body(not(isEmptyOrNullString()));
+  }
+
+  private String fetchHtmlWithBudget(String path, int budgetBytes) {
+    String html =
+        given().accept("text/html").when().get(path).then().statusCode(200).extract().asString();
+    assertTrue(
+        html.length() <= budgetBytes,
+        () -> "HTML payload over budget for " + path + ": " + html.length() + " bytes");
+    return html;
+  }
+}


### PR DESCRIPTION
## Summary
- add a public experience smoke test suite for high-traffic pages and critical assets
- enforce lightweight HTML payload budgets for Home/Community/Community Board in CI
- document experience SLO targets and local validation flow

## Validation
- `./mvnw.cmd -q "-Dtest=PublicExperienceSmokeTest,HomePastEventsTest,CommunityBoardResourceTest" test`
