### PR TITLE
ci: skip Quality Gates and PR Validation for docs-only changes

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
     types: [opened, reopened, synchronize, ready_for_review]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
     types: [opened, reopened, synchronize, ready_for_review]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
   push:
     branches: [ main ]
   workflow_dispatch:


### PR DESCRIPTION
Adds paths-ignore for docs/** and **.md to pr-check.yml and quality-gates.yml workflows. This prevents CI from running on documentation-only PRs, reducing unnecessary build minutes.

Split from #894 which also included an unrelated i18n refactoring.