### PR TITLE
fix: moderation note visibility in CFP queue + Discord OAuth error handling (#816, #815)

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
@@ -1612,6 +1612,9 @@ public interface AppMessages {
     @Message("Content impact")
     String events_cfp_admin_rating_impact();
 
+    @Message("Moderation note")
+    String events_cfp_admin_moderation_note();
+
     @Message("Moderation note (optional)")
     String events_cfp_admin_note_placeholder();
 

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/DiscordLinkService.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/DiscordLinkService.java
@@ -156,8 +156,12 @@ public class DiscordLinkService {
           email,
           new UserProfile.DiscordAccount(
               user.id(), user.handle(), "https://discord.com/users/" + url(user.id()), user.avatarUrl(), Instant.now()));
-      gamificationService.award(userId, GamificationActivity.DISCORD_LINKED);
-      boardService.requestRefresh("discord-oauth-claim");
+      try {
+        gamificationService.award(userId, GamificationActivity.DISCORD_LINKED);
+        boardService.requestRefresh("discord-oauth-claim");
+      } catch (Exception e) {
+        LOG.warnf("Discord post-link operations failed (link already saved): %s", e.getMessage());
+      }
       return redirectWithParams(target, "discordLinked", "1");
     } catch (Exception e) {
       LOG.warnf("Discord OAuth callback failed: %s", e.getMessage());

--- a/quarkus-app/src/main/resources/com/scanales/homedir/config/AppMessages_es.properties
+++ b/quarkus-app/src/main/resources/com/scanales/homedir/config/AppMessages_es.properties
@@ -950,6 +950,7 @@ events_cfp_admin_moderation_page_title=CFP Moderación · {event}
 events_cfp_admin_nav_edit_event=Editar evento
 events_cfp_admin_nav_public_cfp=Público CFP
 events_cfp_admin_not_available=n / A
+events_cfp_admin_moderation_note=Nota de moderación
 events_cfp_admin_note_placeholder=Nota de moderación (opcional)
 events_cfp_admin_promote_success=Catalogado:
 events_cfp_admin_proposed_by=Propuesto por:

--- a/quarkus-app/src/main/resources/i18n.properties
+++ b/quarkus-app/src/main/resources/i18n.properties
@@ -204,6 +204,7 @@ events_cfp_admin_submission_not_available=N/A
 events_cfp_admin_rating_technical=Technical detail
 events_cfp_admin_rating_narrative=Narrative
 events_cfp_admin_rating_impact=Content impact
+events_cfp_admin_moderation_note=Moderation note
 events_cfp_admin_note_placeholder=Moderation note (optional)
 events_cfp_admin_error_stale_submission=Another moderator already updated this proposal. Refresh the queue.
 events_cfp_admin_error_reject_note_required=Add a moderation note before rejecting this proposal.

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -1019,6 +1019,7 @@ events_cfp_admin_submission_not_available=N/A
 events_cfp_admin_rating_technical=Detalle tecnico
 events_cfp_admin_rating_narrative=Narrativa
 events_cfp_admin_rating_impact=Impacto
+events_cfp_admin_moderation_note=Nota de moderacion
 events_cfp_admin_note_placeholder=Nota de moderacion (opcional)
 events_cfp_admin_error_stale_submission=Otro moderador ya actualizo esta propuesta. Recarga la cola.
 events_cfp_admin_error_reject_note_required=Agrega una nota de moderacion antes de rechazar esta propuesta.

--- a/quarkus-app/src/main/resources/templates/AdminEventCfpResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventCfpResource/detail.html
@@ -574,7 +574,7 @@
           + '<div class="card cfp-detail-section"><h3>' + escapeHtml(i18n.sectionReview) + '</h3>'
           + '<p class="form-hint" style="margin-top: 0.35rem;">' + escapeHtml(i18n.reviewDesc) + '</p>'
           + '<div id="cfpReviewGrid" class="cfp-review-grid"></div>'
-          + '<input id="cfpModerationNote" type="text" class="form-input cfp-detail-note" placeholder="' + escapeHtml(i18n.moderationNotePlaceholder) + '" value="' + escapeHtml(item.moderation_note || "") + '">'
+          + '<textarea id="cfpModerationNote" class="form-input cfp-detail-note" rows="2" maxlength="500" placeholder="' + escapeHtml(i18n.moderationNotePlaceholder) + '">' + escapeHtml(item.moderation_note || "") + '</textarea>'
           + '<div class="cfp-detail-actions" id="cfpDetailActions"></div></div>';
 
       const reviewGrid = document.getElementById("cfpReviewGrid");

--- a/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
@@ -388,7 +388,8 @@
       reviewerRemoved: "{i18n:events_cfp_admin_reviewers_removed}",
       reviewerError: "{i18n:events_cfp_admin_reviewers_error}",
       reviewerEmailRequired: "{i18n:events_cfp_admin_reviewers_email_required}",
-      reviewerRemove: "{i18n:events_cfp_admin_reviewers_remove}"
+      reviewerRemove: "{i18n:events_cfp_admin_reviewers_remove}",
+      moderationNote: "{i18n:events_cfp_admin_moderation_note}"
     };
     const pageSize = 20;
     let activeStatus = "under_review";
@@ -843,7 +844,7 @@
       if (item.moderation_note) {
         const noteLine = document.createElement("p");
         noteLine.className = "cfp-admin-meta";
-        noteLine.textContent = "Nota: " + item.moderation_note;
+        noteLine.textContent = i18n.moderationNote + ": " + item.moderation_note;
         article.appendChild(noteLine);
       }
 

--- a/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
@@ -840,6 +840,13 @@
         article.appendChild(row(i18n.deliveryTitle + ": " + deliveryParts.join(" · ")));
       }
 
