### PR TITLE
fix(r1): add missing slash in CapacityLoginFilter path check

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/capacity/CapacityLoginFilter.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/capacity/CapacityLoginFilter.java
@@ -29,7 +29,7 @@ public class CapacityLoginFilter implements ContainerRequestFilter {
       return;
     }
     String path = ctx.getUriInfo().getPath();
-    if (!path.startsWith("private")) {
+    if (!path.startsWith("/private")) {
       return;
     }
     String email = getEmail();


### PR DESCRIPTION
## Resumen
Corrige el path check en CapacityLoginFilter que nunca matcheaba paths reales por falta de slash inicial.

## Por que
La linea 32 verificaba startsWith('private') pero getUriInfo().getPath() devuelve paths con slash inicial como /private/dashboard. Por lo tanto la condicion siempre era true y el filtro nunca bloqueaba logins aunque la capacidad estuviera al limite.

## Cambio
- Cambiado el string private por /private en el startsWith

## Validacion
- mvn compile sin errores
- CapacityLoginFilter ahora evalua capacidad en paths /private/*

## Rollback
Revertir este PR