### PR TITLE
fix(i18n): apply selected locale fallback beyond home

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/util/TemplateLocaleUtil.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/util/TemplateLocaleUtil.java
@@ -16,12 +16,7 @@ public final class TemplateLocaleUtil {
   private TemplateLocaleUtil() {}
 
   public static TemplateInstance apply(TemplateInstance templateInstance, String localeCode) {
-    String normalized = normalize(localeCode);
-    Locale locale = Locale.forLanguageTag(normalized);
-    return templateInstance
-        .setLocale(locale)
-        .data("resolvedLocaleCode", normalized)
-        .data("locale", locale);
+    return apply(templateInstance, localeCode, resolveCurrentHeaders());
   }
 
   public static TemplateInstance apply(
@@ -95,6 +90,14 @@ public final class TemplateLocaleUtil {
       return userProfiles.find(userId.toLowerCase(Locale.ROOT))
           .map(com.scanales.eventflow.model.UserProfile::getPreferredLocale)
           .orElse(null);
+    } catch (Exception ignored) {
+      return null;
+    }
+  }
+
+  private static HttpHeaders resolveCurrentHeaders() {
+    try {
+      return Arc.container().instance(HttpHeaders.class).get();
     } catch (Exception ignored) {
       return null;
     }

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeTimelineTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeTimelineTest.java
@@ -57,4 +57,17 @@ public class HomeTimelineTest {
         .body(containsString("<html lang=\"es\">"))
         .body(containsString(">Inicio</a>"));
   }
+
+  @Test
+  public void eventsDirectoryRespectsAcceptLanguage() {
+    given()
+        .header("Accept-Language", "es")
+        .accept("text/html")
+        .when()
+        .get("/eventos")
+        .then()
+        .statusCode(200)
+        .body(containsString("<html lang=\"es\">"))
+        .body(containsString(">Inicio</a>"));
+  }
 }


### PR DESCRIPTION
## Summary\n- update TemplateLocaleUtil.apply(template, localeCookie) to also fallback to profile locale and current request Accept-Language\n- add regression test to ensure /eventos renders Spanish locale/nav when browser language is s\n\n## Validation\n- mvn -Dtest=HomeTimelineTest test\n\n## Context\nFollow-up to #423 to cover pages that still defaulted to n without cookie.