### PR TITLE
[codex] simplify Community Picks ordering

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/community/CommunityFeaturedSnapshotService.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/community/CommunityFeaturedSnapshotService.java
@@ -107,6 +107,15 @@ public class CommunityFeaturedSnapshotService {
     return new FeaturedPage(page, total);
   }
 
+  public List<FeaturedItem> all(String filter, String mediaFilter) {
+    maybeRefreshAsyncOnDemand();
+    Snapshot current = snapshot.get();
+    String normalizedFilter = normalizeFilter(filter);
+    String normalizedMediaFilter = normalizeMediaFilter(mediaFilter);
+    String snapshotKey = snapshotKey(normalizedFilter, normalizedMediaFilter);
+    return List.copyOf(current.rankedByFilter().getOrDefault(snapshotKey, List.of()));
+  }
+
   public void onVotesUpdated() {
     invalidateResponseCacheAfterVote();
     voteRefreshPending.set(true);

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/CommunityContentApiResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/CommunityContentApiResource.java
@@ -71,60 +71,62 @@ public class CommunityContentApiResource {
     }
     long userVoteCount = userId == null || userId.isBlank() ? 0L : voteService.countVotesByUser(userId);
     List<ContentItemResponse> items;
-    int total;
-    if ("new".equals(view)) {
-      List<CommunityContentItem> all =
-          applyMediaFilter(applyFilter(contentService.allItems(), filter), mediaFilter);
-      List<CommunityContentItem> ordered = all;
-      total = ordered.size();
-      List<CommunityContentItem> pageItems = paginateItems(ordered, limit, offset);
-      List<String> pageIds = pageItems.stream().map(CommunityContentItem::id).toList();
-      Map<String, CommunityVoteAggregate> pageAggregates = voteService.getAggregates(pageIds, userId);
-      Instant now = Instant.now();
-      items =
-          pageItems.stream()
-              .map(
-                  item -> {
-                    CommunityVoteAggregate aggregate =
-                        pageAggregates.getOrDefault(item.id(), CommunityVoteAggregate.empty());
-                    double score =
-                        CommunityScoreCalculator.score(aggregate, item.createdAt(), now, decayEnabled);
-                    return toResponse(item, aggregate, score);
-                  })
-              .toList();
-    } else {
-      CommunityFeaturedSnapshotService.FeaturedPage featuredPage =
-          featuredSnapshotService.page(filter.apiValue, mediaFilter, limit, offset);
-      List<CommunityFeaturedSnapshotService.FeaturedItem> page = featuredPage.items();
-      total = featuredPage.total();
-      if (userId == null || userId.isBlank() || page.isEmpty()) {
-        items =
-            page.stream()
-                .map(item -> toResponse(item.item(), item.aggregate(), item.score()))
-                .toList();
-      } else {
-        List<String> pageIds =
-            page.stream().map(item -> item.item().id()).toList();
-        Map<String, CommunityVoteAggregate> userAggregates =
-            voteService.getAggregates(pageIds, userId);
-        items =
-            page.stream()
-                .map(
-                    item -> {
-                      CommunityVoteType myVote =
-                          userAggregates.getOrDefault(item.item().id(), CommunityVoteAggregate.empty()).myVote();
-                      CommunityVoteAggregate base = item.aggregate();
-                      CommunityVoteAggregate aggregate =
-                          new CommunityVoteAggregate(
-                              base.recommended(),
-                              base.mustSee(),
-                              base.notForMe(),
-                              myVote);
-                      return toResponse(item.item(), aggregate, item.score());
-                    })
-                .toList();
+    List<CommunityContentItem> filtered =
+        applyMediaFilter(applyFilter(contentService.allItems(), filter), mediaFilter);
+    List<CommunityFeaturedSnapshotService.FeaturedItem> featuredItems =
+        featuredSnapshotService.all(filter.apiValue, mediaFilter);
+    Map<String, CommunityFeaturedSnapshotService.FeaturedItem> featuredById =
+        featuredItems.stream()
+            .filter(item -> item.item() != null && item.item().id() != null)
+            .collect(
+                java.util.stream.Collectors.toMap(
+                    item -> item.item().id(),
+                    item -> item,
+                    (left, right) -> left,
+                    java.util.LinkedHashMap::new));
+    java.util.Set<String> featuredIds = featuredById.keySet();
+    List<CommunityContentItem> ordered = new java.util.ArrayList<>(filtered.size());
+    ordered.addAll(
+        featuredItems.stream()
+            .map(CommunityFeaturedSnapshotService.FeaturedItem::item)
+            .filter(item -> item != null)
+            .toList());
+    for (CommunityContentItem item : filtered) {
+      if (item == null || item.id() == null || featuredIds.contains(item.id())) {
+        continue;
       }
+      ordered.add(item);
     }
+    int total = ordered.size();
+    List<CommunityContentItem> pageItems = paginateItems(ordered, limit, offset);
+    List<String> pageIds = pageItems.stream().map(CommunityContentItem::id).toList();
+    Map<String, CommunityVoteAggregate> pageAggregates =
+        userId == null || userId.isBlank() ? Map.of() : voteService.getAggregates(pageIds, userId);
+    Instant now = Instant.now();
+    items =
+        pageItems.stream()
+            .map(
+                item -> {
+                  CommunityFeaturedSnapshotService.FeaturedItem featuredItem = featuredById.get(item.id());
+                  if (featuredItem != null) {
+                    CommunityVoteAggregate base = featuredItem.aggregate();
+                    CommunityVoteAggregate userAggregate =
+                        pageAggregates.getOrDefault(item.id(), CommunityVoteAggregate.empty());
+                    CommunityVoteAggregate aggregate =
+                        new CommunityVoteAggregate(
+                            base.recommended(),
+                            base.mustSee(),
+                            base.notForMe(),
+                            userAggregate.myVote());
+                    return toResponse(item, aggregate, featuredItem.score());
+                  }
+                  CommunityVoteAggregate aggregate =
+                      pageAggregates.getOrDefault(item.id(), CommunityVoteAggregate.empty());
+                  double score =
+                      CommunityScoreCalculator.score(aggregate, item.createdAt(), now, decayEnabled);
+                  return toResponse(item, aggregate, score);
+                })
+            .toList();
 
     CommunityContentMetrics metrics = contentService.metrics();
     CacheMeta cacheMeta =
@@ -222,7 +224,7 @@ public class CommunityContentApiResource {
     }
     String normalized = raw.trim().toLowerCase(Locale.ROOT);
     if ("new".equals(normalized) || "featured".equals(normalized)) {
-      return normalized;
+      return "featured";
     }
     return "featured";
   }

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/CommunityResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/CommunityResource.java
@@ -39,7 +39,7 @@ public class CommunityResource {
   @CheckedTemplate
   static class Templates {
     static native TemplateInstance community(
-        boolean isAuthenticated, String initialView, int homedirUsers, int githubUsers, int discordUsers);
+        boolean isAuthenticated, int homedirUsers, int githubUsers, int discordUsers);
   }
 
   @GET
@@ -98,7 +98,6 @@ public class CommunityResource {
       io.vertx.ext.web.RoutingContext context) {
     boolean authenticated = isAuthenticated();
     boolean isAdmin = AdminUtils.isAdmin(identity);
-    String initialView = normalizeView(viewParam);
     String initialFilter = normalizeFilter(filterParam);
     String initialMedia = CommunityContentMedia.normalizeFilter(mediaParam);
     String activeSubmenu = forcedSubmenu != null && !forcedSubmenu.isBlank()
@@ -116,12 +115,8 @@ public class CommunityResource {
         });
     var summary = boardService.summary();
     int discordOnlineUsers = summary.discordOnlineUsers() != null ? summary.discordOnlineUsers() : 0;
-    TemplateInstance template = Templates.community(
-        authenticated,
-        initialView,
-        summary.homedirUsers(),
-        summary.githubUsers(),
-        summary.discordUsers());
+    TemplateInstance template =
+        Templates.community(authenticated, summary.homedirUsers(), summary.githubUsers(), summary.discordUsers());
     return TemplateLocaleUtil.apply(template, localeCookie)
         .data("activePage", "comunidad")
         .data("mainClass", "community-ultra-lite")
@@ -174,17 +169,6 @@ public class CommunityResource {
       return normalized;
     }
     return "all";
-  }
-
-  private String normalizeView(String viewParam) {
-    if (viewParam == null || viewParam.isBlank()) {
-      return "featured";
-    }
-    String normalized = viewParam.trim().toLowerCase();
-    if ("featured".equals(normalized) || "new".equals(normalized)) {
-      return normalized;
-    }
-    return "featured";
   }
 
   private Optional<String> currentUserName() {

--- a/quarkus-app/src/main/resources/templates/CommunityResource/community.html
+++ b/quarkus-app/src/main/resources/templates/CommunityResource/community.html
@@ -24,7 +24,7 @@
   <section class="page-grid">
     {#if activeCommunitySubmenu == 'picks'}
     <div class="section-card events-full-width community-shell-card">
-      <div id="community-content-root" data-authenticated="{isAuthenticated}" data-page-size="10" data-cache-ttl-ms="60000" data-ultra-lite="true" data-initial-view="{initialView}" data-initial-filter="{initialFilter ?: 'all'}" data-initial-media="{initialMedia ?: 'all'}"
+      <div id="community-content-root" data-authenticated="{isAuthenticated}" data-page-size="10" data-cache-ttl-ms="60000" data-ultra-lite="true" data-initial-filter="{initialFilter ?: 'all'}" data-initial-media="{initialMedia ?: 'all'}"
         data-i18n-empty-filtered="{i18n:community_js_empty_filtered}"
         data-i18n-empty-generic="{i18n:community_js_empty_generic}"
         data-i18n-items-unit="{i18n:community_js_items_unit}"
@@ -117,15 +117,6 @@
 
         <div class="community-controls-panel">
           <div class="community-controls-top">
-            <div class="community-view-row" role="tablist" aria-label="Community view">
-              <button type="button" class="btn-primary community-view-btn community-tab" data-view="featured">
-                {i18n:community_view_featured}
-              </button>
-              <button type="button" class="btn-primary community-view-btn community-tab" data-view="new">
-                {i18n:community_view_new}
-              </button>
-            </div>
-
             <div class="community-filter-row" role="group" aria-label="Community source filter">
               <button type="button" class="btn-primary community-filter-btn community-filter" data-filter="all">
                 {i18n:community_filter_all}

--- a/quarkus-app/src/test/java/com/scanales/homedir/community/CommunityContentApiResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/community/CommunityContentApiResourceTest.java
@@ -2,13 +2,15 @@ package com.scanales.homedir.community;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import jakarta.inject.Inject;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,8 +39,9 @@ public class CommunityContentApiResourceTest {
       }
     }
     Files.createDirectories(dir);
+    Instant now = Instant.now();
     Files.writeString(
-        dir.resolve("20260207-java-item-1.yml"),
+        dir.resolve("20260613-java-item-1.yml"),
         """
         id: java-item-1
         title: "Java y Quarkus"
@@ -46,50 +49,51 @@ public class CommunityContentApiResourceTest {
         summary: "Resumen de ejemplo para Quarkus."
         source: "example.org"
         thumbnail_url: "https://cdn.example.org/java-cover.png"
-        created_at: "2026-02-07T10:00:00Z"
+        created_at: "%s"
         media_type: "article_blog"
         tags: ["java","quarkus"]
-        """);
+        """.formatted(iso(now.minus(Duration.ofDays(1)))));
     Files.writeString(
-        dir.resolve("20260206-devops-item-2.yml"),
+        dir.resolve("20260510-devops-item-2.yml"),
         """
         id: devops-item-2
         title: "DevOps baseline"
         url: "https://example.org/devops"
         summary: "Resumen devops."
         source: "example.org"
-        created_at: "2026-02-06T10:00:00Z"
+        created_at: "%s"
         media_type: "podcast"
-        """);
+        """.formatted(iso(now.minus(Duration.ofDays(21)))));
     Files.writeString(
-        dir.resolve("20260205-member-item-3.yml"),
+        dir.resolve("20260509-member-item-3.yml"),
         """
         id: submission-member-item-3
         title: "Aporte de comunidad"
         url: "https://community.example.org/post"
         summary: "Resumen desde miembros."
         source: "Community member"
-        created_at: "2026-02-05T10:00:00Z"
+        created_at: "%s"
         media_type: "video_story"
         tags: ["community"]
-        """);
+        """.formatted(iso(now.minus(Duration.ofDays(30)))));
     contentService.refreshNowForTests();
     featuredSnapshotService.refreshNowForTests();
   }
 
   @Test
-  void listsCuratedContent() {
+  void featuredContentAppearsBeforeTheRestOfTheFeed() {
     given()
         .accept("application/json")
         .when()
-        .get("/api/community/content?view=new&limit=10&offset=0")
+        .get("/api/community/content?limit=10&offset=0")
         .then()
         .statusCode(200)
-        .body("view", equalTo("new"))
+        .body("view", equalTo("featured"))
         .body("filter", equalTo("all"))
         .body("media", equalTo("all"))
-        .body("total", greaterThanOrEqualTo(3))
+        .body("total", equalTo(3))
         .body("items[0].id", equalTo("java-item-1"))
+        .body("items[1].id", equalTo("devops-item-2"))
         .body("items[0].thumbnail_url", equalTo("https://cdn.example.org/java-cover.png"));
   }
 
@@ -98,7 +102,7 @@ public class CommunityContentApiResourceTest {
     given()
         .accept("application/json")
         .when()
-        .get("/api/community/content?view=new&limit=50&offset=0")
+        .get("/api/community/content?limit=50&offset=0")
         .then()
         .statusCode(200)
         .body("limit", equalTo(10));
@@ -187,7 +191,7 @@ public class CommunityContentApiResourceTest {
     given()
         .accept("application/json")
         .when()
-        .get("/api/community/content?view=featured&limit=10&offset=0")
+        .get("/api/community/content?limit=10&offset=0")
         .then()
         .statusCode(200)
         .body("items.find { it.id == 'java-item-1' }.vote_counts.recommended", equalTo(0));
@@ -204,7 +208,7 @@ public class CommunityContentApiResourceTest {
     given()
         .accept("application/json")
         .when()
-        .get("/api/community/content?view=featured&limit=10&offset=0")
+        .get("/api/community/content?limit=10&offset=0")
         .then()
         .statusCode(200)
         .body("items.find { it.id == 'java-item-1' }.vote_counts.recommended", equalTo(1))
@@ -233,9 +237,13 @@ public class CommunityContentApiResourceTest {
     given()
         .accept("application/json")
         .when()
-        .get("/api/community/content?view=featured&limit=10&offset=0")
+        .get("/api/community/content?limit=10&offset=0")
         .then()
         .statusCode(200)
         .body("user_vote_count", equalTo(2));
+  }
+
+  private String iso(Instant instant) {
+    return DateTimeFormatter.ISO_INSTANT.format(instant);
   }
 }

--- a/quarkus-app/src/test/java/com/scanales/homedir/community/CommunitySubmissionApiResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/community/CommunitySubmissionApiResourceTest.java
@@ -237,7 +237,7 @@ public class CommunitySubmissionApiResourceTest {
           given()
               .accept("application/json")
               .when()
-              .get("/api/community/content?view=new&limit=30&offset=0")
+              .get("/api/community/content?limit=30&offset=0")
               .then()
               .statusCode(200)
               .extract()

--- a/quarkus-app/src/test/java/com/scanales/homedir/public_/PublicExperienceSmokeTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/public_/PublicExperienceSmokeTest.java
@@ -34,6 +34,8 @@ public class PublicExperienceSmokeTest {
     String html = fetchHtmlWithBudget("/comunidad", COMMUNITY_HTML_BUDGET_BYTES);
     assertTrue(html.contains("window.userAuthenticated"));
     assertTrue(html.contains("data-login-return-current=\"true\""));
+    assertFalse(html.contains("data-view=\"featured\""));
+    assertFalse(html.contains("data-view=\"new\""));
     assertFalse(html.contains("canva-theme-v2.css"));
     assertFalse(html.contains("/js/retro-theme.js"));
     assertRuntimeBootstrapGuardrails(html);


### PR DESCRIPTION
## What changed
- Removed the visible `featured/new` toggle from Community Picks.
- Kept `all / internet / members` as the only visible source filter.
- Made featured content an ordering behavior: featured items are shown first, then the rest of the feed.
- Kept `all` selected by default.

## Why
The previous UI mixed a presentation mode with a real source filter, which made the page harder to understand.

## Validation
- `git diff --check`
- `mvnw.cmd "-Dtest=CommunityContentApiResourceTest,CommunitySubmissionApiResourceTest,PublicExperienceSmokeTest" test` from `quarkus-app` with `JAVA_TOOL_OPTIONS=--add-opens=java.base/java.lang=ALL-UNNAMED`

## Issue
Closes #783