### PR TITLE
fix: normalize admin event action buttons

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -1126,6 +1126,51 @@ footer {
   line-height: 1;
 }
 
+.event-palette-preview-item {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-top: 0.45rem;
+  min-width: 0;
+}
+
+.event-palette-swatch {
+  width: 2.35rem;
+  height: 1.55rem;
+  flex: 0 0 auto;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.22);
+}
+
+.event-palette-value {
+  min-width: 0;
+  font-family: var(--font-display);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.event-edit-item-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 0.85rem;
+}
+
+.event-edit-delete-form {
+  display: inline-flex;
+  margin: 0;
+}
+
+.event-edit-item-actions .btn {
+  flex: 1 1 10rem;
+  max-width: 14rem;
+  min-height: 2.55rem;
+}
+
 .admin-shell-stat-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(148px, 1fr));

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -1097,6 +1097,35 @@ footer {
   max-width: 100%;
 }
 
+.admin-event-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.admin-event-action-form {
+  display: inline-flex;
+  margin: 0;
+}
+
+.admin-event-action {
+  flex: 0 0 8.25rem;
+  min-height: 2.35rem;
+  padding: 0.45rem 0.65rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  line-height: 1.1;
+  white-space: nowrap;
+}
+
+.admin-event-action .material-symbols-outlined {
+  flex: 0 0 auto;
+  font-size: 1rem;
+  line-height: 1;
+}
+
 .admin-shell-stat-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(148px, 1fr));

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -158,22 +158,42 @@ Nuevo Evento · Homedir
           <div class="form-group">
             <label for="themePrimaryColor" class="form-label">Color principal</label>
             <input id="themePrimaryColor" name="themePrimaryColor" type="color"
-              value="{event.resolvedThemePrimaryColor}" class="form-input">
+              value="{event.resolvedThemePrimaryColor}" class="form-input" data-color-input="primary">
+            <div class="event-palette-preview-item">
+              <span class="event-palette-swatch" data-color-preview="primary"
+                style="background: {event.resolvedThemePrimaryColor};"></span>
+              <span class="event-palette-value" data-color-value="primary">{event.resolvedThemePrimaryColor}</span>
+            </div>
           </div>
           <div class="form-group">
             <label for="themeAccentColor" class="form-label">Color acento</label>
             <input id="themeAccentColor" name="themeAccentColor" type="color"
-              value="{event.resolvedThemeAccentColor}" class="form-input">
+              value="{event.resolvedThemeAccentColor}" class="form-input" data-color-input="accent">
+            <div class="event-palette-preview-item">
+              <span class="event-palette-swatch" data-color-preview="accent"
+                style="background: {event.resolvedThemeAccentColor};"></span>
+              <span class="event-palette-value" data-color-value="accent">{event.resolvedThemeAccentColor}</span>
+            </div>
           </div>
           <div class="form-group">
             <label for="themeSurfaceColor" class="form-label">Color superficie</label>
             <input id="themeSurfaceColor" name="themeSurfaceColor" type="color"
-              value="{event.resolvedThemeSurfaceColor}" class="form-input">
+              value="{event.resolvedThemeSurfaceColor}" class="form-input" data-color-input="surface">
+            <div class="event-palette-preview-item">
+              <span class="event-palette-swatch" data-color-preview="surface"
+                style="background: {event.resolvedThemeSurfaceColor};"></span>
+              <span class="event-palette-value" data-color-value="surface">{event.resolvedThemeSurfaceColor}</span>
+            </div>
           </div>
           <div class="form-group">
             <label for="themeTextColor" class="form-label">Color texto</label>
             <input id="themeTextColor" name="themeTextColor" type="color"
-              value="{event.resolvedThemeTextColor}" class="form-input">
+              value="{event.resolvedThemeTextColor}" class="form-input" data-color-input="text">
+            <div class="event-palette-preview-item">
+              <span class="event-palette-swatch" data-color-preview="text"
+                style="background: {event.resolvedThemeTextColor};"></span>
+              <span class="event-palette-value" data-color-value="text">{event.resolvedThemeTextColor}</span>
+            </div>
           </div>
         </div>
       </fieldset>
