### PR TITLE
fix(r7): prevent thread leak in NotificationSimulationResource

### DIFF
--- a/quarkus-app/src/main/java/io/homedir/notifications/global/NotificationSimulationResource.java
+++ b/quarkus-app/src/main/java/io/homedir/notifications/global/NotificationSimulationResource.java
@@ -3,7 +3,9 @@ package io.homedir.notifications.global;
 import com.scanales.homedir.service.EventService;
 import io.homedir.time.AppClock;
 import io.homedir.time.SimulatedClock;
+import jakarta.annotation.PreDestroy;
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -20,6 +22,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 @RolesAllowed("admin")
+@ApplicationScoped
 public class NotificationSimulationResource {
 
   @Inject SimulatedClock simClock;
@@ -120,6 +123,19 @@ public class NotificationSimulationResource {
       return Response.ok(Map.of("enqueued", plan.size(), "test", testFlag)).build();
     } finally {
       simClock.clear();
+    }
+  }
+
+  @PreDestroy
+  void cleanup() {
+    scheduler.shutdown();
+    try {
+      if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+        scheduler.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      scheduler.shutdownNow();
+      Thread.currentThread().interrupt();
     }
   }
 }


### PR DESCRIPTION
## Resumen
Previene fuga de threads en NotificationSimulationResource al garantizar el shutdown del ScheduledExecutorService.

## Por que
El campo scheduler = Executors.newSingleThreadScheduledExecutor() se crea en la inicializacion sin ningun mecanismo de cleanup. Si el bean es destruido o redeployado, el thread del scheduler nunca se detiene, acumulando threads huérfanos.

Ademas, la clase no tenia un scope CDI explicito, por lo que Quarkus podria crear multiples instancias (cada una con su propio scheduler).

## Cambio
- Agregado @ApplicationScoped para garantizar una unica instancia gestionada por CDI
- Agregado @PreDestroy cleanup() que hace shutdown graceful del scheduler con timeout de 5s y fallback a shutdownNow()

## Validacion
- mvn compile sin errores
- Sin impacto en APIs existentes

## Rollback
Revertir este PR