### PR TITLE
feat: split community LTA tab and normalize section headers

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/AppMessages.java
@@ -1401,6 +1401,9 @@ public interface AppMessages {
     @Message("Community Picks")
     String community_submenu_picks();
 
+    @Message("Lightning Threads Arena")
+    String community_submenu_lta();
+
     @Message("Propose Content")
     String community_submenu_propose();
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/CommunityResource.java
@@ -50,6 +50,16 @@ public class CommunityResource {
   }
 
   @GET
+  @Path("/lta")
+  @PermitAll
+  @Produces(MediaType.TEXT_HTML)
+  public TemplateInstance lta(
+      @jakarta.ws.rs.core.Context jakarta.ws.rs.core.HttpHeaders headers,
+      @jakarta.ws.rs.core.Context io.vertx.ext.web.RoutingContext context) {
+    return render("featured", "all", CommunityContentMedia.ALL, "lta", headers, context);
+  }
+
+  @GET
   @Path("/moderation")
   @PermitAll
   @Produces(MediaType.TEXT_HTML)
@@ -83,7 +93,7 @@ public class CommunityResource {
     String initialFilter = normalizeFilter(filterParam);
     String initialMedia = CommunityContentMedia.normalizeFilter(mediaParam);
     String activeSubmenu =
-        forcedSubmenu != null && !forcedSubmenu.isBlank() ? forcedSubmenu : "picks";
+        forcedSubmenu != null && !forcedSubmenu.isBlank() ? forcedSubmenu : "lta";
     metrics.recordPageView("/comunidad/" + activeSubmenu, headers, context);
     currentUserId().ifPresent(
         userId -> {
@@ -124,8 +134,11 @@ public class CommunityResource {
   @GET
   @Path("/picks")
   @PermitAll
-  public Response picks() {
-    return Response.seeOther(URI.create("/comunidad?view=featured")).build();
+  @Produces(MediaType.TEXT_HTML)
+  public TemplateInstance picks(
+      @jakarta.ws.rs.core.Context jakarta.ws.rs.core.HttpHeaders headers,
+      @jakarta.ws.rs.core.Context io.vertx.ext.web.RoutingContext context) {
+    return render("featured", "all", CommunityContentMedia.ALL, "picks", headers, context);
   }
 
   private String normalizeFilter(String filterParam) {

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -500,6 +500,25 @@ footer {
   gap: 0.5rem;
 }
 
+.section-header.hd-section-heading {
+  padding-bottom: 0.2rem;
+}
+
+.section-header.hd-section-heading::after {
+  content: "";
+  display: block;
+  width: min(280px, 72%);
+  height: 1px;
+  margin-top: 0.28rem;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 215, 0, 0.55),
+    rgba(255, 255, 255, 0.32),
+    rgba(255, 255, 255, 0)
+  );
+  opacity: 0.85;
+}
+
 .section-header h1 {
   font-family: var(--font-display);
   font-size: 1.5rem;
@@ -2689,6 +2708,15 @@ footer {
 .home-pane-header .section-subtitle {
   font-size: 0.7rem;
   margin: 0;
+}
+
+.home-pane-section-header {
+  gap: 0.25rem;
+}
+
+.home-pane-section-header.hd-section-heading::after {
+  width: min(140px, 78%);
+  margin-top: 0.18rem;
 }
 
 .home-pane-header .page-title {

--- a/quarkus-app/src/main/resources/messages.properties
+++ b/quarkus-app/src/main/resources/messages.properties
@@ -456,6 +456,7 @@ community_board_group_github_desc=Contributors with a linked GitHub account in t
 community_board_group_discord=Discord users
 community_board_group_discord_desc=People who joined our official OSSantiago Discord server.
 community_board_view_members=View members
+community_submenu_lta=Lightning Threads Arena
 community_board_members_count={0} members
 community_board_search_placeholder=Search by name, handle or email
 community_board_search_aria=Search member

--- a/quarkus-app/src/main/resources/messages_es.properties
+++ b/quarkus-app/src/main/resources/messages_es.properties
@@ -396,6 +396,7 @@ community_board_search_aria=Search member
 community_board_search_placeholder=Search by name, handle or email
 community_board_subtitle=Community · Board
 community_board_view_members=View members
+community_submenu_lta=Lightning Threads Arena
 community_submenu_aria_label=Submenú de comunidad
 events_detail_agenda_by_scenario=By Scenario
 events_detail_agenda_sequential=Sequential

--- a/quarkus-app/src/main/resources/templates/CommunityBoardResource/board.html
+++ b/quarkus-app/src/main/resources/templates/CommunityBoardResource/board.html
@@ -2,7 +2,7 @@
 {#title}{i18n.community_board_page_title}{/title}
 {#body}
   <header class="page-header events-page-header">
-    <div class="section-header">
+    <div class="section-header hd-section-heading">
       <p class="section-subtitle">{i18n.community_board_subtitle}</p>
       <h1>{i18n.community_board_heading}</h1>
     </div>

--- a/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/CommunityBoardResource/detail.html
@@ -12,7 +12,7 @@
 {/title}
 {#body}
   <header class="page-header events-page-header">
-    <div class="section-header">
+    <div class="section-header hd-section-heading">
       <p class="section-subtitle">{i18n.community_board_subtitle}</p>
       <h1>
         {#if groupPath == 'homedir-users'}

--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -9,7 +9,7 @@
 {#title}{i18n.community_page_title}{/title}
 {#body}
   <header class="page-header events-page-header">
-    <div class="section-header">
+    <div class="section-header hd-section-heading">
       <p class="section-subtitle">{i18n.community_page_eyebrow}</p>
       <h1>{i18n.community_page_heading}</h1>
     </div>
@@ -18,8 +18,12 @@
   {#include fragments/community-submenu.html /}
 
   <section class="page-grid">
-    {#if activeCommunitySubmenu == 'picks'}
+    {#if activeCommunitySubmenu == 'lta'}
     <div class="section-card events-full-width community-shell-card">
+      <div class="section-header community-section-header hd-section-heading">
+        <p class="section-subtitle">{i18n.community_page_eyebrow}</p>
+        <h2 class="page-title">{i18n.home_lightning_title_aka}</h2>
+      </div>
       <section id="community-lta" class="home-lightning-strip community-lta-shell" aria-label="{i18n.home_lightning_title}">
         <div class="home-lightning-header">
           <span class="home-chip">{i18n.home_lightning_badge}</span>
@@ -67,6 +71,10 @@
           </div>
         </div>
       </section>
+    </div>
+    {/if}
+    {#if activeCommunitySubmenu == 'picks'}
+    <div class="section-card events-full-width community-shell-card">
       <div id="community-content-root" data-authenticated="{isAuthenticated}" data-page-size="10" data-cache-ttl-ms="60000" data-ultra-lite="true" data-initial-view="{initialView}" data-initial-filter="{initialFilter ?: 'all'}" data-initial-media="{initialMedia ?: 'all'}"
         data-i18n-empty-filtered="{i18n.community_js_empty_filtered}"
         data-i18n-empty-generic="{i18n.community_js_empty_generic}"
@@ -107,6 +115,10 @@
         data-i18n-cta-vote-progress="{i18n.community_js_cta_vote_progress}"
         data-i18n-cta-vote-ready="{i18n.community_js_cta_vote_ready}"
         data-i18n-empty-no-votes="{i18n.community_js_empty_no_votes}">
+        <div class="section-header community-section-header hd-section-heading">
+          <p class="section-subtitle">{i18n.community_page_eyebrow}</p>
+          <h2 class="page-title">{i18n.community_submenu_picks}</h2>
+        </div>
         <div id="community-feedback" class="community-feedback hidden" role="alert"></div>
 
         {#if isAuthenticated}
@@ -260,7 +272,7 @@
       data-i18n-error-invalid-data-prefix="{i18n.community_submissions_error_invalid_data_prefix}"
       data-i18n-error-submit="{i18n.community_submissions_error_submit}"
       data-i18n-feedback-submitted="{i18n.community_submissions_feedback_submitted}">
-      <div class="section-header">
+      <div class="section-header hd-section-heading">
         <p class="section-subtitle">{i18n.community_propose_eyebrow}</p>
         <h2 class="page-title">{i18n.community_propose_title}</h2>
       </div>
@@ -338,7 +350,7 @@
       data-i18n-error-invalid-data-prefix="{i18n.community_submissions_error_invalid_data_prefix}"
       data-i18n-error-submit="{i18n.community_submissions_error_submit}"
       data-i18n-feedback-submitted="{i18n.community_submissions_feedback_submitted}">
-      <div class="section-header">
+      <div class="section-header hd-section-heading">
         <p class="section-subtitle">{i18n.community_moderation_eyebrow}</p>
         <h2 class="page-title">{i18n.community_moderation_title}</h2>
       </div>
@@ -409,6 +421,17 @@
     cursor: default;
     background: rgba(0, 0, 0, 0.45);
     box-shadow: 0 6px 0 rgba(0, 0, 0, 0.6);
+  }
+
+  .community-section-header {
+    margin-bottom: 0.7rem;
+    gap: 0.24rem;
+  }
+
+  .community-section-header .page-title {
+    margin: 0;
+    font-size: 1.1rem;
+    letter-spacing: 1px;
   }
 
   .community-shell-card *,

--- a/quarkus-app/src/main/resources/templates/EventsDirectoryResource/eventos.html
+++ b/quarkus-app/src/main/resources/templates/EventsDirectoryResource/eventos.html
@@ -4,7 +4,7 @@
 
 
 <header class="page-header events-page-header">
-  <div class="section-header">
+  <div class="section-header hd-section-heading">
     <p class="section-subtitle">{i18n.events_subtitle}</p>
     <h1>{i18n.events_hero_title}</h1>
   </div>
@@ -30,7 +30,7 @@
 </header>
 
 <section class="page-grid">
-  <div class="section-header events-full-width">
+  <div class="section-header events-full-width hd-section-heading">
     <p class="section-subtitle">{i18n.events_section_upcoming_subtitle}</p>
     <h2 class="page-title">{i18n.events_section_upcoming_title}</h2>
   </div>
@@ -150,7 +150,7 @@
 </section>
 
 <section class="page-grid">
-  <div class="section-header events-full-width events-section-margin">
+  <div class="section-header events-full-width events-section-margin hd-section-heading">
     <p class="section-subtitle">{i18n.events_section_past_subtitle}</p>
     <h2 class="page-title">{i18n.events_section_past_title}</h2>
   </div>

--- a/quarkus-app/src/main/resources/templates/events.qute.html
+++ b/quarkus-app/src/main/resources/templates/events.qute.html
@@ -5,7 +5,7 @@
 
 
 <header class="page-header events-page-header">
-  <div class="section-header">
+  <div class="section-header hd-section-heading">
     <p class="section-subtitle">{i18n.events_subtitle}</p>
     <h1>{i18n.events_hero_title}</h1>
   </div>
@@ -32,7 +32,7 @@
 </header>
 
 <section class="page-grid">
-  <div class="section-header events-full-width">
+  <div class="section-header events-full-width hd-section-heading">
     <p class="section-subtitle">{i18n.events_section_upcoming_subtitle}</p>
     <h2 class="page-title">{i18n.events_section_upcoming_title}</h2>
   </div>
@@ -61,7 +61,7 @@
 </section>
 
 <section class="page-grid">
-  <div class="section-header events-full-width events-section-margin">
+  <div class="section-header events-full-width events-section-margin hd-section-heading">
     <p class="section-subtitle">{i18n.events_section_past_subtitle}</p>
     <h2 class="page-title">{i18n.events_section_past_title}</h2>
   </div>

--- a/quarkus-app/src/main/resources/templates/fragments/community-submenu.html
+++ b/quarkus-app/src/main/resources/templates/fragments/community-submenu.html
@@ -1,6 +1,10 @@
 {@ String activeCommunitySubmenu = "main"}
 {@ boolean isAdmin = false}
 <nav class="community-submenu" aria-label="{i18n.community_submenu_aria_label}">
+  <a href="/comunidad/lta" class="btn-primary community-submenu-link {#if activeCommunitySubmenu == 'lta'}community-submenu-link-active{/if}">
+    <span class="material-symbols-outlined community-submenu-icon" aria-hidden="true">bolt</span>
+    <span class="community-submenu-label">{i18n.community_submenu_lta}</span>
+  </a>
   <a href="/comunidad/picks" class="btn-primary community-submenu-link {#if activeCommunitySubmenu == 'picks'}community-submenu-link-active{/if}">
     <span class="material-symbols-outlined community-submenu-icon" aria-hidden="true">auto_awesome</span>
     <span class="community-submenu-label">{i18n.community_submenu_picks}</span>

--- a/quarkus-app/src/main/resources/templates/home.qute.html
+++ b/quarkus-app/src/main/resources/templates/home.qute.html
@@ -2,8 +2,10 @@
 {#title}{i18n.nav_home}{/title}
 {#body}
 <header class="public-header home-highlight-hero">
-  <p class="eyebrow">{i18n.home_welcome_title}</p>
-  <h1 class="home-welcome-en">{i18n.home_welcome_en}</h1>
+  <div class="section-header hd-section-heading">
+    <p class="section-subtitle">{i18n.home_welcome_title}</p>
+    <h1 class="home-welcome-en">{i18n.home_welcome_en}</h1>
+  </div>
   <p class="home-welcome-es">{i18n.home_welcome_es}</p>
   <p class="home-highlights-intro">{i18n.home_highlights_intro}</p>
   <section class="home-new-hot" aria-label="{i18n.home_new_hot_title}">
@@ -93,8 +95,9 @@
         <span class="home-pane-identity home-pane-identity-social" aria-hidden="true">
           <span class="material-symbols-outlined">article</span>
         </span>
-        <div>
-        <h2 class="page-title">{i18n.home_social_highlights_title}</h2>
+        <div class="section-header home-pane-section-header hd-section-heading">
+          <p class="section-subtitle">{i18n.home_social_highlights_eyebrow}</p>
+          <h2 class="page-title">{i18n.home_social_highlights_title}</h2>
         </div>
       </div>
       <a href="/comunidad" class="btn-primary">{i18n.home_btn_open_social}</a>
@@ -131,8 +134,9 @@
           <span class="material-symbols-outlined" aria-hidden="true">event</span>
           {/if}
         </span>
-        <div>
-        <h2 class="page-title">{i18n.home_events_highlights_title}</h2>
+        <div class="section-header home-pane-section-header hd-section-heading">
+          <p class="section-subtitle">{i18n.home_events_highlights_eyebrow}</p>
+          <h2 class="page-title">{i18n.home_events_highlights_title}</h2>
         </div>
       </div>
       <a href="/eventos" class="btn-primary">{i18n.home_btn_open_events}</a>
@@ -175,8 +179,9 @@
         <span class="home-pane-identity home-pane-identity-project" aria-hidden="true">
           <span class="material-symbols-outlined">groups</span>
         </span>
-        <div>
-        <h2 class="page-title">{i18n.home_project_highlights_title}</h2>
+        <div class="section-header home-pane-section-header hd-section-heading">
+          <p class="section-subtitle">{i18n.home_project_highlights_eyebrow}</p>
+          <h2 class="page-title">{i18n.home_project_highlights_title}</h2>
         </div>
       </div>
       <a href="/proyectos" class="btn-primary">{i18n.home_btn_open_project}</a>


### PR DESCRIPTION
## Summary
- split `Lightning Threads Arena` into its own Community submenu entry and make it the default Community landing view
- keep `Community Picks` as an explicit independent submenu view
- align title/subtitle/separator structure in `Home`, `Community`, and `Events` with the same section-header pattern used in `Project`
- add missing i18n wiring for `community_submenu_lta`

## Validation
- `cd quarkus-app && ./mvnw.cmd -DskipTests compile`
