### PR TITLE
[codex] require issue scope lock in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_en.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_en.md
@@ -1,6 +1,10 @@
 ## Summary
 Briefly describe the problem and the solution.
 
+## Issue
+- Linked issue: `#`
+- Scope lock: [ ] This PR stays within the linked issue and any new work is split into a new issue and PR.
+
 ## Why
 Rationale behind this change.
 


### PR DESCRIPTION
## What changed
- Added an `Issue` section to the PR template.
- The template now requires authors to declare that the PR stays within the linked issue.
- The template explicitly instructs contributors to split new work into a new issue and PR.

## Why
- The process needs a visible gate at PR creation time so scope drift is harder to miss.
- This complements the canonical ADEV rule with a repository-local enforcement point.

## Scope
- In: PR template only.
- Out: Product functionality.

## Validation
- `git diff --check`

## Issue
- Closes #787