### PR TITLE
feat(cfp): add reviewer foundation

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/eventops/EventStaffRole.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/eventops/EventStaffRole.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 public enum EventStaffRole {
   ORGANIZER("organizer"),
+  CFP_REVIEWER("cfp-reviewer"),
   SPEAKER("speaker"),
   VOLUNTEER("volunteer"),
   PRODUCTION("production"),

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventCfpResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventCfpResource.java
@@ -1,6 +1,8 @@
 package com.scanales.homedir.private_;
 
 import com.scanales.homedir.cfp.CfpSubmissionService;
+import com.scanales.homedir.eventops.EventOperationsService;
+import com.scanales.homedir.eventops.EventStaffRole;
 import com.scanales.homedir.model.Event;
 import com.scanales.homedir.service.EventService;
 import com.scanales.homedir.util.AdminUtils;
@@ -15,20 +17,25 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
 
 @Path("/private/admin/events/{id}/cfp")
 public class AdminEventCfpResource {
+  private static final Set<EventStaffRole> CFP_REVIEWER_ROLES = Set.of(EventStaffRole.CFP_REVIEWER);
 
   @CheckedTemplate
   static class Templates {
-    static native TemplateInstance moderation(Event event);
+    static native TemplateInstance moderation(Event event, boolean canManage);
 
-    static native TemplateInstance detail(Event event, String submissionId);
+    static native TemplateInstance detail(Event event, String submissionId, boolean canManage);
   }
 
   @Inject EventService eventService;
 
   @Inject CfpSubmissionService cfpSubmissionService;
+  @Inject EventOperationsService eventOperationsService;
 
   @Inject SecurityIdentity identity;
 
@@ -36,14 +43,14 @@ public class AdminEventCfpResource {
   @Authenticated
   @Produces(MediaType.TEXT_HTML)
   public Response moderation(@PathParam("id") String eventId) {
-    if (!AdminUtils.canViewAdminBackoffice(identity)) {
+    if (!canReviewCfp(eventId)) {
       return Response.status(Response.Status.FORBIDDEN).build();
     }
     Event event = eventService.getEvent(eventId);
     if (event == null) {
       return Response.status(Response.Status.NOT_FOUND).build();
     }
-    return Response.ok(Templates.moderation(event)).build();
+    return Response.ok(Templates.moderation(event, AdminUtils.canManageAdminBackoffice(identity))).build();
   }
 
   @GET
@@ -52,7 +59,7 @@ public class AdminEventCfpResource {
   @Produces(MediaType.TEXT_HTML)
   public Response submissionDetail(
       @PathParam("id") String eventId, @PathParam("submissionId") String submissionId) {
-    if (!AdminUtils.canViewAdminBackoffice(identity)) {
+    if (!canReviewCfp(eventId)) {
       return Response.status(Response.Status.FORBIDDEN).build();
     }
     Event event = eventService.getEvent(eventId);
@@ -64,6 +71,31 @@ public class AdminEventCfpResource {
     if (!existsForEvent) {
       return Response.status(Response.Status.NOT_FOUND).build();
     }
-    return Response.ok(Templates.detail(event, submissionId)).build();
+    return Response.ok(Templates.detail(event, submissionId, AdminUtils.canManageAdminBackoffice(identity))).build();
+  }
+
+  private boolean canReviewCfp(String eventId) {
+    if (AdminUtils.canViewAdminBackoffice(identity)) {
+      return true;
+    }
+    return eventOperationsService.hasStaffRole(eventId, currentUserIds(), CFP_REVIEWER_ROLES, true);
+  }
+
+  private Set<String> currentUserIds() {
+    if (identity == null || identity.isAnonymous()) {
+      return Set.of();
+    }
+    LinkedHashSet<String> ids = new LinkedHashSet<>();
+    addNormalizedUserId(ids, identity.getPrincipal() != null ? identity.getPrincipal().getName() : null);
+    addNormalizedUserId(ids, AdminUtils.getClaim(identity, "email"));
+    addNormalizedUserId(ids, AdminUtils.getClaim(identity, "sub"));
+    return ids.isEmpty() ? Set.of() : Set.copyOf(ids);
+  }
+
+  private static void addNormalizedUserId(Set<String> target, String raw) {
+    if (raw == null || raw.isBlank()) {
+      return;
+    }
+    target.add(raw.trim().toLowerCase(Locale.ROOT));
   }
 }

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/CfpSubmissionApiResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/CfpSubmissionApiResource.java
@@ -60,6 +60,7 @@ public class CfpSubmissionApiResource {
   private static final int DEFAULT_LIMIT = PaginationGuardrails.DEFAULT_PAGE_LIMIT;
   private static final int MAX_LIMIT = PaginationGuardrails.MAX_PAGE_LIMIT;
   private static final int MAX_OFFSET = PaginationGuardrails.MAX_OFFSET;
+  private static final Set<EventStaffRole> CFP_REVIEWER_ROLES = Set.of(EventStaffRole.CFP_REVIEWER);
 
   @Inject CfpSubmissionService cfpSubmissionService;
   @Inject CfpConfigService cfpConfigService;
@@ -421,7 +422,7 @@ public class CfpSubmissionApiResource {
   @Path("/stats")
   @Authenticated
   public Response stats(@PathParam("eventId") String eventId) {
-    if (!AdminUtils.isAdmin(identity)) {
+    if (!canReviewCfp(eventId)) {
       return Response.status(Response.Status.FORBIDDEN).entity(Map.of("error", "admin_required")).build();
     }
     CfpSubmissionService.EventStats stats = cfpSubmissionService.statsByEvent(eventId);
@@ -448,7 +449,7 @@ public class CfpSubmissionApiResource {
       @QueryParam("track") String track,
       @QueryParam("limit") Integer limitParam,
       @QueryParam("offset") Integer offsetParam) {
-    if (!AdminUtils.isAdmin(identity)) {
+    if (!canReviewCfp(eventId)) {
       return Response.status(Response.Status.FORBIDDEN).entity(Map.of("error", "admin_required")).build();
     }
     Optional<CfpSubmissionStatus> statusFilter = parseStatusFilter(status);
@@ -481,7 +482,7 @@ public class CfpSubmissionApiResource {
   @Authenticated
   public Response getSubmissionDetail(
       @PathParam("eventId") String eventId, @PathParam("id") String id) {
-    if (!AdminUtils.isAdmin(identity)) {
+    if (!canReviewCfp(eventId)) {
       return Response.status(Response.Status.FORBIDDEN).entity(Map.of("error", "admin_required")).build();
     }
     Optional<CfpSubmission> existing = cfpSubmissionService.findById(id);
@@ -1018,6 +1019,13 @@ public class CfpSubmissionApiResource {
       return Optional.of(name);
     }
     return currentUserId();
+  }
+
+  private boolean canReviewCfp(String eventId) {
+    if (AdminUtils.isAdmin(identity)) {
+      return true;
+    }
+    return eventOperationsService.hasStaffRole(eventId, currentUserIds(), CFP_REVIEWER_ROLES, true);
   }
 
   private static Optional<CfpSubmissionStatus> parseStatusFilter(String status) {

--- a/quarkus-app/src/main/resources/templates/AdminEventCfpResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventCfpResource/detail.html
@@ -13,7 +13,9 @@
       </div>
       <div class="action-group admin-nav-strip">
         <a id="cfpBackToOverviewLink" href="/private/admin/events/{event.id}/cfp" class="btn btn-secondary">{i18n:events_cfp_admin_nav_back_overview}</a>
+        {#if canManage}
         <a href="/private/admin/events/{event.id}/edit" class="btn btn-secondary">{i18n:events_cfp_admin_nav_edit_event}</a>
+        {/if}
         <a href="/event/{event.id}/cfp" class="btn btn-secondary">{i18n:events_cfp_admin_nav_public_cfp}</a>
       </div>
     </div>
@@ -178,6 +180,7 @@
   (() => {
     const eventId = "{event.id}";
     const submissionId = "{submissionId}";
+    const canManage = {#if canManage}true{#else}false{/if};
     const baseEndpoint = "/api/events/" + encodeURIComponent(eventId) + "/cfp/submissions";
     const shell = document.getElementById("cfpDetailShell");
     const feedback = document.getElementById("cfpDetailFeedback");
@@ -540,6 +543,14 @@
 
       const note = document.getElementById("cfpModerationNote");
       const actions = document.getElementById("cfpDetailActions");
+
+      if (!canManage) {
+        technical.select.disabled = true;
+        narrative.select.disabled = true;
+        impact.select.disabled = true;
+        note.disabled = true;
+        return;
+      }
 
       function attachAction(label, className, handler) {
         const btn = document.createElement("button");

--- a/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
@@ -14,8 +14,10 @@
       <div class="action-group admin-nav-strip">
         <a href="/private/admin" class="btn btn-secondary">{i18n:nav_admin_panel}</a>
         <a href="/private/admin/events" class="btn btn-secondary">{i18n:nav_events}</a>
+        {#if canManage}
         <a href="/private/admin/events/{event.id}/edit" class="btn btn-secondary">{i18n:events_cfp_admin_nav_edit_event}</a>
         <a href="/private/admin/events/{event.id}/volunteers" class="btn btn-secondary">{i18n:events_volunteers_open_cta}</a>
+        {/if}
         <a href="/event/{event.id}/cfp" class="btn btn-secondary">{i18n:events_cfp_admin_nav_public_cfp}</a>
       </div>
     </div>
@@ -25,10 +27,13 @@
 <div class="container">
   <nav class="hd-profile-nav cfp-admin-subnav" aria-label="{i18n:events_cfp_admin_subnav_aria}">
     <button type="button" class="hd-profile-nav-btn" data-cfp-admin-nav="cfp-overview-panel">{i18n:events_cfp_admin_subnav_overview}</button>
+    {#if canManage}
     <button type="button" class="hd-profile-nav-btn" data-cfp-admin-nav="cfp-configuration-panel">{i18n:events_cfp_admin_subnav_configuration}</button>
+    {/if}
     <button type="button" class="hd-profile-nav-btn" data-cfp-admin-nav="cfp-review-panel">{i18n:events_cfp_admin_subnav_review}</button>
   </nav>
 
+  {#if canManage}
   <section id="cfp-configuration-panel" data-cfp-admin-section hidden>
   <div class="card admin-shell-margin-bottom-md">
     <div class="admin-shell-card-header">
@@ -137,6 +142,7 @@
   </div>
 
   </section>
+  {/if}
 
   <section id="cfp-overview-panel" data-cfp-admin-section>
   <div class="card admin-shell-margin-bottom-md">
@@ -227,6 +233,7 @@
 <script>
   (() => {
     const eventId = "{event.id}";
+    const canManage = {#if canManage}true{#else}false{/if};
     const baseEndpoint = "/api/events/" + encodeURIComponent(eventId) + "/cfp/submissions";
     const agendaConfigEndpoint = "/api/events/" + encodeURIComponent(eventId) + "/agenda/config";
     const configEndpoint = baseEndpoint + "/config";
@@ -465,6 +472,10 @@
 
     function refreshExportUrl() {
       if (!exportBtn) return;
+      if (!canManage) {
+        exportBtn.removeAttribute("href");
+        return;
+      }
       const params = new URLSearchParams();
       if (activeStatus) params.set("status", activeStatus);
       if (activeSort) params.set("sort", activeSort);
@@ -945,7 +956,7 @@
     }
 
     async function loadEventConfig() {
-      if (!eventConfigSummary) {
+      if (!canManage || !eventConfigSummary) {
         return;
       }
       try {
@@ -962,7 +973,7 @@
     }
 
     async function saveEventConfig() {
-      if (!eventConfigSaveBtn) return;
+      if (!canManage || !eventConfigSaveBtn) return;
       eventConfigSaveBtn.disabled = true;
       if (eventConfigFeedback) {
         eventConfigFeedback.hidden = true;
@@ -999,7 +1010,7 @@
     }
 
     async function clearEventConfig() {
-      if (!eventConfigClearBtn) return;
+      if (!canManage || !eventConfigClearBtn) return;
       eventConfigClearBtn.disabled = true;
       if (eventConfigFeedback) {
         eventConfigFeedback.hidden = true;
@@ -1023,7 +1034,7 @@
     }
 
     async function publishResults() {
-      if (!publishResultsBtn) return;
+      if (!canManage || !publishResultsBtn) return;
       publishResultsBtn.disabled = true;
       if (resultsFeedback) {
         resultsFeedback.hidden = true;
@@ -1058,7 +1069,7 @@
     }
 
     async function loadTestingConfig() {
-      if (!testingToggle) return;
+      if (!canManage || !testingToggle) return;
       try {
         const response = await fetch(configEndpoint, { headers: { Accept: "application/json" } });
         if (!response.ok) return;
@@ -1069,7 +1080,7 @@
     }
 
     async function saveTestingConfig() {
-      if (!testingToggle || !testingSaveBtn) return;
+      if (!canManage || !testingToggle || !testingSaveBtn) return;
       testingSaveBtn.disabled = true;
       try {
         const response = await fetch(configEndpoint, {
@@ -1090,7 +1101,7 @@
     }
 
     async function loadAgendaNoticeConfig() {
-      if (!agendaNoticeToggle) return;
+      if (!canManage || !agendaNoticeToggle) return;
       try {
         const response = await fetch(agendaConfigEndpoint, { headers: { Accept: "application/json" } });
         if (!response.ok) return;
@@ -1101,7 +1112,7 @@
     }
 
     async function saveAgendaNoticeConfig() {
-      if (!agendaNoticeToggle || !agendaNoticeSaveBtn) return;
+      if (!canManage || !agendaNoticeToggle || !agendaNoticeSaveBtn) return;
       agendaNoticeSaveBtn.disabled = true;
       try {
         const response = await fetch(agendaConfigEndpoint, {
@@ -1190,11 +1201,13 @@
       syncModerationUrl();
       loadList().then(() => listEl?.scrollIntoView({ behavior: "smooth", block: "start" }));
     });
-    testingSaveBtn?.addEventListener("click", saveTestingConfig);
-    eventConfigSaveBtn?.addEventListener("click", saveEventConfig);
-    eventConfigClearBtn?.addEventListener("click", clearEventConfig);
-    publishResultsBtn?.addEventListener("click", publishResults);
-    agendaNoticeSaveBtn?.addEventListener("click", saveAgendaNoticeConfig);
+    if (canManage) {
+      testingSaveBtn?.addEventListener("click", saveTestingConfig);
+      eventConfigSaveBtn?.addEventListener("click", saveEventConfig);
+      eventConfigClearBtn?.addEventListener("click", clearEventConfig);
+      publishResultsBtn?.addEventListener("click", publishResults);
+      agendaNoticeSaveBtn?.addEventListener("click", saveAgendaNoticeConfig);
+    }
     restoreModerationStateFromUrl();
     applyControlsFromState();
     const initialPanelId = (() => {
@@ -1214,9 +1227,11 @@
         openCfpAdminSection(hash, false);
       }
     });
-    loadTestingConfig();
-    loadEventConfig();
-    loadAgendaNoticeConfig();
+    if (canManage) {
+      loadTestingConfig();
+      loadEventConfig();
+      loadAgendaNoticeConfig();
+    }
     loadCfpInsightsSummary();
     loadList();
   })();

--- a/quarkus-app/src/test/java/com/scanales/homedir/cfp/CfpSubmissionApiResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/cfp/CfpSubmissionApiResourceTest.java
@@ -7,6 +7,8 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.scanales.homedir.eventops.EventOperationsService;
+import com.scanales.homedir.eventops.EventStaffRole;
 import com.scanales.homedir.insights.DevelopmentInsightsLedgerService;
 import com.scanales.homedir.model.Event;
 import com.scanales.homedir.service.EventService;
@@ -29,6 +31,7 @@ public class CfpSubmissionApiResourceTest {
   @Inject EventService eventService;
   @Inject SpeakerService speakerService;
   @Inject DevelopmentInsightsLedgerService insightsLedger;
+  @Inject EventOperationsService eventOperationsService;
 
   @BeforeEach
   void setup() {
@@ -36,6 +39,7 @@ public class CfpSubmissionApiResourceTest {
     cfpEventConfigService.resetForTests();
     speakerService.reset();
     eventService.reset();
+    eventOperationsService.clearAllForTests();
     eventService.saveEvent(new Event(EVENT_ID, "CFP API Event", "desc"));
   }
 
@@ -618,6 +622,68 @@ public class CfpSubmissionApiResourceTest {
         .accept("application/json")
         .when()
         .get("/api/events/" + EVENT_ID + "/cfp/submissions/stats")
+        .then()
+        .statusCode(403)
+        .body("error", equalTo("admin_required"));
+  }
+
+  @Test
+  @TestSecurity(user = "reviewer@example.com")
+  void reviewerCanReadModerationQueueButCannotMutate() {
+    CfpSubmission created =
+        cfpSubmissionService.create(
+            "member@example.com",
+            "Member",
+            new CfpSubmissionService.CreateRequest(
+                EVENT_ID,
+                "Talk title",
+                "Summary",
+                "Long abstract",
+                "beginner",
+                "talk",
+                30,
+                "en",
+                "platform-engineering-idp",
+                List.of("devops"),
+                List.of()));
+    eventOperationsService.upsertStaff(
+        EVENT_ID,
+        "reviewer@example.com",
+        "Reviewer",
+        EventStaffRole.CFP_REVIEWER,
+        "manual",
+        true);
+
+    given()
+        .accept("application/json")
+        .when()
+        .get("/api/events/" + EVENT_ID + "/cfp/submissions?limit=10&offset=0")
+        .then()
+        .statusCode(200)
+        .body("items", hasSize(1))
+        .body("items[0].id", equalTo(created.id()));
+
+    given()
+        .accept("application/json")
+        .when()
+        .get("/api/events/" + EVENT_ID + "/cfp/submissions/" + created.id())
+        .then()
+        .statusCode(200)
+        .body("item.id", equalTo(created.id()));
+
+    given()
+        .accept("application/json")
+        .when()
+        .get("/api/events/" + EVENT_ID + "/cfp/submissions/stats")
+        .then()
+        .statusCode(200)
+        .body("total", equalTo(1));
+
+    given()
+        .contentType("application/json")
+        .body("{\"status\":\"accepted\",\"note\":\"ok\"}")
+        .when()
+        .put("/api/events/" + EVENT_ID + "/cfp/submissions/" + created.id() + "/status")
         .then()
         .statusCode(403)
         .body("error", equalTo("admin_required"));

--- a/quarkus-app/src/test/java/com/scanales/homedir/eventops/AdminEventOperationsApiResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/eventops/AdminEventOperationsApiResourceTest.java
@@ -120,6 +120,28 @@ class AdminEventOperationsApiResourceTest {
   }
 
   @Test
+  @TestSecurity(user = "admin@example.org")
+  void adminCanAssignCfpReviewerRole() {
+    given()
+        .contentType("application/json")
+        .body(
+            """
+            {
+              "user_name":"Reviewer One",
+              "role":"cfp-reviewer",
+              "source":"manual",
+              "active":true
+            }
+            """)
+        .when()
+        .put("/api/private/admin/events/" + EVENT_ID + "/ops/staff/reviewer@example.com")
+        .then()
+        .statusCode(200)
+        .body("item.role", equalTo("cfp-reviewer"))
+        .body("item.active", equalTo(true));
+  }
+
+  @Test
   @TestSecurity(user = "member@example.com")
   void nonAdminCannotAccessAdminOpsEndpoints() {
     given()

--- a/quarkus-app/src/test/java/com/scanales/homedir/private_/AdminEventCfpPageTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/private_/AdminEventCfpPageTest.java
@@ -4,6 +4,8 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 
 import com.scanales.homedir.cfp.CfpSubmissionService;
+import com.scanales.homedir.eventops.EventOperationsService;
+import com.scanales.homedir.eventops.EventStaffRole;
 import com.scanales.homedir.model.Event;
 import com.scanales.homedir.service.EventService;
 import io.quarkus.test.junit.QuarkusTest;
@@ -19,12 +21,15 @@ public class AdminEventCfpPageTest {
   @Inject EventService eventService;
 
   @Inject CfpSubmissionService cfpSubmissionService;
+  @Inject EventOperationsService eventOperationsService;
 
   private static final String EVENT_ID = "cfp-admin-page-event";
 
   @AfterEach
   void cleanup() {
     eventService.deleteEvent(EVENT_ID);
+    cfpSubmissionService.clearAllForTests();
+    eventOperationsService.clearAllForTests();
   }
 
   @Test
@@ -96,6 +101,68 @@ public class AdminEventCfpPageTest {
     eventService.saveEvent(new Event(EVENT_ID, "CFP Admin Event", "desc"));
 
     given().when().get("/private/admin/events/" + EVENT_ID + "/cfp").then().statusCode(403);
+  }
+
+  @Test
+  @TestSecurity(user = "reviewer@example.org")
+  void reviewerCanOpenModerationPageInReadOnlyMode() {
+    eventService.saveEvent(new Event(EVENT_ID, "CFP Admin Event", "desc"));
+    eventOperationsService.upsertStaff(
+        EVENT_ID,
+        "reviewer@example.org",
+        "Reviewer",
+        EventStaffRole.CFP_REVIEWER,
+        "manual",
+        true);
+
+    given()
+        .when()
+        .get("/private/admin/events/" + EVENT_ID + "/cfp")
+        .then()
+        .statusCode(200)
+        .body(containsString("/api/events/"))
+        .body(containsString("/cfp/submissions"))
+        .body(containsString("data-cfp-admin-nav=\"cfp-overview-panel\""))
+        .body(containsString("data-cfp-admin-nav=\"cfp-review-panel\""))
+        .body(containsString("const canManage = false"));
+  }
+
+  @Test
+  @TestSecurity(user = "reviewer@example.org")
+  void reviewerCanOpenSubmissionDetailPageInReadOnlyMode() {
+    eventService.saveEvent(new Event(EVENT_ID, "CFP Admin Event", "desc"));
+    eventOperationsService.upsertStaff(
+        EVENT_ID,
+        "reviewer@example.org",
+        "Reviewer",
+        EventStaffRole.CFP_REVIEWER,
+        "manual",
+        true);
+    var submission =
+        cfpSubmissionService.create(
+            "speaker@example.org",
+            "Speaker",
+            new CfpSubmissionService.CreateRequest(
+                EVENT_ID,
+                "Observability as product signal",
+                "Short summary",
+                "Longer proposal detail for the admin page.",
+                "advanced",
+                "talk",
+                30,
+                "en",
+                "platform-engineering-idp",
+                List.of(),
+                List.of("https://example.org/talk")));
+
+    given()
+        .when()
+        .get("/private/admin/events/" + EVENT_ID + "/cfp/submissions/" + submission.id())
+        .then()
+        .statusCode(200)
+        .body(containsString("id=\"cfpDetailShell\""))
+        .body(containsString("const submissionId = \"" + submission.id() + "\""))
+        .body(containsString("const canManage = false"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add an event-scoped `cfp-reviewer` staff role
- allow reviewers to open CFP moderation pages and read the queue, stats, and submission detail
- keep reviewers in read-only mode while leaving config, publish, status changes, ratings, and promote actions admin-only

## Why
A collaborator with a view-style account can open the CFP admin shell today, but the page cannot load proposals because the backing APIs still require full admin access. This batch fixes that mismatch without broadening global admin power.

## Scope
- event staff role enum and assignment coverage
- CFP page/resource authorization for reviewers
- CFP moderation API read access for reviewers
- read-only CFP admin UX for non-managing reviewers

## Out Of Scope
- reviewer write actions like rating or status changes
- final CFP decisions, result publication, promotion, or event config changes
- assignment UX beyond the existing event ops path

## Validation
- `cd quarkus-app && mvn -q -DskipTests "-Dproject.build.directory=target-cfp-reviewer-compile" compile`
- `cd quarkus-app && mvn -q -DskipITs "-Dproject.build.directory=target-cfp-reviewer-tests-2" "-Dtest=com.scanales.homedir.private_.AdminEventCfpPageTest,com.scanales.homedir.cfp.CfpSubmissionApiResourceTest,com.scanales.homedir.eventops.AdminEventOperationsApiResourceTest" test`
- `git diff --check`

## Production Verification Plan
- assign `cfp-reviewer` to a collaborator for a real event
- verify `/private/admin/events/{eventId}/cfp` loads proposals and detail pages
- verify reviewer cannot mutate status, config, results, or promotion actions

## Rollback
- revert this PR to restore admin-only CFP moderation access