@@ -189,7 +209,7 @@ Nuevo Evento · Homedir
     {#for sc in event.scenarios}
     <div
       style="background: rgba(255,255,255,0.05); padding: 1rem; border-radius: var(--radius-sm); margin-bottom: 1rem;">
-      <form method="post" action="/private/admin/events/{event.id}/scenario">
+      <form id="scenario-form-{sc.id}" method="post" action="/private/admin/events/{event.id}/scenario">
         <input type="hidden" name="scenarioId" value="{sc.id}">
         <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem;">
           <div class="form-group"><label class="form-label">ID</label><input class="form-input" value="{sc.id}"
@@ -201,14 +221,14 @@ Nuevo Evento · Homedir
           <div class="form-group"><label class="form-label">Ubicación</label><input name="location"
               value="{sc.location}" placeholder="Ubicación" class="form-input"></div>
         </div>
-        <div class="form-actions">
-          <button type="submit" class="btn btn-secondary">Guardar</button>
-        </div>
       </form>
-      <form method="post" action="/private/admin/events/{event.id}/scenario/{sc.id}/delete"
-        class="needs-confirm form-actions" style="margin-top: 0;">
-        <button type="submit" class="btn btn-danger">Eliminar</button>
-      </form>
+      <div class="event-edit-item-actions">
+        <button type="submit" class="btn btn-secondary" form="scenario-form-{sc.id}">Guardar</button>
+        <form method="post" action="/private/admin/events/{event.id}/scenario/{sc.id}/delete"
+          class="needs-confirm inline-form event-edit-delete-form">
+          <button type="submit" class="btn btn-danger">Eliminar</button>
+        </form>
+      </div>
     </div>
     {/for}
     <div style="background: rgba(255,255,255,0.05); padding: 1rem; border-radius: var(--radius-sm);">
@@ -233,7 +253,7 @@ Nuevo Evento · Homedir
     {#if !t.break}
     <div
       style="background: rgba(255,255,255,0.05); padding: 1rem; border-radius: var(--radius-sm); margin-bottom: 1rem;">
-      <form method="post" action="/private/admin/events/{event.id}/talk">
+      <form id="talk-form-{t.id}" method="post" action="/private/admin/events/{event.id}/talk">
         <input type="hidden" name="talkId" value="{t.id}">
         <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem;">
           <div class="form-group"><label class="form-label">ID</label><input class="form-input" value="{t.id}" disabled>
@@ -261,14 +281,14 @@ Nuevo Evento · Homedir
             </select>
           </div>
         </div>
-        <div class="form-actions">
-          <button type="submit" class="btn btn-secondary">Guardar</button>
-        </div>
       </form>
-      <form method="post" action="/private/admin/events/{event.id}/talk/{t.id}/delete"
-        class="needs-confirm inline-form form-actions" style="margin-top: 0;">
-        <button type="submit" class="btn btn-danger">Eliminar</button>
-      </form>
+      <div class="event-edit-item-actions">
+        <button type="submit" class="btn btn-secondary" form="talk-form-{t.id}">Guardar</button>
+        <form method="post" action="/private/admin/events/{event.id}/talk/{t.id}/delete"
+          class="needs-confirm inline-form event-edit-delete-form">
+          <button type="submit" class="btn btn-danger">Eliminar</button>
+        </form>
+      </div>
     </div>
     {/if}
     {/for}
@@ -327,7 +347,7 @@ Nuevo Evento · Homedir
     {#if t.break}
     <div
       style="background: rgba(255,255,255,0.05); padding: 1rem; border-radius: var(--radius-sm); margin-bottom: 1rem;">
-      <form method="post" action="/private/admin/events/{event.id}/break">
+      <form id="break-form-{t.id}" method="post" action="/private/admin/events/{event.id}/break">
         <input type="hidden" name="breakId" value="{t.id}">
         <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem;">
           <div class="form-group"><label class="form-label">ID</label><input class="form-input" value="{t.id}" disabled>
@@ -355,14 +375,14 @@ Nuevo Evento · Homedir
             </select>
           </div>
         </div>
-        <div class="form-actions">
-          <button type="submit" class="btn btn-secondary">Guardar</button>
-        </div>
       </form>
-      <form method="post" action="/private/admin/events/{event.id}/break/{t.id}/delete"
-        class="needs-confirm inline-form form-actions" style="margin-top: 0;">
-        <button type="submit" class="btn btn-danger">Eliminar</button>
-      </form>
+      <div class="event-edit-item-actions">
+        <button type="submit" class="btn btn-secondary" form="break-form-{t.id}">Guardar</button>
+        <form method="post" action="/private/admin/events/{event.id}/break/{t.id}/delete"
+          class="needs-confirm inline-form event-edit-delete-form">
+          <button type="submit" class="btn btn-danger">Eliminar</button>
+        </form>
+      </div>
     </div>
     {/if}
     {/for}
@@ -444,6 +464,19 @@ Nuevo Evento · Homedir
       speakerSelect.addEventListener('change', filterTalks);
       filterTalks();
     }
+
+    document.querySelectorAll('[data-color-input]').forEach(input => {
+      const key = input.dataset.colorInput;
+      const swatch = document.querySelector('[data-color-preview="' + key + '"]');
+      const value = document.querySelector('[data-color-value="' + key + '"]');
+      function syncColorPreview() {
+        if (swatch) swatch.style.background = input.value;
+        if (value) value.textContent = input.value;
+      }
+      input.addEventListener('input', syncColorPreview);
+      input.addEventListener('change', syncColorPreview);
+      syncColorPreview();
+    });
   })();
 </script>
 {/body}

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
@@ -61,15 +61,22 @@
                             style="padding: 2px 8px; border-radius: 4px; font-size: 0.8rem; background: rgba(255,255,255,0.1);">{ev.typeLabel}</span>
                     </td>
                     <td class="u-p-2">
