### PR TITLE
fix(r7): add real health checks for disk space and persistence writability

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/health/DiskHealthCheck.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/health/DiskHealthCheck.java
@@ -1,0 +1,42 @@
+package com.scanales.homedir.health;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Readiness
+@ApplicationScoped
+public class DiskHealthCheck implements HealthCheck {
+
+  @ConfigProperty(name = "homedir.data.dir", defaultValue = "data")
+  String dataDirPath;
+
+  @ConfigProperty(name = "homedir.health.disk.threshold", defaultValue = "52428800")
+  long minFreeBytes;
+
+  @Override
+  public HealthCheckResponse call() {
+    try {
+      Path dataDir = Path.of(dataDirPath);
+      if (!Files.exists(dataDir)) {
+        return HealthCheckResponse.named("disk-space").down().build();
+      }
+      FileStore store = Files.getFileStore(dataDir);
+      long usable = store.getUsableSpace();
+      boolean healthy = usable >= minFreeBytes;
+      return HealthCheckResponse.named("disk-space")
+          .status(healthy)
+          .withData("usableBytes", usable)
+          .withData("minFreeBytes", minFreeBytes)
+          .build();
+    } catch (Exception e) {
+      return HealthCheckResponse.named("disk-space").down().build();
+    }
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/homedir/health/PersistenceHealthCheck.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/health/PersistenceHealthCheck.java
@@ -1,0 +1,34 @@
+package com.scanales.homedir.health;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Readiness
+@ApplicationScoped
+public class PersistenceHealthCheck implements HealthCheck {
+
+  @ConfigProperty(name = "homedir.data.dir", defaultValue = "data")
+  String dataDirPath;
+
+  @Override
+  public HealthCheckResponse call() {
+    try {
+      Path dataDir = Path.of(dataDirPath);
+      boolean exists = Files.exists(dataDir);
+      boolean writable = exists && Files.isWritable(dataDir);
+      return HealthCheckResponse.named("persistence")
+          .status(writable)
+          .withData("exists", exists)
+          .withData("writable", writable)
+          .build();
+    } catch (Exception e) {
+      return HealthCheckResponse.named("persistence").down().build();
+    }
+  }
+}

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -40,6 +40,9 @@ community.github.default-branch=main
 quests.github.repo-owner=os-santiago
 quests.github.repo-name=community-directory
 
+# Health checks
+homedir.health.disk.threshold=${DISK_MIN_FREE_BYTES:52428800}
+
 # Application version
 # quarkus.application.version removed to use project version by default
 # Store Vert.x cache on a writable volume


### PR DESCRIPTION
## Resumen
Agrega health checks reales de disco y persistencia para reemplazar los checks dummy de Quarkus.

## Por que
El endpoint /q/health solo devolvia checks genericos de Quarkus sin informacion del estado real del disco ni de la persistencia. En produccion esto impide detectar falta de espacio en disco o problemas de escritura en data/.

## Cambio
- Creado DiskHealthCheck.java: verifica espacio usable en el filesystem contra homedir.health.disk.threshold (default 50MB)
- Creado PersistenceHealthCheck.java: verifica que el directorio data/ exista y sea escribible
- Agregada propiedad homedir.health.disk.threshold en application.properties (via env DISK_MIN_FREE_BYTES)

## Validacion
- GET /q/health devuelve checks disk-space y persistence con datos reales
- mvn compile sin errores
- Sin impacto en APIs existentes

## Rollback
Revertir este PR y eliminar los dos archivos en health/