### PR TITLE
fix: add non-JWT token expiration fallback in HtmlSessionExpiryFilter

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/security/HtmlSessionExpiryFilter.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/security/HtmlSessionExpiryFilter.java
@@ -71,14 +71,18 @@ public class HtmlSessionExpiryFilter implements ContainerRequestFilter {
     if (id == null) {
       return true;
     }
-    JsonWebToken jwt = null;
-    if (id.getPrincipal() instanceof JsonWebToken jw) {
-      jwt = jw;
+    if (id.getPrincipal() instanceof JsonWebToken jwt) {
+      Long exp = jwt.getExpirationTime();
+      if (exp != null) {
+        return exp <= (System.currentTimeMillis() / 1000L);
+      }
     }
-    if (jwt == null) {
-      return false;
+    // Fallback para tokens no-JWT: intentar leer exp desde atributos
+    Object expAttr = id.getAttribute("exp");
+    if (expAttr instanceof Number n) {
+      return n.longValue() <= (System.currentTimeMillis() / 1000L);
     }
-    Long exp = jwt.getExpirationTime();
-    return exp != null && exp <= (System.currentTimeMillis() / 1000L);
+    // Sin informacion de expiracion, asumir no expirado
+    return false;
   }
 }


### PR DESCRIPTION
## Resumen
Corrige la deteccion de expiracion de sesion para tokens no-JWT en `HtmlSessionExpiryFilter`.

## Por que
Cuando el principal no es un `JsonWebToken` (ej. tokens opacos, form auth en dev), `isExpired()` retornaba `false` silenciosamente, dejando sesiones expiradas sin detectar y sin redirigir al usuario a `/`.

## Cambio
- Refactorizado `isExpired()`: elimina variable intermedia `jwt`, usa `instanceof` directo
- Agrega fallback: si el principal no es JWT, intenta leer `exp` desde `SecurityIdentity.getAttribute("exp")`
- Si tampoco hay `exp` en atributos, retorna `false` (comportamiento original para tokens sin info de expiracion)

## Validacion
- `mvn compile` sin errores
- `mvn test` sin regresiones