### PR TITLE
fix(auth): preserve current page after login across site

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -65,6 +65,28 @@ const $ = (key) => document.querySelector(SELECTORS[key]);
 const $$ = (key) => document.querySelectorAll(SELECTORS[key]);
 const isUltraLiteMode = () => document.body && document.body.classList.contains('ultra-lite-mode');
 
+function currentRelativeUrl() {
+    const path = window.location.pathname || '/';
+    const query = window.location.search || '';
+    const hash = window.location.hash || '';
+    return `${path}${query}${hash}`;
+}
+
+function buildLoginCallbackUrl(redirectTarget) {
+    const fallback = '/';
+    const rawTarget = typeof redirectTarget === 'string' ? redirectTarget.trim() : '';
+    const target = rawTarget || currentRelativeUrl() || fallback;
+    return `/private/login-callback?redirect=${encodeURIComponent(target)}`;
+}
+
+function setupLoginReturnLinks() {
+    const links = document.querySelectorAll('a[data-login-return-current="true"]');
+    links.forEach((link) => {
+        const preferred = (link.getAttribute('data-login-redirect') || '').trim();
+        link.setAttribute('href', buildLoginCallbackUrl(preferred || currentRelativeUrl()));
+    });
+}
+
 function adjustLayout() {
     const toggle = $('menuToggle');
     const links = $('primaryNav');
@@ -309,6 +331,7 @@ function restoreScroll() {
 }
 
 function onDomContentLoaded() {
+    setupLoginReturnLinks();
     setupMenu();
     setupUserMenu();
     setupUserMenuActiveState();
@@ -378,6 +401,7 @@ function removeListeners() {
 }
 
 if (typeof window !== 'undefined') {
+    window.buildLoginCallbackUrl = buildLoginCallbackUrl;
     window.initListeners = initListeners;
     window.removeListeners = removeListeners;
     initListeners();

--- a/quarkus-app/src/main/resources/META-INF/resources/js/community-content.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/community-content.js
@@ -1134,7 +1134,12 @@
 
   async function sendVote(itemId, vote) {
     if (!authenticated) {
-      window.location.href = "/private/profile";
+      const redirectTarget = `${window.location.pathname || "/"}${window.location.search || ""}${window.location.hash || ""}`;
+      if (typeof window.buildLoginCallbackUrl === "function") {
+        window.location.href = window.buildLoginCallbackUrl(redirectTarget);
+      } else {
+        window.location.href = `/private/login-callback?redirect=${encodeURIComponent(redirectTarget)}`;
+      }
       return;
     }
     const item = state.items.find((entry) => String(entry.id) === String(itemId));

--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -61,7 +61,7 @@
           </form>
           <div id="home-lightning-login" class="home-lightning-login {#if isAuthenticated}hidden{/if}">
             <p>{i18n:home_lightning_login_required}</p>
-            <a href="/private/profile" class="btn-primary">{i18n:home_lightning_login_cta}</a>
+            <a href="/private/login-callback?redirect=/comunidad/lta" class="btn-primary" data-login-return-current="true">{i18n:home_lightning_login_cta}</a>
           </div>
           <div id="home-lightning-feedback" class="home-lightning-feedback hidden" role="status"></div>
           <div id="home-lightning-list" class="home-lightning-list"></div>
@@ -315,7 +315,7 @@
       {#else}
       <div class="community-empty">
         <p>{i18n:community_login_to_propose}</p>
-        <a class="btn-primary" href="/private/profile">{i18n:community_login}</a>
+        <a class="btn-primary" href="/private/login-callback?redirect=/comunidad/propose" data-login-return-current="true">{i18n:community_login}</a>
       </div>
       {/if}
     </div>

--- a/quarkus-app/src/main/resources/templates/EventResource/cfp.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/cfp.html
@@ -118,7 +118,7 @@
     <p id="cfpFeedback" class="form-hint" hidden></p>
     {#else}
     <p class="section-subtitle">{i18n:events_cfp_login_required}</p>
-    <a href="/private/login-callback?redirect=/event/{event.id}/cfp" class="btn-primary">{i18n:events_cfp_login_btn}</a>
+    <a href="/private/login-callback?redirect=/event/{event.id}/cfp" class="btn-primary" data-login-return-current="true">{i18n:events_cfp_login_btn}</a>
     {/if}
   </article>
 

--- a/quarkus-app/src/main/resources/templates/PublicResource/publicPage.html
+++ b/quarkus-app/src/main/resources/templates/PublicResource/publicPage.html
@@ -4,7 +4,7 @@
 <div class="content-box">
     <h1>{i18n:public_title}</h1>
     <p>{i18n:public_description}</p>
-    <p><a href="/private" class="btn btn-primary">{i18n:btn_login_google}</a></p>
+    <p><a href="/private/login-callback?redirect=/" class="btn btn-primary" data-login-return-current="true">{i18n:btn_login_google}</a></p>
 </div>
 {/body}
 {/include}

--- a/quarkus-app/src/main/resources/templates/fragments/header.html
+++ b/quarkus-app/src/main/resources/templates/fragments/header.html
@@ -109,7 +109,14 @@
       </div>
     </div>
     {#else}
-    <a href="{#if isDev}/login.html{#else}/private/profile{/if}" class="login-btn-nav">{i18n:nav_login}</a>
+    {#if isDev}
+    <a href="/login.html" class="login-btn-nav">{i18n:nav_login}</a>
+    {#else}
+    <a
+      href="/private/login-callback?redirect={#if activePage == 'comunidad'}/comunidad{#else if activePage == 'eventos'}/eventos{#else if activePage == 'proyectos'}/proyectos{#else if activePage == 'notifications'}/notifications/center{#else}/{/if}"
+      class="login-btn-nav"
+      data-login-return-current="true">{i18n:nav_login}</a>
+    {/if}
     {/if}
   </div>
 </nav>

--- a/quarkus-app/src/main/resources/templates/fragments/login-modal.html
+++ b/quarkus-app/src/main/resources/templates/fragments/login-modal.html
@@ -6,7 +6,8 @@
         <h2>{i18n:login_modal_title}</h2>
         <p class="subtitle">{i18n:login_modal_subtitle}</p>
         <div class="login-buttons">
-            <a href="/private/profile" class="login-btn btn-login-flex" id="googleLogin">
+            <a href="/private/login-callback?redirect=/" class="login-btn btn-login-flex" id="googleLogin"
+                data-login-return-current="true">
                 <svg viewbox="0 0 24 24" fill="currentColor">
                     <path
                         d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
@@ -23,7 +24,8 @@
                 </svg>
                 {i18n:login_modal_google}
             </a>
-            <a href="/private/profile" class="login-btn btn-login-flex" id="githubLogin">
+            <a href="/private/login-callback?redirect=/" class="login-btn btn-login-flex" id="githubLogin"
+                data-login-return-current="true">
                 <svg viewbox="0 0 24 24" fill="currentColor" class="icon-margin-right">
                     <path
                         d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />

--- a/quarkus-app/src/main/resources/templates/publicProfile.qute.html
+++ b/quarkus-app/src/main/resources/templates/publicProfile.qute.html
@@ -144,7 +144,7 @@
         <div class="wrapped-cta">
             <h2>{i18n:public_profile_cta_title}</h2>
             <p>{i18n:public_profile_cta_desc}</p>
-            <a href="/private/profile" class="wrapped-btn-primary">
+            <a href="/private/login-callback?redirect=/" class="wrapped-btn-primary" data-login-return-current="true">
                 {i18n:public_profile_cta_btn}
             </a>
         </div>

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/PublicExperienceSmokeTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/PublicExperienceSmokeTest.java
@@ -20,6 +20,7 @@ public class PublicExperienceSmokeTest {
   void homePageAvoidsKnownRuntimeRegressionPatterns() {
     String html = fetchHtmlWithBudget("/", HOME_HTML_BUDGET_BYTES);
     assertTrue(html.contains("window.userAuthenticated"));
+    assertTrue(html.contains("data-login-return-current=\"true\""));
     assertFalse(html.contains("canva-theme-v2.css"));
     assertFalse(html.contains("/js/retro-theme.js"));
   }
@@ -28,6 +29,7 @@ public class PublicExperienceSmokeTest {
   void communityPageAvoidsKnownRuntimeRegressionPatterns() {
     String html = fetchHtmlWithBudget("/comunidad", COMMUNITY_HTML_BUDGET_BYTES);
     assertTrue(html.contains("window.userAuthenticated"));
+    assertTrue(html.contains("data-login-return-current=\"true\""));
     assertFalse(html.contains("canva-theme-v2.css"));
     assertFalse(html.contains("/js/retro-theme.js"));
   }


### PR DESCRIPTION
## Summary
- make login CTAs return users to their current page instead of forcing `/private/profile`
- add a global login URL helper in `app.js` and auto-wire links marked with `data-login-return-current="true"`
- apply this to header login, login modal, community login prompts, CFP login prompt, public profile CTA and legacy public page login
- keep safe fallback hrefs server-side, while runtime refines redirect with path/query/hash
- add smoke assertions to avoid regressions in markup wiring

## Validation
- `mvn -f quarkus-app/pom.xml "-Dtest=PublicExperienceSmokeTest,EventCfpPageTest" test`