### PR TITLE
feat(home): add New/Hot comic showcase with lightweight SVG panels

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
@@ -1946,6 +1946,48 @@ public interface AppMessages {
     @Message("Community Highlights")
     String home_highlights_intro();
 
+    @Message("New / Hot")
+    String home_new_hot_badge();
+
+    @Message("What you can do right now")
+    String home_new_hot_title();
+
+    @Message("Curated content from the internet")
+    String home_new_hot_card_curated_title();
+
+    @Message("Discover hand-picked technology, open source, AI, and platform engineering signals.")
+    String home_new_hot_card_curated_desc();
+
+    @Message("Comic panel about curated community content")
+    String home_new_hot_card_curated_alt();
+
+    @Message("Hosted events in HomeDir")
+    String home_new_hot_card_events_title();
+
+    @Message("Track upcoming events, formats, and activity highlights from a single timeline.")
+    String home_new_hot_card_events_desc();
+
+    @Message("Comic panel about hosted events")
+    String home_new_hot_card_events_alt();
+
+    @Message("CFP + personalized agendas")
+    String home_new_hot_card_cfp_title();
+
+    @Message("Submit talks, follow moderation status, and build your own agenda flow.")
+    String home_new_hot_card_cfp_desc();
+
+    @Message("Comic panel about CFP and personalized agendas")
+    String home_new_hot_card_cfp_alt();
+
+    @Message("Connect accounts, level up, and earn HCoin")
+    String home_new_hot_card_level_title();
+
+    @Message("Link GitHub and Discord, grow class momentum, and use HCoin to improve your profile.")
+    String home_new_hot_card_level_desc();
+
+    @Message("Comic panel about leveling and HCoin rewards")
+    String home_new_hot_card_level_alt();
+
     @Message("updates available")
     String home_metric_updates();
 

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -2183,6 +2183,83 @@ footer {
   opacity: 0.96;
 }
 
+.home-new-hot {
+  margin-top: 0.22rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.home-new-hot-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.home-new-hot-badge {
+  border-color: rgba(255, 179, 0, 0.75);
+  color: #fff3ce;
+  background: rgba(255, 153, 0, 0.18);
+}
+
+.home-new-hot-title {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.9px;
+  text-transform: uppercase;
+}
+
+.home-new-hot-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+
+.home-new-hot-card {
+  text-decoration: none;
+  color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: rgba(0, 0, 0, 0.3);
+  padding: 0.38rem;
+  gap: 0.4rem;
+  min-height: 0;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+
+.home-new-hot-card:hover {
+  border-color: #ffd700;
+  transform: none;
+  box-shadow: inset 0 0 0 1px rgba(255, 215, 0, 0.16);
+}
+
+.home-new-hot-card img {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(0, 0, 0, 0.26);
+}
+
+.home-new-hot-copy {
+  display: grid;
+  gap: 0.22rem;
+}
+
+.home-new-hot-copy h3 {
+  margin: 0;
+  font-size: 0.74rem;
+  line-height: 1.25;
+}
+
+.home-new-hot-copy p {
+  margin: 0;
+  font-size: 0.67rem;
+  line-height: 1.3;
+  opacity: 0.9;
+}
+
 .home-top-metrics {
   display: grid;
   width: 100%;
@@ -2768,6 +2845,10 @@ footer {
     gap: 0.75rem;
   }
 
+  .home-new-hot-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .home-panorama-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -2792,6 +2873,10 @@ footer {
   }
 
   .home-top-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .home-new-hot-grid {
     grid-template-columns: 1fr;
   }
 

--- a/quarkus-app/src/main/resources/META-INF/resources/img/home-new-hot-cfp.svg
+++ b/quarkus-app/src/main/resources/META-INF/resources/img/home-new-hot-cfp.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" fill="none">
+  <defs>
+    <pattern id="dots-c" width="16" height="16" patternUnits="userSpaceOnUse">
+      <circle cx="3" cy="3" r="1.8" fill="#2b0f19"/>
+    </pattern>
+  </defs>
+  <rect width="640" height="360" fill="#120810"/>
+  <rect x="10" y="10" width="620" height="340" rx="12" fill="#3c1528" stroke="#f5f5f5" stroke-width="4"/>
+  <rect x="18" y="18" width="604" height="324" rx="8" fill="url(#dots-c)" opacity="0.38"/>
+  <rect x="42" y="42" width="280" height="276" rx="16" fill="#24121e" stroke="#f5f5f5" stroke-width="4"/>
+  <rect x="64" y="64" width="236" height="34" rx="10" fill="#ff7bb8"/>
+  <rect x="64" y="110" width="236" height="14" rx="7" fill="#ffe5f2"/>
+  <rect x="64" y="132" width="206" height="12" rx="6" fill="#ffe5f2" opacity="0.9"/>
+  <rect x="64" y="162" width="236" height="78" rx="10" fill="#11090f" stroke="#f5f5f5" stroke-width="3"/>
+  <rect x="80" y="178" width="204" height="10" rx="5" fill="#ff7bb8"/>
+  <rect x="80" y="196" width="176" height="10" rx="5" fill="#ffd2e8"/>
+  <rect x="80" y="214" width="152" height="10" rx="5" fill="#ffd2e8"/>
+  <rect x="64" y="252" width="112" height="36" rx="8" fill="#ff7bb8"/>
+  <rect x="188" y="252" width="112" height="36" rx="8" fill="#ffd2e8"/>
+  <rect x="340" y="56" width="258" height="106" rx="14" fill="#ff7bb8" stroke="#111111" stroke-width="4"/>
+  <path d="M372 130l26-20 18 12 30-28 34 34" stroke="#111111" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="340" y="180" width="258" height="136" rx="14" fill="#11090f" stroke="#f5f5f5" stroke-width="4"/>
+  <circle cx="388" cy="224" r="24" fill="#ff7bb8"/>
+  <circle cx="470" cy="224" r="24" fill="#ffcf6b"/>
+  <circle cx="552" cy="224" r="24" fill="#79d0ff"/>
+  <rect x="360" y="268" width="220" height="12" rx="6" fill="#ffe5f2"/>
+  <rect x="360" y="288" width="184" height="10" rx="5" fill="#ffe5f2" opacity="0.9"/>
+</svg>

--- a/quarkus-app/src/main/resources/META-INF/resources/img/home-new-hot-curated.svg
+++ b/quarkus-app/src/main/resources/META-INF/resources/img/home-new-hot-curated.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" fill="none">
+  <defs>
+    <pattern id="dots-a" width="18" height="18" patternUnits="userSpaceOnUse">
+      <circle cx="3" cy="3" r="2" fill="#13212f"/>
+    </pattern>
+  </defs>
+  <rect width="640" height="360" fill="#0a0f16"/>
+  <rect x="10" y="10" width="620" height="340" rx="12" fill="#142235" stroke="#f5f5f5" stroke-width="4"/>
+  <rect x="18" y="18" width="604" height="324" rx="8" fill="url(#dots-a)" opacity="0.35"/>
+  <rect x="44" y="44" width="270" height="184" rx="16" fill="#1f3550" stroke="#f5f5f5" stroke-width="4"/>
+  <rect x="336" y="58" width="258" height="102" rx="14" fill="#ffe071" stroke="#111111" stroke-width="4"/>
+  <rect x="350" y="72" width="230" height="18" rx="9" fill="#111111"/>
+  <rect x="350" y="100" width="210" height="14" rx="7" fill="#111111"/>
+  <rect x="350" y="124" width="190" height="14" rx="7" fill="#111111"/>
+  <circle cx="179" cy="136" r="58" fill="#5bb0ff" stroke="#111111" stroke-width="4"/>
+  <path d="M153 133c16 0 30 13 30 30M153 133c0-16 13-30 30-30M153 133h24" stroke="#111111" stroke-width="7" stroke-linecap="round"/>
+  <circle cx="179" cy="136" r="9" fill="#111111"/>
+  <rect x="336" y="184" width="258" height="132" rx="14" fill="#0e1d2e" stroke="#f5f5f5" stroke-width="4"/>
+  <rect x="350" y="200" width="94" height="20" rx="10" fill="#5bb0ff"/>
+  <rect x="350" y="230" width="198" height="14" rx="7" fill="#e8f2ff"/>
+  <rect x="350" y="254" width="166" height="14" rx="7" fill="#e8f2ff" opacity="0.9"/>
+  <rect x="350" y="278" width="120" height="14" rx="7" fill="#e8f2ff" opacity="0.8"/>
+</svg>

--- a/quarkus-app/src/main/resources/META-INF/resources/img/home-new-hot-events.svg
+++ b/quarkus-app/src/main/resources/META-INF/resources/img/home-new-hot-events.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" fill="none">
+  <defs>
+    <pattern id="dots-b" width="20" height="20" patternUnits="userSpaceOnUse">
+      <circle cx="4" cy="4" r="2" fill="#251c0a"/>
+    </pattern>
+  </defs>
+  <rect width="640" height="360" fill="#110e08"/>
+  <rect x="10" y="10" width="620" height="340" rx="12" fill="#2e2514" stroke="#f5f5f5" stroke-width="4"/>
+  <rect x="18" y="18" width="604" height="324" rx="8" fill="url(#dots-b)" opacity="0.36"/>
+  <rect x="42" y="44" width="262" height="272" rx="16" fill="#3d2d16" stroke="#f5f5f5" stroke-width="4"/>
+  <rect x="62" y="64" width="222" height="30" rx="8" fill="#ffcf6b"/>
+  <rect x="62" y="106" width="222" height="190" rx="12" fill="#17110a" stroke="#f5f5f5" stroke-width="3"/>
+  <rect x="78" y="126" width="72" height="54" rx="8" fill="#ffcf6b"/>
+  <rect x="160" y="126" width="56" height="14" rx="7" fill="#ffeed0"/>
+  <rect x="160" y="146" width="48" height="12" rx="6" fill="#ffeed0" opacity="0.9"/>
+  <rect x="160" y="164" width="40" height="12" rx="6" fill="#ffeed0" opacity="0.8"/>
+  <rect x="78" y="192" width="72" height="54" rx="8" fill="#ffcf6b"/>
+  <rect x="160" y="192" width="56" height="14" rx="7" fill="#ffeed0"/>
+  <rect x="160" y="212" width="48" height="12" rx="6" fill="#ffeed0" opacity="0.9"/>
+  <rect x="160" y="230" width="40" height="12" rx="6" fill="#ffeed0" opacity="0.8"/>
+  <rect x="326" y="58" width="272" height="118" rx="16" fill="#ffcf6b" stroke="#111111" stroke-width="4"/>
+  <circle cx="364" cy="116" r="28" fill="#111111"/>
+  <rect x="404" y="92" width="174" height="16" rx="8" fill="#111111"/>
+  <rect x="404" y="118" width="152" height="14" rx="7" fill="#111111"/>
+  <rect x="404" y="142" width="124" height="14" rx="7" fill="#111111"/>
+  <rect x="326" y="190" width="272" height="126" rx="16" fill="#111111" stroke="#f5f5f5" stroke-width="4"/>
+  <path d="M356 280l38-32 28 20 40-36 44 42" stroke="#6cc5ff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="356" cy="280" r="8" fill="#6cc5ff"/>
+  <circle cx="394" cy="248" r="8" fill="#6cc5ff"/>
+  <circle cx="422" cy="268" r="8" fill="#6cc5ff"/>
+  <circle cx="462" cy="232" r="8" fill="#6cc5ff"/>
+  <circle cx="506" cy="274" r="8" fill="#6cc5ff"/>
+</svg>

--- a/quarkus-app/src/main/resources/META-INF/resources/img/home-new-hot-level.svg
+++ b/quarkus-app/src/main/resources/META-INF/resources/img/home-new-hot-level.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" fill="none">
+  <defs>
+    <pattern id="dots-d" width="18" height="18" patternUnits="userSpaceOnUse">
+      <circle cx="3" cy="3" r="2" fill="#102017"/>
+    </pattern>
+  </defs>
+  <rect width="640" height="360" fill="#070f0b"/>
+  <rect x="10" y="10" width="620" height="340" rx="12" fill="#163224" stroke="#f5f5f5" stroke-width="4"/>
+  <rect x="18" y="18" width="604" height="324" rx="8" fill="url(#dots-d)" opacity="0.35"/>
+  <rect x="42" y="44" width="266" height="272" rx="16" fill="#112218" stroke="#f5f5f5" stroke-width="4"/>
+  <circle cx="174" cy="122" r="56" fill="#79d0ff" stroke="#111111" stroke-width="4"/>
+  <circle cx="174" cy="122" r="14" fill="#111111"/>
+  <rect x="86" y="194" width="176" height="22" rx="11" fill="#5de290"/>
+  <rect x="86" y="228" width="176" height="16" rx="8" fill="#d8ffe7"/>
+  <rect x="86" y="254" width="148" height="14" rx="7" fill="#d8ffe7" opacity="0.9"/>
+  <rect x="330" y="56" width="270" height="112" rx="14" fill="#5de290" stroke="#111111" stroke-width="4"/>
+  <circle cx="372" cy="112" r="24" fill="#111111"/>
+  <rect x="408" y="90" width="168" height="14" rx="7" fill="#111111"/>
+  <rect x="408" y="114" width="148" height="14" rx="7" fill="#111111"/>
+  <rect x="408" y="138" width="120" height="14" rx="7" fill="#111111"/>
+  <rect x="330" y="184" width="270" height="132" rx="14" fill="#0e1912" stroke="#f5f5f5" stroke-width="4"/>
+  <rect x="354" y="206" width="70" height="70" rx="10" fill="#ffd164" stroke="#111111" stroke-width="4"/>
+  <circle cx="389" cy="241" r="22" fill="#111111"/>
+  <rect x="446" y="212" width="132" height="14" rx="7" fill="#d8ffe7"/>
+  <rect x="446" y="236" width="120" height="12" rx="6" fill="#d8ffe7" opacity="0.9"/>
+  <rect x="446" y="258" width="98" height="12" rx="6" fill="#d8ffe7" opacity="0.8"/>
+</svg>

--- a/quarkus-app/src/main/resources/i18n.properties
+++ b/quarkus-app/src/main/resources/i18n.properties
@@ -153,6 +153,20 @@ nav_signed_in_as=Signed in as
 home_hero_title=COMMUNITY PLATFORM TO SCALE YOUR OPEN SOURCE PROJECTS.
 home_hero_start=Get Started
 home_hero_learn_more=Learn More
+home_new_hot_badge=New / Hot
+home_new_hot_title=What you can do right now
+home_new_hot_card_curated_title=Curated content from the internet
+home_new_hot_card_curated_desc=Discover hand-picked technology, open source, AI, and platform engineering signals.
+home_new_hot_card_curated_alt=Comic panel about curated community content
+home_new_hot_card_events_title=Hosted events in HomeDir
+home_new_hot_card_events_desc=Track upcoming events, formats, and activity highlights from a single timeline.
+home_new_hot_card_events_alt=Comic panel about hosted events
+home_new_hot_card_cfp_title=CFP + personalized agendas
+home_new_hot_card_cfp_desc=Submit talks, follow moderation status, and build your own agenda flow.
+home_new_hot_card_cfp_alt=Comic panel about CFP and personalized agendas
+home_new_hot_card_level_title=Connect accounts, level up, and earn HCoin
+home_new_hot_card_level_desc=Link GitHub and Discord, grow class momentum, and use HCoin to improve your profile.
+home_new_hot_card_level_alt=Comic panel about leveling and HCoin rewards
 
 # --- Quest Board ---
 quest_board_title=Quest Board

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -230,6 +230,20 @@ events_cfp_not_found_desc=No encontramos este evento.
 home_hero_title=PLATAFORMA COMUNITARIA PARA ESCALAR TUS PROYECTOS OPEN SOURCE.
 home_hero_start=Comenzar
 home_hero_learn_more=Saber más
+home_new_hot_badge=Nuevo / Hot
+home_new_hot_title=Lo que puedes hacer ahora mismo
+home_new_hot_card_curated_title=Contenido seleccionado de la red
+home_new_hot_card_curated_desc=Descubre señales curadas de tecnología, open source, IA y platform engineering.
+home_new_hot_card_curated_alt=Viñeta comic sobre contenido curado de comunidad
+home_new_hot_card_events_title=Eventos hosteados en HomeDir
+home_new_hot_card_events_desc=Revisa próximos eventos, formatos y actividad destacada desde una sola línea de tiempo.
+home_new_hot_card_events_alt=Viñeta comic sobre eventos hosteados
+home_new_hot_card_cfp_title=CFP y agendas personalizadas
+home_new_hot_card_cfp_desc=Postula charlas, sigue moderación y arma tu propio flujo de agenda.
+home_new_hot_card_cfp_alt=Viñeta comic sobre CFP y agendas personalizadas
+home_new_hot_card_level_title=Conecta cuentas, sube de nivel y gana HCoin
+home_new_hot_card_level_desc=Vincula GitHub y Discord, aumenta momentum de clase y usa HCoin para mejorar tu perfil.
+home_new_hot_card_level_alt=Viñeta comic sobre progreso de nivel y recompensas HCoin
 
 # --- Quest Board ---
 quest_board_title=Tablero de Misiones

--- a/quarkus-app/src/main/resources/templates/home.qute.html
+++ b/quarkus-app/src/main/resources/templates/home.qute.html
@@ -6,6 +6,42 @@
   <h1 class="home-welcome-en">{i18n.home_welcome_en}</h1>
   <p class="home-welcome-es">{i18n.home_welcome_es}</p>
   <p class="home-highlights-intro">{i18n.home_highlights_intro}</p>
+  <section class="home-new-hot" aria-label="{i18n.home_new_hot_title}">
+    <div class="home-new-hot-header">
+      <span class="home-chip home-new-hot-badge">{i18n.home_new_hot_badge}</span>
+      <h2 class="home-new-hot-title">{i18n.home_new_hot_title}</h2>
+    </div>
+    <div class="home-new-hot-grid">
+      <a href="/comunidad?view=featured" class="home-new-hot-card">
+        <img src="/img/home-new-hot-curated.svg" alt="{i18n.home_new_hot_card_curated_alt}" loading="lazy" width="320" height="180">
+        <div class="home-new-hot-copy">
+          <h3>{i18n.home_new_hot_card_curated_title}</h3>
+          <p>{i18n.home_new_hot_card_curated_desc}</p>
+        </div>
+      </a>
+      <a href="/eventos" class="home-new-hot-card">
+        <img src="/img/home-new-hot-events.svg" alt="{i18n.home_new_hot_card_events_alt}" loading="lazy" width="320" height="180">
+        <div class="home-new-hot-copy">
+          <h3>{i18n.home_new_hot_card_events_title}</h3>
+          <p>{i18n.home_new_hot_card_events_desc}</p>
+        </div>
+      </a>
+      <a href="/eventos" class="home-new-hot-card">
+        <img src="/img/home-new-hot-cfp.svg" alt="{i18n.home_new_hot_card_cfp_alt}" loading="lazy" width="320" height="180">
+        <div class="home-new-hot-copy">
+          <h3>{i18n.home_new_hot_card_cfp_title}</h3>
+          <p>{i18n.home_new_hot_card_cfp_desc}</p>
+        </div>
+      </a>
+      <a href="/private/profile/catalog" class="home-new-hot-card">
+        <img src="/img/home-new-hot-level.svg" alt="{i18n.home_new_hot_card_level_alt}" loading="lazy" width="320" height="180">
+        <div class="home-new-hot-copy">
+          <h3>{i18n.home_new_hot_card_level_title}</h3>
+          <p>{i18n.home_new_hot_card_level_desc}</p>
+        </div>
+      </a>
+    </div>
+  </section>
   <div class="home-top-metrics">
     <a href="#home-social" class="home-top-metric">
       <span class="home-top-metric-head">

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeTimelineTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeTimelineTest.java
@@ -19,6 +19,7 @@ public class HomeTimelineTest {
         .statusCode(200)
         .body(containsString("HomeDir"))
         .body(containsString("Welcome"))
+        .body(containsString("New / Hot"))
         .body(containsString("Highlights"))
         .body(containsString("Latest community content"))
         .body(containsString("Upcoming agenda"));


### PR DESCRIPTION
## Summary
- add a new `New / Hot` showcase section at the top of Home
- introduce 4 comic/manga style lightweight SVG panels (local static assets, no extra API calls)
- each panel links to a key user journey:
  - curated community content
  - hosted events
  - CFP + personalized agendas
  - account linking, leveling and HCoin profile progress
- add i18n keys (EN/ES) and message bundle wiring for all new texts
- add a regression assertion in `HomeTimelineTest` for the new section

## Notes
- kept look & feel aligned with current Home style (same card language, chips, borders)
- kept performance-safe approach (static SVGs, lazy loading, no runtime animation loops)

## Validation
- `cd quarkus-app && .\\mvnw.cmd -q "-Dtest=HomeTimelineTest,HomePastEventsTest,PublicExperienceSmokeTest" test`
