### PR TITLE
fix(r7): log warning on IOException in NotificationRepository.loadForUser

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/notifications/NotificationRepository.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/notifications/NotificationRepository.java
@@ -80,6 +80,7 @@ public class NotificationRepository {
       var type = mapper.getTypeFactory().constructCollectionType(List.class, Notification.class);
       return mapper.readValue(f.toFile(), type);
     } catch (IOException e) {
+      LOG.warnf("Failed to load notifications for user %s: %s", userId, e.getMessage());
       return new ArrayList<>();
     }
   }


### PR DESCRIPTION
## Resumen
Agrega log warning cuando ocurre un IOException al cargar notificaciones, en lugar de tragar la excepcion silenciosamente.

## Por que
En loadForUser(), si el archivo de notificaciones esta corrupto o hay un error de deserializacion, el catch (IOException e) retornaba una lista vacia sin ningun log, haciendo imposible diagnosticar problemas de persistencia.

## Cambio
- Agregado LOG.warnf() en el catch IOException de loadForUser()

## Validacion
- mvn compile sin errores
- Sin impacto en APIs existentes