-                        <div style="display: flex; gap: 0.5rem;">
-                            <a href="/private/admin/events/{ev.id}/edit" class="btn btn-secondary"
-                                style="padding: 0.3rem 0.6rem; font-size: 0.8rem;">Editar</a>
-                            <a href="/private/admin/metrics?event={ev.id}&amp;range=all" class="btn btn-ghost"
-                                style="padding: 0.3rem 0.6rem; font-size: 0.8rem;">Métricas</a>
+                        <div class="admin-event-actions">
+                            <a href="/private/admin/events/{ev.id}/edit" class="btn btn-secondary admin-event-action">
+                                <span class="material-symbols-outlined" aria-hidden="true">edit</span>
+                                <span>Editar</span>
+                            </a>
+                            <a href="/private/admin/metrics?event={ev.id}&amp;range=all"
+                                class="btn btn-ghost admin-event-action">
+                                <span class="material-symbols-outlined" aria-hidden="true">analytics</span>
+                                <span>Métricas</span>
+                            </a>
                             <form method="post" action="/private/admin/events/{ev.id}/delete"
-                                class="needs-confirm inline-form">
-                                <button type="submit" class="btn btn-danger"
-                                    style="padding: 0.3rem 0.6rem; font-size: 0.8rem;">Eliminar</button>
+                                class="needs-confirm inline-form admin-event-action-form">
+                                <button type="submit" class="btn btn-danger admin-event-action">
+                                    <span class="material-symbols-outlined" aria-hidden="true">delete</span>
+                                    <span>Eliminar</span>
+                                </button>
                             </form>
                         </div>
                     </td>

--- a/quarkus-app/src/test/java/com/scanales/homedir/admin/AdminAccessTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/admin/AdminAccessTest.java
@@ -4,11 +4,14 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 
 import com.scanales.homedir.model.Event;
+import com.scanales.homedir.model.Scenario;
+import com.scanales.homedir.model.Talk;
 import com.scanales.homedir.service.EventService;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.SecurityAttribute;
 import io.quarkus.test.security.TestSecurity;
 import jakarta.inject.Inject;
