### PR TITLE
style: align home with public section layout

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -5459,43 +5459,32 @@ footer {
 }
 
 .home-priority-shell {
-  max-width: 1180px;
-  margin: 0 auto 1rem;
+  margin-bottom: 1.5rem;
 }
 
 .home-priority-hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
-  gap: 1rem;
+  grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.75fr);
+  gap: 1.5rem;
   align-items: stretch;
 }
 
-.home-priority-hero-copy,
-.home-priority-spotlight,
-.home-priority-card,
-.home-priority-status {
-  border: 3px solid #12233d;
-  border-radius: 8px;
-  background: rgba(8, 16, 32, 0.84);
-  box-shadow: 0 10px 0 rgba(0, 0, 0, 0.32), inset 0 0 18px rgba(255, 255, 255, 0.05);
-}
-
-.home-priority-hero-copy,
-.home-priority-spotlight {
-  padding: 1.1rem;
+.home-priority-hero-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
 }
 
 .home-priority-hero-copy h1 {
   max-width: 860px;
-  margin: 0.1rem 0 0.65rem;
-  font-size: clamp(1.65rem, 2.7vw, 2.7rem);
-  line-height: 1.08;
+  margin: 0;
 }
 
 .home-priority-hero-copy p,
 .home-priority-spotlight p,
 .home-priority-card p {
-  color: #d8e7ff;
+  color: rgba(255, 255, 255, 0.92);
 }
 
 .home-priority-actions {
@@ -5516,6 +5505,8 @@ footer {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  min-height: 100%;
+  border-left-color: rgba(255, 215, 0, 0.85);
 }
 
 .home-priority-spotlight h2,
@@ -5526,24 +5517,23 @@ footer {
 }
 
 .home-priority-icon {
-  width: 2.35rem;
-  height: 2.35rem;
+  width: 2.5rem;
+  height: 2.5rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
-  border: 2px solid rgba(255, 215, 0, 0.72);
-  border-radius: 8px;
+  border: 3px solid rgba(255, 255, 255, 0.68);
+  border-bottom-width: 5px;
+  border-right-width: 4px;
+  border-radius: 0;
   color: #ffd700;
-  background: rgba(255, 215, 0, 0.12);
+  background: rgba(0, 0, 0, 0.32);
+  box-shadow: 0 4px 0 rgba(0, 0, 0, 0.42);
 }
 
 .home-priority-grid {
-  max-width: 1180px;
-  margin: 0 auto 1rem;
-  display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.85rem;
 }
 
 .home-priority-card {
@@ -5551,11 +5541,6 @@ footer {
   flex-direction: column;
   gap: 0.75rem;
   min-height: 100%;
-  padding: 0.95rem;
-}
-
-.home-priority-card::before {
-  content: none;
 }
 
 .home-priority-card-head {
@@ -5587,12 +5572,13 @@ footer {
   display: grid;
   gap: 0.18rem;
   min-width: 0;
-  padding: 0.58rem 0.65rem;
-  border: 2px solid rgba(123, 215, 255, 0.28);
-  border-radius: 8px;
+  padding: 0.65rem 0.72rem;
+  border: 2px solid rgba(255, 255, 255, 0.28);
+  border-left: 4px solid rgba(255, 215, 0, 0.58);
+  border-radius: 0;
   color: #ffffff;
   text-decoration: none;
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(0, 0, 0, 0.24);
 }
 
 .home-priority-news-item span,
@@ -5616,36 +5602,43 @@ footer {
   border-color: rgba(255, 215, 0, 0.62);
 }
 
-.home-priority-status {
-  max-width: 1180px;
-  margin: 0 auto 1rem;
-  display: grid;
+.home-priority-status-grid {
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0;
-  overflow: hidden;
+  margin-bottom: 1.25rem;
 }
 
 .home-priority-status-item {
   display: grid;
-  gap: 0.1rem;
-  padding: 0.75rem 0.9rem;
+  gap: 0.18rem;
+  min-width: 0;
+  padding: 1.15rem 1rem;
   color: #ffffff;
   text-decoration: none;
-  border-right: 2px solid rgba(255, 255, 255, 0.1);
+  border: 3px solid rgba(255, 255, 255, 0.7);
+  border-bottom: 6px solid rgba(0, 0, 0, 0.7);
+  border-right: 5px solid rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.45);
+  box-shadow: 0 6px 0 rgba(0, 0, 0, 0.6);
 }
 
-.home-priority-status-item:last-child {
-  border-right: 0;
+.home-priority-status-item:hover,
+.home-priority-status-item:focus-visible {
+  background: rgba(0, 0, 0, 0.55);
+  box-shadow: 0 6px 0 rgba(0, 0, 0, 0.6), inset 0 0 0 1px rgba(255, 215, 0, 0.18);
 }
 
 .home-priority-status-item strong {
   color: #ffd700;
-  font-size: 1.18rem;
+  font-family: var(--font-display);
+  font-size: 1.35rem;
+  line-height: 1;
 }
 
 .home-priority-status-item span {
-  color: #a8c3df;
-  font-size: 0.72rem;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.78rem;
+  line-height: 1.35;
+  text-transform: uppercase;
 }
 
 .community-submenu {
@@ -6010,7 +6003,8 @@ footer {
   }
 
   .home-priority-hero,
-  .home-priority-grid {
+  .home-priority-grid,
+  .home-priority-status-grid {
     grid-template-columns: 1fr;
   }
 }
@@ -6035,17 +6029,12 @@ footer {
     padding: 0.85rem;
   }
 
-  .home-priority-status {
+  .home-priority-status-grid {
     grid-template-columns: 1fr;
   }
 
   .home-priority-status-item {
-    border-right: 0;
-    border-bottom: 2px solid rgba(255, 255, 255, 0.1);
-  }
-
-  .home-priority-status-item:last-child {
-    border-bottom: 0;
+    padding: 1rem;
   }
 
   .home-how-grid,

--- a/quarkus-app/src/main/resources/templates/home.qute.html
+++ b/quarkus-app/src/main/resources/templates/home.qute.html
@@ -1,18 +1,20 @@
 {#include layout/main activePage="home" mainClass="homedir-main-home" noLoginModal=true}
 {#title}{i18n:nav_home}{/title}
 {#body}
-<header class="public-header home-priority-shell" aria-label="{i18n:home_priority_aria}">
+<header class="page-header events-page-header home-priority-shell" aria-label="{i18n:home_priority_aria}">
   <section class="home-priority-hero">
     <div class="home-priority-hero-copy">
-      <p class="section-subtitle">{i18n:home_priority_eyebrow}</p>
-      <h1>{i18n:home_priority_title}</h1>
+      <div class="section-header hd-section-heading">
+        <p class="section-subtitle">{i18n:home_priority_eyebrow}</p>
+        <h1>{i18n:home_priority_title}</h1>
+      </div>
       <p>{i18n:home_priority_intro}</p>
       <div class="home-priority-actions">
         <a href="/event/devopsdays-santiago-2026" class="btn-primary">{i18n:home_priority_primary_cta}</a>
         <a href="/comunidad/picks" class="btn-secondary">{i18n:home_priority_secondary_cta}</a>
       </div>
     </div>
-    <aside class="home-priority-spotlight" aria-label="{i18n:home_priority_events_title}">
+    <aside class="section-card home-priority-spotlight" aria-label="{i18n:home_priority_events_title}">
       <span class="home-priority-icon material-symbols-outlined" aria-hidden="true">event</span>
       <p class="section-subtitle">{i18n:home_priority_events_eyebrow}</p>
       <h2>{i18n:home_priority_events_title}</h2>
@@ -25,7 +27,7 @@
   </section>
 </header>
 
-<section class="home-priority-grid" aria-label="{i18n:home_priority_grid_aria}">
+<section class="page-grid home-priority-grid" aria-label="{i18n:home_priority_grid_aria}">
   <article class="section-card home-priority-card home-priority-card-event">
     <div class="home-priority-card-head">
       <span class="home-priority-icon material-symbols-outlined" aria-hidden="true">campaign</span>
@@ -88,7 +90,7 @@
   </article>
 </section>
 
-<section class="home-priority-status" aria-label="{i18n:home_priority_status_aria}">
+<section class="page-grid home-priority-status-grid" aria-label="{i18n:home_priority_status_aria}">
   <a href="/eventos" class="home-priority-status-item">
     <strong>{upcomingCount}</strong>
     <span>{i18n:home_priority_status_events}</span>


### PR DESCRIPTION
## Summary
- Align the simplified home with the visual language used by Community, Events, and Project.
- Reuse `page-header`, `page-grid`, `section-card`, and `hd-section-heading` conventions on the home layout.
- Remove the custom dark-blue home panel treatment in favor of the existing retro section-card framing.

## Scope in
- Home template classes and home-specific CSS only.

## Scope out
- No new images or media assets.
- No copy, route, backend, event, CFP, volunteer, sponsor, or reputation engine changes.

## Validation
- `git diff --check`
- `mvn "-Dtest=HomeTimelineTest,HomeMemberOnboardingTest,HomePastEventsTest" test`
- Result: 8 tests passed.

## Production verification plan
1. Open `/` after deploy.
2. Compare visual treatment against `/comunidad`, `/eventos`, and `/proyectos`.
3. Confirm the simplified home still shows the three priority paths clearly.
4. Confirm desktop and mobile layouts remain readable.

## Rollback plan
Revert this PR to restore the first simplified home styling from PR #725.