### PR TITLE
fix(community): show LTA modified badge only after user edit

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/community/CommunityLightningStateSnapshot.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/community/CommunityLightningStateSnapshot.java
@@ -1,6 +1,7 @@
 package com.scanales.eventflow.community;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -11,6 +12,8 @@ public record CommunityLightningStateSnapshot(
     Map<String, CommunityLightningComment> comments,
     Map<String, String> threadLikesByUser,
     Map<String, String> commentLikesByUser,
+    Map<String, Instant> threadEditedAtById,
+    Map<String, Instant> commentEditedAtById,
     Map<String, CommunityLightningReport> reports,
     Map<String, String> reportIndexByUserTarget) {
 
@@ -19,6 +22,8 @@ public record CommunityLightningStateSnapshot(
   public static CommunityLightningStateSnapshot empty() {
     return new CommunityLightningStateSnapshot(
         CURRENT_SCHEMA_VERSION,
+        new LinkedHashMap<>(),
+        new LinkedHashMap<>(),
         new LinkedHashMap<>(),
         new LinkedHashMap<>(),
         new LinkedHashMap<>(),

--- a/quarkus-app/src/main/resources/META-INF/resources/js/home-lightning.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/home-lightning.js
@@ -129,13 +129,8 @@
     return Number.isFinite(value) ? value : 0;
   }
 
-  function isModified(createdAt, updatedAt) {
-    const created = parseEpoch(createdAt);
-    const updated = parseEpoch(updatedAt);
-    if (!created || !updated) {
-      return false;
-    }
-    return Math.abs(updated - created) >= 1000;
+  function isModified(editedAt) {
+    return parseEpoch(editedAt) > 0;
   }
 
   function threadMeta(thread) {
@@ -144,8 +139,8 @@
     if (posted) {
       parts.push(`${i18n.datePosted}: ${posted}`);
     }
-    const modified = isModified(thread.created_at, thread.updated_at);
-    const updated = formatDate(thread.updated_at);
+    const modified = isModified(thread.edited_at);
+    const updated = formatDate(thread.edited_at);
     if (modified && updated) {
       parts.push(`${i18n.dateUpdated}: ${updated}`);
     }
@@ -169,9 +164,9 @@
 
   function commentMarkup(comment, isBest) {
     const cls = isBest ? "home-lightning-comment best" : "home-lightning-comment";
-    const modified = isModified(comment.created_at, comment.updated_at);
+    const modified = isModified(comment.edited_at);
     const posted = formatDate(comment.created_at);
-    const updated = formatDate(comment.updated_at);
+    const updated = formatDate(comment.edited_at);
     const dateLine = modified && updated
       ? `${i18n.datePosted}: ${posted} · ${i18n.dateUpdated}: ${updated}`
       : `${i18n.datePosted}: ${posted}`;

--- a/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityLightningApiResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/community/CommunityLightningApiResourceTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
@@ -68,7 +69,8 @@ public class CommunityLightningApiResourceTest {
         .statusCode(200)
         .body("items", hasSize(greaterThanOrEqualTo(1)))
         .body("items[0].id", equalTo(threadId))
-        .body("items[0].title", equalTo("Docker or Podman?"));
+        .body("items[0].title", equalTo("Docker or Podman?"))
+        .body("items[0].edited_at", nullValue());
   }
 
   @Test
@@ -159,7 +161,7 @@ public class CommunityLightningApiResourceTest {
         .statusCode(200)
         .body("item.title", equalTo("Docker and Podman together?"))
         .body("item.is_owner", equalTo(true))
-        .body("item.updated_at", notNullValue());
+        .body("item.edited_at", notNullValue());
 
     String commentId =
         given()
@@ -181,7 +183,7 @@ public class CommunityLightningApiResourceTest {
         .statusCode(200)
         .body("comment.body", equalTo("Edited concise reply."))
         .body("comment.is_owner", equalTo(true))
-        .body("comment.updated_at", notNullValue())
+        .body("comment.edited_at", notNullValue())
         .body("thread.last_comment_at", notNullValue());
   }
 

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/PersistenceServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/PersistenceServiceTest.java
@@ -144,6 +144,8 @@ public class PersistenceServiceTest {
             new java.util.LinkedHashMap<>(),
             new java.util.LinkedHashMap<>(),
             new java.util.LinkedHashMap<>(),
+            new java.util.LinkedHashMap<>(),
+            new java.util.LinkedHashMap<>(),
             new java.util.LinkedHashMap<>());
 
     service.saveCommunityLightningStateSync(snapshot);


### PR DESCRIPTION
## Summary
- use explicit edited_at metadata for LTA threads/comments
- keep updated_at for technical activity, but render Modified only when edited_at exists
- preserve edit metadata in persistence snapshot
- add regression assertions for edited vs non-edited behavior

## Why
Modified was displayed for non-edited posts because updated_at changes on publish/likes/comments.

## Validation
- mvn -q "-Dtest=CommunityLightningApiResourceTest,PersistenceServiceTest" test

## Production verification
- /comunidad/lta non-edited thread: no Modified badge
- edit own thread/comment: Modified badge appears
