### PR TITLE
fix(r3): agregar estado empty a Now Box

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
@@ -4569,6 +4569,9 @@ public interface AppMessages {
     @Message("Next")
     String now_box_status_next();
 
+    @Message("No active events right now.")
+    String now_box_empty();
+
     @Message("HomeDir - OSSantiago Community Platform")
     String layout_default_title();
 

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -5788,6 +5788,12 @@ footer {
   content: none !important;
 }
 
+.now-empty {
+  padding: 1.5rem;
+  text-align: center;
+  color: #a8c3df;
+}
+
 /* Normalize legacy card/list components to the same lightweight baseline used in Community. */
 .homedir-body.ultra-lite-mode .card,
 .homedir-body.ultra-lite-mode .card:hover,

--- a/quarkus-app/src/main/resources/messages.properties
+++ b/quarkus-app/src/main/resources/messages.properties
@@ -766,6 +766,7 @@ now_box_view_full_agenda=View full agenda
 now_box_status_finished=Finished
 now_box_status_live=Live
 now_box_status_next=Next
+now_box_empty=No active events right now.
 layout_default_title=HomeDir - OSSantiago Community Platform
 layout_default_og_title=HomeDir - OSSantiago Community Platform
 layout_default_og_description=HomeDir: your community to build, learn, and share through events, projects, and curated content.

--- a/quarkus-app/src/main/resources/messages_es.properties
+++ b/quarkus-app/src/main/resources/messages_es.properties
@@ -851,6 +851,7 @@ now_box_status_next=Siguiente
 now_box_subtitle=Último, en vivo y siguiente por evento.
 now_box_title=Ocurriendo ahora
 now_box_view_full_agenda=Ver agenda completa
+now_box_empty=No hay eventos activos ahora.
 talk_back_to_event=Volver al evento
 talk_back_to_scenario=Volver al escenario
 talk_breadcrumb_home=Inicio

--- a/quarkus-app/src/main/resources/templates/_now-box.qute.html
+++ b/quarkus-app/src/main/resources/templates/_now-box.qute.html
@@ -1,10 +1,10 @@
-{#if nowBox?.events?? && !nowBox.events.isEmpty()}
 <div class="box now-box">
   <div class="box-header">
     <h2>{i18n:now_box_title}</h2>
     <p class="muted">{i18n:now_box_subtitle}</p>
   </div>
 
+  {#if nowBox?.events?? && !nowBox.events.isEmpty()}
   <div class="now-grid">
     {#for e in nowBox.events}
     <section class="now-event">
@@ -51,5 +51,9 @@
     </section>
     {/for}
   </div>
+  {#else}
+  <div class="now-empty">
+    <p>{i18n:now_box_empty}</p>
+  </div>
+  {/if}
 </div>
-{/if}


### PR DESCRIPTION
## Resumen
El Now Box ocultaba todo el componente cuando no había eventos activos. Ahora siempre se muestra el shell (título + subtítulo) con un mensaje de estado vacío cuando no hay contenido.

## Por qué
Ocultar completamente el componente es confuso para el usuario. Un estado empty con mensaje informativo mejora la experiencia y consistencia visual.

## Alcance
- **In:** _now-box.qute.html siempre renderiza el shell, con eventos o mensaje empty según corresponda. AppMessages.java + messages.properties + messages_es.properties con nueva clave now_box_empty. homedir.css con estilo .now-empty.
- **Out:** No se modifica la lógica de eventos ni la integración del componente (sigue siendo un fragmento no incluido actualmente).

## Validación
- [x] Build local y tests pasados (mvnw compile).
- [ ] Verificación UI/UX: El Now Box muestra el mensaje empty cuando no hay eventos.
- [ ] CodeQL/Sanitization preflight (Rule #24).

## Plan de Producción
- **Verificación:** Revisar que el Now Box se renderiza con el mensaje empty cuando nowBox.events está vacío.
- **Rollback:** Revertir este commit.

## Estado Operacional
- [ ] auto-merge habilitado (Rule #32).
- [ ] Workspace sincronizado (Rule #29).