+import java.time.LocalTime;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
@@ -87,6 +90,48 @@ public class AdminAccessTest {
           .body(containsString("btn btn-ghost admin-event-action"))
           .body(containsString("btn btn-danger admin-event-action"))
           .body(containsString("/private/admin/metrics?event=admin-actions-ui-test&amp;range=all"));
+    } finally {
+      eventService.deleteEvent(eventId);
+    }
+  }
+
+  @Test
+  @TestSecurity(user = "sergio.canales.e@gmail.com")
+  public void adminEventEditShowsPalettePreviewAndInlineItemActions() {
+    String eventId = "admin-edit-ui-test";
+    eventService.deleteEvent(eventId);
+    Event event = new Event(eventId, "Admin Edit UI Test", "Admin event edit UI test");
+    event.setThemePrimaryColor("#123456");
+    event.setThemeAccentColor("#abcdef");
+    event.setThemeSurfaceColor("#0f172a");
+    event.setThemeTextColor("#f8fafc");
+    event.getScenarios().add(new Scenario("main-stage", "Main Stage"));
+    Talk talk = new Talk("opening-talk", "Opening Talk");
+    talk.setLocation("main-stage");
+    talk.setStartTime(LocalTime.of(9, 0));
+    talk.setDurationMinutes(30);
+    event.getAgenda().add(talk);
+    Talk breakSlot = new Talk("coffee-break", "Coffee Break");
+    breakSlot.setBreak(true);
+    breakSlot.setLocation("main-stage");
+    breakSlot.setStartTime(LocalTime.of(10, 0));
+    breakSlot.setDurationMinutes(15);
+    event.getAgenda().add(breakSlot);
+    eventService.saveEvent(event);
+
+    try {
+      given()
+          .when()
+          .get("/private/admin/events/" + eventId + "/edit")
+          .then()
+          .statusCode(200)
+          .body(containsString("data-color-input=\"primary\""))
+          .body(containsString("data-color-preview=\"primary\""))
+          .body(containsString("style=\"background: #123456;\""))
+          .body(containsString("class=\"event-edit-item-actions\""))
+          .body(containsString("form=\"scenario-form-main-stage\""))
+          .body(containsString("form=\"talk-form-opening-talk\""))
+          .body(containsString("form=\"break-form-coffee-break\""));
     } finally {
       eventService.deleteEvent(eventId);
     }

--- a/quarkus-app/src/test/java/com/scanales/homedir/admin/AdminAccessTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/admin/AdminAccessTest.java
@@ -3,13 +3,19 @@ package com.scanales.homedir.admin;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 
+import com.scanales.homedir.model.Event;
+import com.scanales.homedir.service.EventService;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.SecurityAttribute;
 import io.quarkus.test.security.TestSecurity;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 public class AdminAccessTest {
+
+  @Inject
+  EventService eventService;
 
   @Test
   @TestSecurity(user = "alice")
@@ -61,6 +67,29 @@ public class AdminAccessTest {
         .statusCode(200)
         .body(containsString("/private/admin/campaigns"))
         .body(containsString("campaign"));
+  }
+
+  @Test
+  @TestSecurity(user = "sergio.canales.e@gmail.com")
+  public void adminEventsListUsesNormalizedActionButtons() {
+    String eventId = "admin-actions-ui-test";
+    eventService.deleteEvent(eventId);
+    eventService.saveEvent(new Event(eventId, "Admin Actions UI Test", "Admin events list UI test"));
+
+    try {
+      given()
+          .when()
+          .get("/private/admin/events")
+          .then()
+          .statusCode(200)
+          .body(containsString("class=\"admin-event-actions\""))
+          .body(containsString("btn btn-secondary admin-event-action"))
+          .body(containsString("btn btn-ghost admin-event-action"))
+          .body(containsString("btn btn-danger admin-event-action"))
+          .body(containsString("/private/admin/metrics?event=admin-actions-ui-test&amp;range=all"));
+    } finally {
+      eventService.deleteEvent(eventId);
+    }
   }
 
 }


### PR DESCRIPTION
## Summary
- Normalize the `/private/admin/events` table action buttons with a shared action group and stable action button sizing.
- Add icons to Edit, Metrics, and Delete actions while preserving the existing labels.
- Add persistent palette previews in `/private/admin/events/{id}/edit` so each selected event color remains visible after selection.
- Place Save and Delete actions for existing scenarios, talks, and breaks in one left/right action row.
- Cover the rendered admin events list and edit controls with focused admin view tests.

## Why
The events admin list had inconsistent action button styles and labels could overflow their controls. The event edit page also hid the selected palette outside the native color picker interaction, and section Save/Delete actions consumed vertical space by stacking.

## Scope
In scope:
- Admin events list action markup
- Admin event edit palette preview markup and client-side preview sync
- Admin event edit item action layout
- Admin shell CSS for event action buttons, palette previews, and edit action rows
- Focused admin render tests

Out of scope:
- Event management behavior
- Metrics page behavior
- Public event views
- Event persistence or palette resolution rules

## Validation
- `git diff --check`
- `mvn -Dtest=AdminAccessTest test` from `quarkus-app` (7 tests, build success)

## Production verification plan
- Open `/private/admin/events` with an admin account.
- Confirm Edit, Metrics, and Delete actions have matching button dimensions and labels stay inside the controls.
- Open `/private/admin/events/devopsdays-santiago-2026/edit`.
- Confirm every palette field shows a persistent swatch and hex value for the selected color.
- Change a palette color and confirm the visible swatch/value update immediately.
- Confirm Save and Delete actions for existing scenarios, talks, and breaks appear side by side and wrap cleanly on narrow viewports.

## Rollback plan
Revert this PR to restore the previous inline action styles and edit controls.
