### PR TITLE
fix(profile): rename public quest counter to activities

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
@@ -1665,6 +1665,15 @@ public interface AppMessages {
     @Message("Class progression")
     String public_profile_class_progress_title();
 
+    @Message("Activities completed")
+    String public_profile_activity_count_title();
+
+    @Message("Signals captured")
+    String public_profile_activity_count_subtitle();
+
+    @Message("No badges earned yet. Keep contributing to unlock more.")
+    String public_profile_badges_empty();
+
     @Message("Share Profile")
     String btn_share_profile();
 

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -80,6 +80,9 @@ public_profile_accounts_discord=Discord
 public_profile_accounts_discord_open=Abrir perfil
 public_profile_accounts_empty=Aún no hay cuentas conectadas.
 public_profile_class_progress_title=Progresión por clase
+public_profile_activity_count_title=Actividades completadas
+public_profile_activity_count_subtitle=Señales capturadas
+public_profile_badges_empty=Aún no tienes insignias. Sigue aportando para desbloquear más.
 
 # --- Global Navigation ---
 nav_home=Inicio

--- a/quarkus-app/src/main/resources/templates/publicProfile.qute.html
+++ b/quarkus-app/src/main/resources/templates/publicProfile.qute.html
@@ -56,11 +56,11 @@
                 </div>
             </div>
 
-            <!-- Card 2: Quests Completed -->
+            <!-- Card 2: Activities Completed -->
             <div class="wrapped-card">
-                <span class="wrapped-stat-label">Quests Completed</span>
+                <span class="wrapped-stat-label">{i18n.public_profile_activity_count_title}</span>
                 <span class="wrapped-stat-value purple">{questsCompleted}</span>
-                <p class="wrapped-subtext">Missions Accomplished</p>
+                <p class="wrapped-subtext">{i18n.public_profile_activity_count_subtitle}</p>
             </div>
 
             <div class="wrapped-card wrapped-card-full">
@@ -107,7 +107,7 @@
                     <span class="wrapped-badge-pill"><span class="material-symbols-outlined"
                             style="font-size: 16px;">verified</span> {badge}</span>
                     {#else}
-                    <span class="wrapped-empty-msg">No badges earned yet. Join quests to unlock!</span>
+                    <span class="wrapped-empty-msg">{i18n.public_profile_badges_empty}</span>
                     {/for}
                 </div>
             </div>

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/PublicProfileResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/PublicProfileResourceTest.java
@@ -71,6 +71,7 @@ public class PublicProfileResourceTest {
         .body(containsString("public_user#1001"))
         .body(containsString("Connected accounts"))
         .body(containsString("Class progression"))
+        .body(containsString("Activities completed"))
         .body(containsString("Scientist"));
   }
 


### PR DESCRIPTION
## Summary
- rename public profile counter from quest wording to activity wording
- update public profile badge empty-state text to remove quest wording
- keep existing functionality unchanged (same counter source, only naming)
- add regression assertion for the new public label

## Validation
- ./mvnw.cmd -q -DskipTests compile
- ./mvnw.cmd -q "-Dtest=PublicProfileResourceTest" test