### PR TITLE
feat(r3): add skip-to-content anchor for a11y

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
@@ -6432,4 +6432,7 @@ public interface AppMessages {
     @Message("Community and system signals combine to surface useful contributions.")
     String reputation_hub_how_quality_desc();
 
+    @Message("Skip to content")
+    String skip_to_content();
+
 }

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -6215,3 +6215,20 @@ footer {
     flex-wrap: wrap;
   }
 }
+
+/* Skip-to-content (WCAG 2.4.1 Bypass Blocks) */
+.skip-link {
+  position: absolute;
+  left: 0;
+  top: -100%;
+  z-index: var(--z-sticky, 1100);
+  padding: 0.5rem 1rem;
+  background: var(--color-primary, #2563eb);
+  color: #ffffff;
+  text-decoration: none;
+  font-weight: 600;
+  border-radius: 0 0 var(--radius-sm, 6px) 0;
+}
+.skip-link:focus {
+  top: 0;
+}

--- a/quarkus-app/src/main/resources/messages/i18n.properties
+++ b/quarkus-app/src/main/resources/messages/i18n.properties
@@ -54,3 +54,4 @@ public_profile_discord_badge=Discord connected
 events_cfp_eyebrow=Events · Community Speakers
 home_priority_cfp_title=DevOpsDays Santiago Call for Papers
 home_priority_cfp_desc=Submit a talk proposal for the event program.
+skip_to_content=Skip to content

--- a/quarkus-app/src/main/resources/messages/i18n_es.properties
+++ b/quarkus-app/src/main/resources/messages/i18n_es.properties
@@ -1337,3 +1337,4 @@ reputation_hub_how_consistency_title=La consistencia importa
 reputation_hub_how_consistency_desc=Las ventanas semanales y mensuales premian participación sostenida, no solo historial.
 reputation_hub_how_quality_title=Reconocimiento contextual
 reputation_hub_how_quality_desc=Se combinan señales comunitarias y del sistema para destacar aportes útiles.
+skip_to_content=Ir al contenido

--- a/quarkus-app/src/main/resources/templates/layout/main.html
+++ b/quarkus-app/src/main/resources/templates/layout/main.html
@@ -61,6 +61,8 @@
   data-i18n-app-no-events="{i18n:app_js_no_events}">
   {#include fragments/floating-shapes.html /}
 
+  <a href="#main-content" class="skip-link" aria-label="{i18n:skip_to_content}">{i18n:skip_to_content}</a>
+
   <div class="app-container">
     {#if noNav != true}
     {#include fragments/header /}


### PR DESCRIPTION
## Resumen

Agrega un enlace de salto al contenido (`skip-link`) como primer elemento enfocable en `layout/main.html` con estilos CSS ocultos hasta focus. Cumple WCAG 2.4.1 (Bypass Blocks).

## Por qué

Usuarios de teclado y lectores de pantalla necesitan poder saltar la navegación repetitiva para ir directo al contenido principal. Sin el skip-link, deben tabular por todos los enlaces del nav antes de llegar al main.

## Cambios

- `main.html`: `<a href="#main-content" class="skip-link">` antes del `app-container`
- `AppMessages.java`: método `skip_to_content()` con `@Message("Skip to content")`
- `i18n.properties`: `skip_to_content=Skip to content`
- `i18n_es.properties`: `skip_to_content=Ir al contenido`
- `homedir.css`: estilos `.skip-link` — oculto (`top: -100%`) hasta focus (`top: 0`)

## Scope in

- 1 línea HTML + 2 i18n keys + 1 método Java + 15 líneas CSS
- Sin hardcodeos, sin dependencias nuevas

## Scope out

- No se modifica base.html (ya será eliminado en PR #759)
- No se agregan tests (cambio de 1 línea visible, verificación manual)

## Validación

- [x] Build exitoso
- [ ] Verificación en navegador: cargar home, presionar Tab → debe aparecer "Skip to content", Enter → salta a #main-content

## Plan de Producción

- **Verificación**: Tab en home page, confirmar skip-link visible en focus y funcional.
- **Rollback**: Revertir este PR.

## Estado Operacional

- [x] auto-merge habilitado
- [x] Workspace sincronizado