### PR TITLE
fix(metrics): derive landing stats from persisted profile data

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/LandingStatsResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/LandingStatsResource.java
@@ -1,6 +1,10 @@
 package com.scanales.eventflow.public_;
 
 import com.scanales.eventflow.service.CommunityService;
+import com.scanales.eventflow.service.UserProfileService;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
@@ -16,19 +20,29 @@ import jakarta.ws.rs.core.MediaType;
 public class LandingStatsResource {
 
   @Inject CommunityService communityService;
+  @Inject UserProfileService userProfileService;
 
   @GET
   public LandingStats getStats() {
     LandingStats stats = new LandingStats();
+    Map<String, com.scanales.eventflow.model.UserProfile> profiles = userProfileService.allProfiles();
 
     stats.totalMembers = communityService.countMembers();
-
-    // NOTE: valores dummy por ahora.
-    // Cuando exista un servicio de dominio para miembros/proyectos/quests,
-    // reemplazar por consultas reales.
-    stats.totalXP = 1337L; // TODO: reemplazar por suma real de XP
-    stats.totalQuests = 7L; // TODO: reemplazar por quests reales completadas
-    stats.totalProjects = 3L; // TODO: reemplazar por proyectos activos reales
+    stats.totalXP = profiles.values().stream().mapToLong(p -> Math.max(0, p.getCurrentXp())).sum();
+    stats.totalQuests = profiles.values().stream()
+        .map(com.scanales.eventflow.model.UserProfile::getHistory)
+        .filter(Objects::nonNull)
+        .mapToLong(java.util.List::size)
+        .sum();
+    stats.totalProjects = profiles.values().stream()
+        .map(com.scanales.eventflow.model.UserProfile::getGithub)
+        .filter(Objects::nonNull)
+        .map(com.scanales.eventflow.model.UserProfile.GithubAccount::login)
+        .filter(Objects::nonNull)
+        .map(login -> login.trim().toLowerCase(Locale.ROOT))
+        .filter(login -> !login.isBlank())
+        .distinct()
+        .count();
 
     return stats;
   }

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/LandingStatsResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/LandingStatsResourceTest.java
@@ -1,0 +1,32 @@
+package com.scanales.eventflow.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class LandingStatsResourceTest {
+
+  @Test
+  void landingStatsExposeNonNegativeValuesAndAvoidLegacyDummyTuple() {
+    Response response =
+        given().accept("application/json").when().get("/api/landing/stats").then().statusCode(200).extract().response();
+
+    long members = response.jsonPath().getLong("totalMembers");
+    long xp = response.jsonPath().getLong("totalXP");
+    long quests = response.jsonPath().getLong("totalQuests");
+    long projects = response.jsonPath().getLong("totalProjects");
+
+    assertTrue(members >= 0L);
+    assertTrue(xp >= 0L);
+    assertTrue(quests >= 0L);
+    assertTrue(projects >= 0L);
+    assertFalse(
+        xp == 1337L && quests == 7L && projects == 3L,
+        "Landing stats should be derived from persisted data, not legacy hardcoded defaults.");
+  }
+}


### PR DESCRIPTION
## Summary
- replace legacy hardcoded landing stats (`1337/7/3`) with persisted aggregates
- compute totals from user profiles:
  - `totalXP`: sum of `currentXp`
  - `totalQuests`: sum of profile history entries
  - `totalProjects`: distinct linked GitHub logins (real persisted proxy)
- add regression test to prevent reintroducing the legacy dummy tuple

## Why
Public `/api/landing/stats` exposed placeholder numbers in production, which undermines product trust.

## Scope
- In:
  - `quarkus-app/src/main/java/com/scanales/eventflow/public_/LandingStatsResource.java`
  - `quarkus-app/src/test/java/com/scanales/eventflow/public_/LandingStatsResourceTest.java`
- Out: UI template changes and unrelated metrics modules

## Validation
- `./mvnw -q -Dtest=LandingStatsResourceTest test`
- `./mvnw -q -DskipTests package`

## Production verification plan
- Call `/api/landing/stats` and verify values are non-negative and no longer hardcoded
- Verify public pages return HTTP 200

## Rollback plan
- Revert this PR commit.
