### PR TITLE
chore(ci): add workflow_dispatch trigger to PR Validation workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch` trigger to the PR Validation workflow so it can be manually triggered when needed.

## Why
`quality-gates.yml` already has `workflow_dispatch`, but `pr-check.yml` was missing it. This aligns both workflows and allows manual PR Validation runs.