### PR TITLE
feat(community-board): improve search matching and show discord coverage in detail

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityBoardResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityBoardResource.java
@@ -61,6 +61,10 @@ public class CommunityBoardResource {
         String groupPath,
         String groupTitle,
         String groupDescription,
+        int discordGuildMembers,
+        int discordListedUsers,
+        int discordLinkedProfiles,
+        int discordCoveragePercent,
         String searchQuery,
         int total,
         int limit,
@@ -125,6 +129,7 @@ public class CommunityBoardResource {
     boolean hasNextPage = pageEnd < slice.total();
     int previousOffset = Math.max(0, slice.offset() - slice.limit());
     int nextOffset = slice.offset() + slice.limit();
+    var summary = boardService.summary();
     String previousPageUrl =
         hasPreviousPage ? detailUrl(group.path(), normalizedQuery, slice.limit(), previousOffset) : null;
     String nextPageUrl =
@@ -135,6 +140,10 @@ public class CommunityBoardResource {
             group.path(),
             titleFor(group),
             descriptionFor(group),
+            summary.discordUsers(),
+            summary.discordListedUsers(),
+            summary.discordLinkedProfiles(),
+            summary.discordCoveragePercent(),
             normalizedQuery,
             slice.total(),
             slice.limit(),

--- a/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
@@ -48,6 +48,14 @@
           <p class="section-subtitle">{i18n.community_board_pagination_status(pageStart, pageEnd, total)}</p>
         {/if}
       </div>
+      {#if groupPath == 'discord-users'}
+        <div class="board-detail-metrics" aria-label="Discord coverage metrics">
+          <span class="board-detail-metric">{i18n.community_board_discord_guild_members(discordGuildMembers)}</span>
+          <span class="board-detail-metric">{i18n.community_board_discord_listed(discordListedUsers)}</span>
+          <span class="board-detail-metric">{i18n.community_board_discord_linked_profiles(discordLinkedProfiles)}</span>
+          <span class="board-detail-metric">{i18n.community_board_discord_coverage(discordCoveragePercent)}</span>
+        </div>
+      {/if}
 
       <form class="search-form board-search-form" method="get" action="/comunidad/board/{groupPath}">
         <input
@@ -182,6 +190,22 @@
       gap: 0.75rem;
       margin-bottom: 1rem;
       flex-wrap: wrap;
+    }
+
+    .board-detail-metrics {
+      display: flex;
+      gap: 0.45rem;
+      flex-wrap: wrap;
+      margin: 0 0 1rem 0;
+    }
+
+    .board-detail-metric {
+      border: 1px solid rgba(255, 255, 255, 0.3);
+      border-radius: 999px;
+      padding: 0.25rem 0.55rem;
+      font-size: 0.78rem;
+      opacity: 0.92;
+      background: rgba(0, 0, 0, 0.28);
     }
 
     .board-search-input {

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityBoardResourceTest.java
@@ -319,4 +319,14 @@ public class CommunityBoardResourceTest {
         .statusCode(200)
         .body(containsString("Board Visible Name"));
   }
+
+  @Test
+  void discordBoardSearchMatchesHandleEvenWhenQueryUsesDifferentSeparators() {
+    given()
+        .when()
+        .get("/comunidad/board/discord-users?q=discorduser1001")
+        .then()
+        .statusCode(200)
+        .body(containsString("Discord User"));
+  }
 }


### PR DESCRIPTION
## Summary
- improve Community Board member search so queries match even when separators differ (`_`, `#`, `@`, spaces)
- keep existing search behavior and add normalized fallback matching for display name, handle, and id
- expose Discord coverage metrics in `/comunidad/board/discord-users` detail view:
  - guild members
  - listed profiles
  - linked profiles
  - coverage %
- add regression test for normalized search (`discorduser1001` matches `discord_user#1001`)

## Why
This advances the next iteration focused on making Community Board clearer and more useful:
- users can find members more reliably
- Discord board detail now shows coverage context where users are searching

## Validation
- `cd quarkus-app && .\\mvnw.cmd -q "-Dtest=CommunityBoardResourceTest,PublicExperienceSmokeTest" test`
