### PR TITLE
fix(r1): make MessageDigest thread-safe and remove insecure default salt

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/notifications/NotificationConfig.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/notifications/NotificationConfig.java
@@ -43,7 +43,7 @@ public class NotificationConfig {
   // Iteration 6 operability
   public static boolean metricsEnabled = true;
   public static String logsLevel = "info";
-  public static String userHashSalt = "changeme";
+  public static String userHashSalt = null;
   public static String maxFileSize = "3MB";
   public static Duration maintenanceInterval = Duration.parse("PT30M");
   public static int backpressureQueueMax = 10000;

--- a/quarkus-app/src/main/java/com/scanales/homedir/notifications/NotificationService.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/notifications/NotificationService.java
@@ -1,6 +1,5 @@
 package com.scanales.homedir.notifications;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.nio.charset.StandardCharsets;
@@ -37,18 +36,14 @@ public class NotificationService {
   private final AtomicLong dropped = new AtomicLong();
   private final AtomicLong volatileAccepted = new AtomicLong();
 
-  private MessageDigest digest;
-
-  @PostConstruct
-  void init() {
-    // load existing notifications from disk
-    // Not required in this iteration; repository loads lazily per user
-    try {
-      digest = MessageDigest.getInstance("SHA-256");
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalStateException("Missing SHA-256 MessageDigest", e);
-    }
-  }
+  private static final ThreadLocal<MessageDigest> DIGEST =
+      ThreadLocal.withInitial(() -> {
+        try {
+          return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+          throw new IllegalStateException("Missing SHA-256 MessageDigest", e);
+        }
+      });
 
   /** Enqueues a notification, applying dedupe and capacity checks. */
   public NotificationResult enqueue(Notification n) {
@@ -225,7 +220,7 @@ public class NotificationService {
   private String hashUser(String userId) {
     if (userId == null)
       return "";
-    byte[] d = digest.digest((NotificationConfig.userHashSalt + userId).getBytes(StandardCharsets.UTF_8));
+    byte[] d = DIGEST.get().digest((NotificationConfig.userHashSalt + userId).getBytes(StandardCharsets.UTF_8));
     return HexFormat.of().formatHex(d).substring(0, 16);
   }
 }


### PR DESCRIPTION
## Resumen
Corrige dos vulnerabilidades en el sistema de notificaciones: MessageDigest no thread-safe y salt inseguro por defecto.

## Por que
1. **MessageDigest no thread-safe**: NotificationService usaba una unica instancia de MessageDigest compartida entre threads, lo que puede producir hashes incorrectos bajo concurrencia.
2. **Salt "changeme" hardcodeado**: NotificationConfig.userHashSalt tenia el valor por defecto "changeme", que es trivial y conocido. El metodo resolveUserHashSalt() ya genera un salt aleatorio si detecta null o inseguro, pero nunca se activaba porque el default no era null.

## Cambio
- Reemplazado MessageDigest por ThreadLocal<MessageDigest> con inicializacion lazy en NotificationService
- Removido @PostConstruct init() ya no necesario
- Cambiado NotificationConfig.userHashSalt = null para que resolveUserHashSalt() genere un salt aleatorio

## Validacion
- mvn compile sin errores
- resolveUserHashSalt() ya maneja null correctamente y genera salt aleatorio de 32 bytes via SecureRandom

## Rollback
Revertir este PR