### PR TITLE
style(community): compact ultra-lite pattern for LTA and controls

### DIFF
--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -428,6 +428,21 @@
     opacity: 1 !important;
   }
 
+  /* LTA area also runs with strict low-motion to avoid hover jitter and paint spikes. */
+  #community-lightning-root,
+  #community-lightning-root *,
+  #community-lightning-root *::before,
+  #community-lightning-root *::after {
+    animation: none !important;
+    transition: none !important;
+    transform: none !important;
+    will-change: auto !important;
+    filter: none !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    text-shadow: none !important;
+  }
+
   .community-shell-card,
   .community-shell-card:hover {
     transform: none;
@@ -447,6 +462,35 @@
     margin: 0;
     font-size: 1.1rem;
     letter-spacing: 1px;
+  }
+
+  .community-submenu {
+    position: sticky;
+    top: 0.45rem;
+    z-index: 6;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 10px;
+    background: rgba(0, 0, 0, 0.36);
+    padding: 0.4rem;
+    margin-top: 0.05rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .community-submenu-link {
+    min-height: 38px;
+    border-width: 2px;
+    border-bottom-width: 4px;
+    border-right-width: 3px;
+    border-radius: 8px;
+    padding: 0.32rem 0.45rem;
+    font-size: 0.58rem;
+    letter-spacing: 0.55px;
+  }
+
+  .community-submenu-link-active {
+    box-shadow:
+      0 4px 0 rgba(0, 0, 0, 0.32),
+      0 0 0 1px rgba(255, 215, 0, 0.42) inset;
   }
 
   .community-shell-card *,
@@ -505,6 +549,104 @@
     display: none;
   }
 
+  .community-lta-shell {
+    border: 1px solid rgba(255, 255, 255, 0.24);
+    border-radius: 10px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0.22));
+    padding: 0.64rem;
+    gap: 0.56rem;
+  }
+
+  .community-lta-shell .home-lightning-header {
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.24);
+    padding: 0.52rem 0.58rem;
+  }
+
+  .community-lta-shell .home-chip {
+    border-color: rgba(255, 215, 0, 0.62);
+    background: rgba(255, 215, 0, 0.14);
+  }
+
+  .community-lta-stage {
+    display: grid;
+    grid-template-columns: minmax(230px, 280px) minmax(0, 1fr);
+    align-items: start;
+    gap: 0.56rem;
+  }
+
+  .community-lta-compose {
+    display: grid;
+    gap: 0.46rem;
+    position: sticky;
+    top: 4.2rem;
+  }
+
+  .community-lta-shell .home-lightning-form,
+  .community-lta-shell .home-lightning-login,
+  .community-lta-shell .home-lightning-feedback {
+    border: 1px solid rgba(255, 255, 255, 0.24);
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.24);
+    padding: 0.48rem;
+  }
+
+  .community-lta-shell .home-lightning-form input {
+    min-height: 38px;
+  }
+
+  .community-lta-shell .community-lta-feed {
+    min-width: 0;
+  }
+
+  .community-lta-shell .home-lightning-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.48rem;
+  }
+
+  .community-lta-shell .home-lightning-item {
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    border-left: 3px solid rgba(255, 215, 0, 0.42);
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.22);
+    padding: 0.52rem;
+    gap: 0.32rem;
+  }
+
+  .community-lta-shell .home-lightning-item-head {
+    align-items: center;
+    gap: 0.3rem;
+  }
+
+  .community-lta-shell .home-lightning-item-head strong {
+    font-size: 0.69rem;
+    letter-spacing: 0.2px;
+  }
+
+  .community-lta-shell .home-lightning-item-head small {
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.24);
+    padding: 0.08rem 0.32rem;
+    font-size: 0.62rem;
+  }
+
+  .community-lta-shell .home-lightning-item h3 {
+    margin: 0;
+    font-size: 0.79rem;
+    line-height: 1.32;
+  }
+
+  .community-lta-shell .home-lightning-comments {
+    border-top: 1px dashed rgba(255, 255, 255, 0.2);
+    padding-top: 0.35rem;
+  }
+
+  .community-lta-shell .home-lightning-actions {
+    justify-content: center;
+  }
+
   .community-skeleton {
     display: grid;
     gap: 1rem;
@@ -520,10 +662,13 @@
 
   .community-controls-panel {
     border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: 8px;
-    background: rgba(0, 0, 0, 0.2);
-    padding: 0.5rem;
+    border-radius: 10px;
+    background: rgba(0, 0, 0, 0.3);
+    padding: 0.45rem;
     margin-bottom: 0.6rem;
+    position: sticky;
+    top: 4.6rem;
+    z-index: 5;
   }
 
   .community-controls-top {
@@ -570,6 +715,8 @@
     display: flex;
     gap: 0.35rem;
     flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: thin;
     margin-bottom: 0;
   }
 
@@ -586,6 +733,8 @@
     display: flex;
     gap: 0.35rem;
     flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: thin;
     margin-bottom: 0;
   }
 
