### PR TITLE
fix(home): center New/Hot card images

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -2483,6 +2483,8 @@ footer {
 .home-new-hot-card img {
   width: 50%;
   max-width: 160px;
+  display: block;
+  margin: 0 auto;
   aspect-ratio: 16 / 9;
   object-fit: cover;
   border: 1px solid rgba(255, 255, 255, 0.2);


### PR DESCRIPTION
## Summary
- center New/Hot card images in Home to improve visual alignment and consistency
- keep compact image size from current layout while centering horizontally

## Validation
- cd quarkus-app && ./mvnw.cmd -q -DskipTests compile