### PR TITLE
fix(ci): robust SSH host key handling for production deploy

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'quarkus-app/**'
       - '.github/workflows/pr-check.yml'
+      - '.github/workflows/release.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
       HEALTHCHECK_URL: ${{ vars.DEPLOY_HEALTHCHECK_URL }}
       DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY != '' && secrets.DEPLOY_SSH_PRIVATE_KEY || secrets.VPS_SSH_KEY }}
       DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
+      DEPLOY_SSH_STRICT_HOST_KEY_CHECKING: ${{ vars.DEPLOY_SSH_STRICT_HOST_KEY_CHECKING }}
 
     steps:
       - name: Checkout code
@@ -108,10 +109,19 @@ jobs:
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           port="${DEPLOY_PORT:-22}"
+          strict="${DEPLOY_SSH_STRICT_HOST_KEY_CHECKING:-accept-new}"
+          if [ "${strict}" = "no" ]; then
+            echo "Strict host key checking disabled; skipping known_hosts bootstrap."
+            exit 0
+          fi
           if [ -n "${DEPLOY_SSH_KNOWN_HOSTS:-}" ]; then
             printf '%s\n' "$DEPLOY_SSH_KNOWN_HOSTS" >> ~/.ssh/known_hosts
           else
-            ssh-keyscan -p "$port" "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+            if ssh-keyscan -T 5 -p "$port" "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null; then
+              echo "known_hosts populated from ssh-keyscan."
+            else
+              echo "::warning::ssh-keyscan failed for ${DEPLOY_HOST}:${port}. Continuing with StrictHostKeyChecking=${strict}."
+            fi
           fi
           chmod 644 ~/.ssh/known_hosts
 
@@ -123,7 +133,17 @@ jobs:
           set -euo pipefail
           port="${DEPLOY_PORT:-22}"
           cmd="${DEPLOY_COMMAND:-/usr/local/bin/homedir-update.sh}"
-          ssh -p "$port" "${DEPLOY_USER}@${DEPLOY_HOST}" "DEPLOY_TRIGGER=github-actions ${cmd} ${RELEASE_TAG}"
+          strict="${DEPLOY_SSH_STRICT_HOST_KEY_CHECKING:-accept-new}"
+          if [ "${strict}" = "no" ]; then
+            ssh -p "$port" \
+              -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null \
+              "${DEPLOY_USER}@${DEPLOY_HOST}" "DEPLOY_TRIGGER=github-actions ${cmd} ${RELEASE_TAG}"
+          else
+            ssh -p "$port" \
+              -o StrictHostKeyChecking="${strict}" \
+              "${DEPLOY_USER}@${DEPLOY_HOST}" "DEPLOY_TRIGGER=github-actions ${cmd} ${RELEASE_TAG}"
+          fi
 
       - name: Verify production healthcheck
         if: ${{ steps.deploy_config.outputs.enabled == 'true' }}


### PR DESCRIPTION
## Summary
- harden `Production Release` SSH bootstrap to avoid failing when `ssh-keyscan` is transiently unavailable
- default deploy SSH to `StrictHostKeyChecking=accept-new` unless overridden by env var
- add `.github/workflows/release.yml` to PR validation path filters so workflow changes trigger CI

## Why
Recent production releases failed at `Prepare SSH known_hosts`, blocking automatic deploy even when build and image push succeeded.

## Scope
- In: `.github/workflows/release.yml`, `.github/workflows/pr-check.yml`
- Out: app runtime behavior, UI/API changes

## Validation
- `./mvnw -q -DskipTests package` (from `quarkus-app`)

## Production verification plan
- Merge PR and watch `Production Release` run
- Confirm deploy step reaches SSH command and healthcheck
- Verify HTTP 200 on `/`, `/comunidad`, `/eventos`, `/proyectos`

## Rollback plan
- Revert this PR to previous release workflow revision.
