### PR TITLE
fix(profile): show XP progress fill and public URL actions

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/retro-theme.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/retro-theme.css
@@ -2451,7 +2451,7 @@
       position: absolute;
       top: 0;
       right: 0;
-      background: var(--primary-color);
+      background: var(--primary-color, var(--color-accent, #ffd700));
       color: white;
       padding: 0.2rem 0.8rem;
       border-bottom-left-radius: 8px;
@@ -3289,7 +3289,7 @@
     .hd-class-option.selected {
       opacity: 1;
       filter: none;
-      border-color: var(--primary-color) !important;
+      border-color: var(--primary-color, var(--color-accent, #ffd700)) !important;
       background: rgba(255, 255, 255, 0.1);
       transform: scale(1.02);
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
@@ -3309,7 +3309,10 @@
     }
 
     .progress-bar-fill {
-      background: var(--primary-color);
+      background: linear-gradient(90deg,
+          var(--primary-color, var(--color-accent, #ffd700)),
+          #ffef99);
+      box-shadow: 0 0 8px rgba(255, 215, 0, 0.35);
       height: 100%;
       width: var(--xp-percent, 0%);
     }

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -123,9 +123,13 @@
                     <h2 class="hd-panel-title">{i18n.resume_level(questProfile.level)}</h2>
                     <p class="hd-page-intro">{i18n.resume_exp(questProfile.currentXp, questProfile.nextLevelXp)}</p>
                 </div>
-                {#if githubLinked}
+                {#if publicProfileHandle??}
                 <div class="hd-panel-actions">
-                    <button class="hd-btn hd-btn-secondary" onclick="shareProfile('{github.login}')">
+                    <a class="hd-btn hd-btn-secondary" href="/u/{publicProfileHandle}" target="_blank"
+                        rel="noopener noreferrer">
+                        <span class="material-symbols-outlined">open_in_new</span> {i18n.btn_view_profile}
+                    </a>
+                    <button class="hd-btn hd-btn-secondary" onclick="shareProfile('{publicProfileHandle}')">
                         <span class="material-symbols-outlined">share</span> {i18n.btn_share_profile}
                     </button>
                 </div>
@@ -136,8 +140,7 @@
             <!-- Progress Bar -->
             <!-- Progress Bar -->
             <div class="progress-bar-container">
-                <div class="progress-bar-fill js-progress-fill"
-                    data-progress="{(questProfile.currentXp / questProfile.nextLevelXp) * 100}">
+                <div class="progress-bar-fill js-progress-fill" data-progress="{questProgressPercent}">
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary\n- fix private profile progress bar rendering by using backend-computed percentage and robust color fallback\n- avoid transparent fill when --primary-color is undefined by adding fallback to accent color\n- always show public profile actions in /private/profile (open public profile + share link), even without linked GitHub\n\n## Validation\n- ./mvnw -q -DskipTests compile\n\n## User-visible outcome\n- XP/class bars in /private/profile show proportional colored fill again\n- Public profile URL is now directly accessible from private profile