### PR TITLE
fix(profile): keep class progress visible for all identities

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/retro-theme.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/retro-theme.css
@@ -3275,24 +3275,23 @@
 
     /* Profile Page Styles */
     .hd-class-option {
-      opacity: 0.5;
-      filter: grayscale(100%);
-      transition: all 0.3s ease;
+      opacity: 1;
+      filter: none;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      background: rgba(255, 255, 255, 0.03);
+      transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
     }
 
     .hd-class-option:hover {
-      opacity: 0.9;
-      filter: grayscale(20%);
-      background: rgba(255, 255, 255, 0.05);
+      border-color: rgba(255, 215, 0, 0.42);
+      background: rgba(255, 255, 255, 0.06);
+      transform: translateY(-1px);
     }
 
     .hd-class-option.selected {
-      opacity: 1;
-      filter: none;
       border-color: var(--primary-color, var(--color-accent, #ffd700)) !important;
-      background: rgba(255, 255, 255, 0.1);
-      transform: scale(1.02);
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+      background: rgba(255, 215, 0, 0.09);
+      box-shadow: 0 0 0 1px rgba(255, 215, 0, 0.25), 0 8px 16px rgba(0, 0, 0, 0.2);
     }
 
     .hd-panel-actions-margin {


### PR DESCRIPTION
## Summary
- remove global opacity/grayscale attenuation from class cards in profile
- keep class highlighting by border/background/shadow for the dominant class
- preserve visible progress bars for all classes regardless of primary selection

## Validation
- mvn -q "-Dtest=ProfileResourceTest" test