### PR TITLE
fix(ci): unblock release workflow parsing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,14 @@ jobs:
     permissions:
       contents: write
       packages: write
+    env:
+      DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST != '' && vars.DEPLOY_SSH_HOST || vars.VPS_HOST }}
+      DEPLOY_USER: ${{ vars.DEPLOY_SSH_USER != '' && vars.DEPLOY_SSH_USER || vars.VPS_USER }}
+      DEPLOY_PORT: ${{ vars.DEPLOY_SSH_PORT != '' && vars.DEPLOY_SSH_PORT || vars.VPS_PORT }}
+      DEPLOY_COMMAND: ${{ vars.DEPLOY_SSH_COMMAND }}
+      HEALTHCHECK_URL: ${{ vars.DEPLOY_HEALTHCHECK_URL }}
+      DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY != '' && secrets.DEPLOY_SSH_PRIVATE_KEY || secrets.VPS_SSH_KEY }}
+      DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
 
     steps:
       - name: Checkout code
@@ -77,38 +85,40 @@ jobs:
           docker push $IMAGE_NAME:latest
           docker push $IMAGE_NAME:$TAG
 
+      - name: Resolve deploy configuration
+        id: deploy_config
+        run: |
+          set -euo pipefail
+          enabled="false"
+          if [ -n "${DEPLOY_HOST:-}" ] && [ -n "${DEPLOY_USER:-}" ] && [ -n "${DEPLOY_SSH_PRIVATE_KEY:-}" ]; then
+            enabled="true"
+          fi
+          echo "enabled=${enabled}" >> "$GITHUB_OUTPUT"
+
       - name: Start SSH agent
-        if: ${{ (vars.DEPLOY_SSH_HOST != '' || vars.VPS_HOST != '') && (vars.DEPLOY_SSH_USER != '' || vars.VPS_USER != '') && (secrets.DEPLOY_SSH_PRIVATE_KEY != '' || secrets.VPS_SSH_KEY != '') }}
+        if: ${{ steps.deploy_config.outputs.enabled == 'true' }}
         uses: webfactory/ssh-agent@v0.9.0
         with:
-          ssh-private-key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY != '' && secrets.DEPLOY_SSH_PRIVATE_KEY || secrets.VPS_SSH_KEY }}
+          ssh-private-key: ${{ env.DEPLOY_SSH_PRIVATE_KEY }}
 
       - name: Prepare SSH known_hosts
-        if: ${{ (vars.DEPLOY_SSH_HOST != '' || vars.VPS_HOST != '') && (vars.DEPLOY_SSH_USER != '' || vars.VPS_USER != '') && (secrets.DEPLOY_SSH_PRIVATE_KEY != '' || secrets.VPS_SSH_KEY != '') }}
-        env:
-          DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST != '' && vars.DEPLOY_SSH_HOST || vars.VPS_HOST }}
-          DEPLOY_PORT: ${{ vars.DEPLOY_SSH_PORT != '' && vars.DEPLOY_SSH_PORT || vars.VPS_PORT }}
-          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
+        if: ${{ steps.deploy_config.outputs.enabled == 'true' }}
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           port="${DEPLOY_PORT:-22}"
-          if [ -n "${DEPLOY_KNOWN_HOSTS:-}" ]; then
-            printf '%s\n' "$DEPLOY_KNOWN_HOSTS" >> ~/.ssh/known_hosts
+          if [ -n "${DEPLOY_SSH_KNOWN_HOSTS:-}" ]; then
+            printf '%s\n' "$DEPLOY_SSH_KNOWN_HOSTS" >> ~/.ssh/known_hosts
           else
             ssh-keyscan -p "$port" "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
           fi
           chmod 644 ~/.ssh/known_hosts
 
       - name: Deploy to VPS via SSH
-        if: ${{ (vars.DEPLOY_SSH_HOST != '' || vars.VPS_HOST != '') && (vars.DEPLOY_SSH_USER != '' || vars.VPS_USER != '') && (secrets.DEPLOY_SSH_PRIVATE_KEY != '' || secrets.VPS_SSH_KEY != '') }}
+        if: ${{ steps.deploy_config.outputs.enabled == 'true' }}
         env:
-          DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST != '' && vars.DEPLOY_SSH_HOST || vars.VPS_HOST }}
-          DEPLOY_USER: ${{ vars.DEPLOY_SSH_USER != '' && vars.DEPLOY_SSH_USER || vars.VPS_USER }}
-          DEPLOY_PORT: ${{ vars.DEPLOY_SSH_PORT != '' && vars.DEPLOY_SSH_PORT || vars.VPS_PORT }}
           RELEASE_TAG: v${{ steps.tag_version.outputs.new_version }}
-          DEPLOY_COMMAND: ${{ vars.DEPLOY_SSH_COMMAND }}
         run: |
           set -euo pipefail
           port="${DEPLOY_PORT:-22}"
@@ -116,9 +126,7 @@ jobs:
           ssh -p "$port" "${DEPLOY_USER}@${DEPLOY_HOST}" "DEPLOY_TRIGGER=github-actions ${cmd} ${RELEASE_TAG}"
 
       - name: Verify production healthcheck
-        if: ${{ (vars.DEPLOY_SSH_HOST != '' || vars.VPS_HOST != '') && (vars.DEPLOY_SSH_USER != '' || vars.VPS_USER != '') && (secrets.DEPLOY_SSH_PRIVATE_KEY != '' || secrets.VPS_SSH_KEY != '') }}
-        env:
-          HEALTHCHECK_URL: ${{ vars.DEPLOY_HEALTHCHECK_URL }}
+        if: ${{ steps.deploy_config.outputs.enabled == 'true' }}
         run: |
           set -euo pipefail
           url="${HEALTHCHECK_URL:-https://homedir.opensourcesantiago.io/q/health}"
@@ -133,6 +141,6 @@ jobs:
           exit 1
 
       - name: Deploy fallback notice
-        if: ${{ !((vars.DEPLOY_SSH_HOST != '' || vars.VPS_HOST != '') && (vars.DEPLOY_SSH_USER != '' || vars.VPS_USER != '') && (secrets.DEPLOY_SSH_PRIVATE_KEY != '' || secrets.VPS_SSH_KEY != '')) }}
+        if: ${{ steps.deploy_config.outputs.enabled != 'true' }}
         run: |
           echo "SSH deploy is not configured. Deployment will rely on homedir-auto-deploy.timer fallback on the VPS."


### PR DESCRIPTION
## Summary\n- remove secrets.* usage from step if expressions in elease.yml\n- resolve deploy config in a dedicated step and gate deploy steps with that output\n- keep the same deploy behavior (SSH immediate deploy + fallback timer)\n\n## Why\nRelease runs on main were failing at startup (0s, no jobs) due invalid workflow expression constraints. This unblocks production releases.\n\n## Validation\n- workflow file updated with supported expression usage\n- previous failing run pattern addressed (jobs=[], 0s failure)