@@ -611,8 +760,10 @@
   .community-media-row {
     display: flex;
     gap: 0.32rem;
-    flex-wrap: wrap;
-    margin-bottom: 0.4rem;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: thin;
+    margin-bottom: 0.32rem;
   }
 
   .community-media-btn {
@@ -638,8 +789,10 @@
   .community-topic-row {
     display: flex;
     gap: 0.32rem;
-    flex-wrap: wrap;
-    margin-bottom: 0.4rem;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: thin;
+    margin-bottom: 0.36rem;
   }
 
   .community-active-filters {
@@ -705,6 +858,36 @@
   }
 
   @media (max-width: 920px) {
+    .community-submenu {
+      position: static;
+      padding: 0;
+      border: 0;
+      border-radius: 0;
+      background: transparent;
+      margin-bottom: 0.42rem;
+    }
+
+    .community-submenu-link {
+      font-size: 0.6rem;
+    }
+
+    .community-lta-stage {
+      grid-template-columns: 1fr;
+    }
+
+    .community-lta-compose {
+      position: static;
+    }
+
+    .community-lta-shell .home-lightning-list {
+      grid-template-columns: 1fr;
+    }
+
+    .community-controls-panel {
+      position: static;
+      top: auto;
+    }
+
     .community-controls-top {
       grid-template-columns: 1fr;
       gap: 0.36rem;
@@ -712,8 +895,9 @@
 
     .community-filter-row,
     .community-view-row,
-    .community-media-row {
-      flex-wrap: wrap;
+    .community-media-row,
+    .community-topic-row {
+      flex-wrap: nowrap;
     }
   }
 


### PR DESCRIPTION
## Summary
- apply a strict ultra-lite visual profile to `/comunidad/lta` to reduce repaint/hover jitter
- make Community submenu sticky and compact for faster section switching
- compact and stabilize Community Picks controls with horizontal chip rows and sticky control panel
- preserve current look & feel while improving visual hierarchy and scan speed

## Why
`/comunidad` still felt visually noisy and laggy in the LTA and filter areas. This iteration applies a `media-first + progressive disclosure` pattern using low-motion styling and compact controls.

## Scope
- In: `quarkus-app/src/main/resources/templates/CommunityResource/community.html` (community page scoped styles)
- Out: backend/API changes, JS behavior changes, new dependencies

## Validation
- `./mvnw -q -DskipTests package` (from `quarkus-app`)

## Production verification plan
- Verify HTTP 200: `/`, `/comunidad`, `/eventos`, `/proyectos`
- Verify `/comunidad/lta` renders with:
  - sticky compact submenu
  - stable LTA cards without hover flicker
  - compact controls and visible content above the fold
- Verify no new critical browser console errors on Community pages

## Rollback plan
- Revert this PR commit and redeploy previous stable tag.