+      if (item.moderation_note) {
+        const noteLine = document.createElement("p");
+        noteLine.className = "cfp-admin-meta";
+        noteLine.textContent = "Nota: " + item.moderation_note;
+        article.appendChild(noteLine);
+      }
+
       const actions = document.createElement("div");
       actions.className = "cfp-admin-actions";
 


### PR DESCRIPTION
## Summary
Two independent fixes in this branch:

### 1. #816 — Moderation note not visible in CFP queue
The note was persisted correctly by `CfpSubmissionService.updateStatus()`, but `buildSubmissionCard` in `moderation.html` never rendered `item.moderation_note`. Admins added a note, returned to the queue, saw no evidence, and concluded the note didn't persist.

**Fix:** Show `item.moderation_note` on queue cards when present, using existing `cfp-admin-meta` style. Also swapped `<input type="text">` to `<textarea rows="2" maxlength="500">` for longer notes.

### 2. #815 — Discord connection shows error despite successful link
After `profiles.linkDiscord()` persisted the account, `gamificationService.award()` or `boardService.requestRefresh()` could throw. The single catch block then returned `discordError=unexpected`, making the user think the connection failed — even though the Discord account was already linked. Data only appeared after manual refresh.

**Fix:** Wrapped post-link operations in their own try-catch so they don't break the success redirect.

## Issues
- Linked issues: #816, #815
- Scope lock: [x] This PR stays within the linked issues.

## Scope
- In: Moderation note display on queue cards; textarea for notes; try-catch around Discord post-link ops
- Out: Backend note persistence logic is unchanged (was already correct)

## Validation
- [x] Local build and tests passed (CfpSubmissionServiceTest: 23/23; note persistence confirmed)
- [x] UI/UX: note renders with existing `cfp-admin-meta` CSS class
- [ ] CodeQL/Sanitization preflight (Rule #24) — pending CI

## Production Plan
- Verification: Open CFP submission with a note → visible on queue card; Link Discord → success without error
- Rollback: revert commits `c78376a0` and `265a7d44`

## Operational Status
- [ ] auto-merge enabled (Rule #32)
- [ ] Workspace synced (Rule #29)