### PR TITLE
fix(deploy): restore VPS_* fallback in release workflow env vars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,12 @@ jobs:
       contents: write
       packages: write
     env:
-      DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST }}
-      DEPLOY_USER: ${{ vars.DEPLOY_SSH_USER }}
-      DEPLOY_PORT: ${{ vars.DEPLOY_SSH_PORT }}
+      DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST || vars.VPS_HOST }}
+      DEPLOY_USER: ${{ vars.DEPLOY_SSH_USER || vars.VPS_USER }}
+      DEPLOY_PORT: ${{ vars.DEPLOY_SSH_PORT || vars.VPS_PORT }}
       DEPLOY_COMMAND: ${{ vars.DEPLOY_SSH_COMMAND }}
       HEALTHCHECK_URL: ${{ vars.DEPLOY_HEALTHCHECK_URL }}
-      DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+      DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY || secrets.VPS_SSH_KEY }}
       DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
       DEPLOY_SSH_STRICT_HOST_KEY_CHECKING: ${{ vars.DEPLOY_SSH_STRICT_HOST_KEY_CHECKING }}
 


### PR DESCRIPTION
## Descripción

Restaura el fallback a variables `VPS_*` (`VPS_HOST`, `VPS_USER`, `VPS_PORT`, `VPS_SSH_KEY`) en el job de release cuando `DEPLOY_SSH_*` no está configurado.

## Problema

El PR #893 eliminó los fallbacks legacy, dejando el workflow así:

```yaml
DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST }}
```

Pero `DEPLOY_SSH_HOST`, `DEPLOY_SSH_USER`, `DEPLOY_SSH_PORT`, `DEPLOY_SSH_PRIVATE_KEY` **no existen** como variables/secrets en GitHub Actions. Las únicas configuradas son `VPS_HOST`, `VPS_USER`, `VPS_PORT`, `VPS_SSH_KEY`.

Esto causa que el paso `Resolve deploy configuration` determine `enabled=false` y el deploy SSH nunca se ejecute.

## Solución

Usar operador `||` para fallback cuando `DEPLOY_SSH_*` no existe:

```yaml
DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST || vars.VPS_HOST }}
```

Si `vars.DEPLOY_SSH_HOST` es undefined/falsy, cae a `vars.VPS_HOST`.

## Cambios

```diff
- DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST }}
- DEPLOY_USER: ${{ vars.DEPLOY_SSH_USER }}
- DEPLOY_PORT: ${{ vars.DEPLOY_SSH_PORT }}
- DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+ DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST || vars.VPS_HOST }}
+ DEPLOY_USER: ${{ vars.DEPLOY_SSH_USER || vars.VPS_USER }}
+ DEPLOY_PORT: ${{ vars.DEPLOY_SSH_PORT || vars.VPS_PORT }}
+ DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY || secrets.VPS_SSH_KEY }}
```

## Closes

Closes #897

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review tooling configuration to enhance development workflow
  * Improved deployment environment variable fallback handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->