### PR TITLE
fix(r3): agregar stylesheet @media print

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/print.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/print.css
@@ -1,0 +1,80 @@
+@media print {
+  body {
+    background: #fff !important;
+    color: #000 !important;
+    font-size: 11pt;
+    line-height: 1.5;
+  }
+
+  .floating-shapes,
+  .top-nav,
+  .hd-top-nav,
+  .alpha-banner,
+  .breadcrumbs,
+  footer,
+  .login-modal,
+  .skip-link,
+  .notifications-bell,
+  .header-locale-switcher,
+  .user-menu-container,
+  .home-priority-actions .btn-primary,
+  .home-priority-actions .btn-secondary,
+  .home-priority-link,
+  .btn,
+  .btn-primary,
+  .btn-secondary,
+  .btn-ghost,
+  .close-modal,
+  .community-submenu,
+  .community-controls-panel,
+  .community-activation,
+  .community-personal-empty,
+  .community-activation-guest,
+  .community-skeleton,
+  .community-actions,
+  .home-priority-spotlight,
+  .home-priority-card-event,
+  .home-priority-card-collaboration,
+  .home-priority-status-item,
+  .now-box {
+    display: none !important;
+  }
+
+  .app-container {
+    max-width: 100%;
+    padding: 0;
+    background: none !important;
+  }
+
+  .homedir-main {
+    padding: 0;
+    background: none !important;
+  }
+
+  a {
+    color: #000 !important;
+    text-decoration: underline;
+  }
+
+  h1, h2, h3, h4 {
+    page-break-after: avoid;
+  }
+
+  img {
+    max-width: 100% !important;
+    page-break-inside: avoid;
+  }
+
+  .card, .section-card {
+    border: 1px solid #ccc !important;
+    background: none !important;
+    box-shadow: none !important;
+    page-break-inside: avoid;
+  }
+
+  .page-header {
+    border-bottom: 2px solid #000;
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
+  }
+}

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/css/retro-theme.css?v={app:version()}">
     <link rel="stylesheet" href="/css/homedir.css?v={app:version()}">
     <link rel="stylesheet" href="/css/notifications.css?v={app:version()}">
+    <link rel="stylesheet" href="/css/print.css?v={app:version()}" media="print" />
     <script src="https://cdn.tailwindcss.com" type="text/javascript"></script>
     <script>window.__EF_NOTIFICATIONS_MODE__ = 'global';</script>
     <script src="/js/notifications-adapter.js?v={app:version()}" defer></script>

--- a/quarkus-app/src/main/resources/templates/layout/main.html
+++ b/quarkus-app/src/main/resources/templates/layout/main.html
@@ -34,6 +34,7 @@
   <link rel="stylesheet" href="/css/retro-theme.css?v={app:version()}" />
   <link rel="stylesheet" href="/css/homedir.css?v={app:version()}" />
   <link rel="stylesheet" href="/css/notifications.css?v={app:version()}" />
+  <link rel="stylesheet" href="/css/print.css?v={app:version()}" media="print" />
   <!-- Open Graph / Social Sharing Defaults -->
   <meta property="og:site_name" content="HomeDir" />
   <meta property="og:type" content="website" />


### PR DESCRIPTION
## Resumen
Agrega hoja de estilos para impresión (print.css) con reglas @media print. Oculta elementos de navegación, botones, modales y decoraciones; optimiza el contenido principal para papel.

## Por qué
El sitio no tenía estilos de impresión. Al imprimir, se mostraban elementos interactivos inservibles (nav, botones, modales) y fondos oscuros que consumen tinta innecesariamente.

## Alcance
- **In:** print.css con reglas @media print. Vinculado en layout/main.html y layout/base.html con media="print".
- **Out:** No se modifican estilos de pantalla existentes.

## Validación
- [x] Build local y tests pasados (mvnw compile).
- [ ] Verificación UI/UX: Print Preview muestra solo contenido principal sin nav, footer, ni decoraciones.
- [ ] CodeQL/Sanitization preflight (Rule #24).

## Plan de Producción
- **Verificación:** File → Print Preview en cualquier página. Debe mostrar contenido limpio sobre fondo blanco.
- **Rollback:** Revertir este commit.

## Estado Operacional
- [ ] auto-merge habilitado (Rule #32).
- [ ] Workspace sincronizado (Rule #29).