### PR TITLE
feat(profile): hybrid class identity when momentum is close

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
@@ -273,6 +273,9 @@ public interface AppMessages {
     @Message("Most active class: {className}")
     String profile_dominant_class(String className);
 
+    @Message("Most active profile: Hybrid ({primaryClass} + {secondaryClass})")
+    String profile_dominant_class_hybrid(String primaryClass, String secondaryClass);
+
     @Message("{xp} XP · Level {level} · {percent}% of your profile momentum")
     String profile_class_xp_level(int xp, int level, int percent);
 

--- a/quarkus-app/src/main/resources/i18n.properties
+++ b/quarkus-app/src/main/resources/i18n.properties
@@ -80,6 +80,7 @@ economy_catalog_status_label=Status
 resume_level=Level {level}
 resume_exp=Experience: {current} XP / {total} XP
 profile_dominant_class=Most active class: {className}
+profile_dominant_class_hybrid=Most active profile: Hybrid ({primaryClass} + {secondaryClass})
 profile_class_xp_level={xp} XP · Level {level} · {percent}% of your profile momentum
 profile_activity_map_title=Activity to class map
 profile_activity_map_intro=Your actions distribute XP across classes. Focus where you want to grow.

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -87,6 +87,7 @@ economy_catalog_status_label=Estado
 resume_level=Nivel {level}
 resume_exp=Experiencia: {current} XP / {total} XP
 profile_dominant_class=Clase con más actividad: {className}
+profile_dominant_class_hybrid=Perfil más activo: Híbrido ({primaryClass} + {secondaryClass})
 profile_class_xp_level={xp} XP · Nivel {level} · {percent}% del impulso de tu perfil
 profile_activity_map_title=Mapa actividad → clase
 profile_activity_map_intro=Tus acciones distribuyen XP entre clases. Enfócate donde quieras crecer.

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -213,8 +213,8 @@
                     <p class="hd-page-intro">{i18n.identity_intro}</p>
                 </div>
             </div>
-            {#if dominantClass}
-            <p class="hd-page-intro">{i18n.profile_dominant_class(dominantClass.displayName)}</p>
+            {#if dominantClassMessage??}
+            <p class="hd-page-intro">{dominantClassMessage}</p>
             {/if}
             <div class="hd-grid-classes hd-grid-classes-layout">
                 {#for cls in classProgress}

--- a/quarkus-app/src/main/resources/templates/publicProfile.qute.html
+++ b/quarkus-app/src/main/resources/templates/publicProfile.qute.html
@@ -39,7 +39,9 @@
 
             <div class="wrapped-card wrapped-card-full">
                 <span class="wrapped-stat-label">{i18n.public_profile_class_progress_title}</span>
-                <p class="wrapped-subtext">{i18n.profile_dominant_class(questClass)}</p>
+                <p class="wrapped-subtext">
+                    {#if dominantClassMessage??}{dominantClassMessage}{#else}{i18n.profile_dominant_class(questClass)}{/if}
+                </p>
                 <div class="wrapped-class-grid">
                     {#for cls in classProgress}
                     <div class="wrapped-class-item">

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
@@ -322,6 +322,27 @@ public class ProfileResourceTest {
         .body(containsString("Showing up to 100 recent entries for safety."));
   }
 
+  @Test
+  public void profileShowsHybridClassWhenTopMomentumIsClose() {
+    String userId = currentUserEmail();
+    UserProfile profile = userProfiles.upsert(userId, userId, userId);
+    java.util.EnumMap<QuestClass, Integer> classXp = new java.util.EnumMap<>(QuestClass.class);
+    classXp.put(QuestClass.SCIENTIST, 15);
+    classXp.put(QuestClass.MAGE, 14);
+    classXp.put(QuestClass.ENGINEER, 5);
+    classXp.put(QuestClass.WARRIOR, 0);
+    profile.setClassXp(classXp);
+    profile.setCurrentXp(34);
+    userProfiles.update(profile);
+
+    given()
+        .when()
+        .get("/private/profile")
+        .then()
+        .statusCode(200)
+        .body(containsString("Most active profile: Hybrid (Scientist + Mage)"));
+  }
+
   private String currentUserEmail() {
     Object emailAttr = securityIdentity.getAttribute("email");
     if (emailAttr != null && !emailAttr.toString().isBlank()) {


### PR DESCRIPTION
## Iteration 1 (low risk)
- add hybrid class messaging when top 2 class momentum values are very close
- keep existing look and feel; only text logic changed in profile identity blocks
- apply the same identity message in private and public profile
- add i18n keys for EN/ES
- add regression test for hybrid class rendering in profile

## Why
This reduces misleading class labels when user momentum is almost tied between two classes, improving trust in class progression signals without changing APIs.

## Validation
- mvn -f quarkus-app/pom.xml ""-Dtest=ProfileResourceTest,PublicProfileResourceTest"" test
