### PR TITLE
feat(economy): progressive stock access with guardrails

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EconomyApiResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EconomyApiResource.java
@@ -34,8 +34,13 @@ public class EconomyApiResource {
   @GET
   @Path("/catalog")
   public Response catalog() {
+    Optional<String> userId = currentUserId();
+    if (userId.isPresent()) {
+      List<EconomyService.CatalogOffer> items = economyService.listCatalogForUser(userId.get());
+      return Response.ok(Map.of("items", items, "count", items.size(), "personalized", true)).build();
+    }
     List<EconomyCatalogItem> items = economyService.listCatalog();
-    return Response.ok(Map.of("items", items, "count", items.size())).build();
+    return Response.ok(Map.of("items", items, "count", items.size(), "personalized", false)).build();
   }
 
   @GET

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -227,3 +227,4 @@ economy.guard.strict=true
 economy.guard.alert-cooldown=PT15M
 economy.rewards.xp-to-hcoin-ratio=0.2
 economy.rewards.min-hcoin=1
+economy.purchase.max-per-minute=12

--- a/quarkus-app/src/test/java/com/scanales/eventflow/economy/EconomyApiResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/economy/EconomyApiResourceTest.java
@@ -51,6 +51,15 @@ public class EconomyApiResourceTest {
     economyService.rewardFromGamification("user@example.com", "seed", 1000, "seed");
 
     given()
+        .accept("application/json")
+        .when()
+        .get("/api/economy/catalog")
+        .then()
+        .statusCode(200)
+        .body("personalized", equalTo(true))
+        .body("items[0].effective_max_per_user", greaterThan(0));
+
+    given()
         .contentType("application/json")
         .body("{\"itemId\":\"profile-glow\"}")
         .when()

--- a/quarkus-app/src/test/java/com/scanales/eventflow/economy/EconomyServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/economy/EconomyServiceTest.java
@@ -80,4 +80,22 @@ public class EconomyServiceTest {
         () -> economyService.rewardFromGamification(userId, "limit_blocked", 10, "seed_blocked"));
     assertTrue(awarded > 0);
   }
+
+  @Test
+  void progressionGatesHighTierCatalogAndUnlocksAfterAdvancing() {
+    String userId = "progression@example.com";
+    economyService.rewardFromGamification(userId, "bootstrap", 3000, "seed");
+
+    List<EconomyService.CatalogOffer> initial = economyService.listCatalogForUser(userId);
+    EconomyService.CatalogOffer architect =
+        initial.stream().filter(item -> "architect-badge".equals(item.id())).findFirst().orElseThrow();
+
+    assertFalse(architect.unlocked());
+    assertTrue(
+        "requires_level".equals(architect.lockReason())
+            || "requires_total_xp".equals(architect.lockReason())
+            || "requires_class_xp".equals(architect.lockReason()));
+
+    assertThrows(EconomyService.ValidationException.class, () -> economyService.purchase(userId, "architect-badge"));
+  }
 }


### PR DESCRIPTION
## Iteration 1 - Progressive stock (backend) + guardrails

### What changed
- Added progression-aware economy catalog for authenticated users (`/api/economy/catalog` personalized response).
- Added unlock gates by progression for each item (level, total XP, class XP).
- Added proportional stock per user (`effective_max_per_user`) based on level and achievement bands.
- Added purchase burst guardrail (`economy.purchase.max-per-minute`) to protect backend under spikes.
- Kept public catalog backward compatible for anonymous traffic.

### Guardrails
- Existing storage/memory guardrails remain active.
- New purchase burst guardrail blocks abusive purchase loops before persistence pressure.

### Validation
- mvn -q "-Dtest=EconomyServiceTest,EconomyApiResourceTest,ProfileResourceTest" test