### PR TITLE
fix(deploy): simplify GitHub Actions env var expressions for SSH deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,12 @@ jobs:
       contents: write
       packages: write
     env:
-      DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST != '' && vars.DEPLOY_SSH_HOST || vars.VPS_HOST }}
-      DEPLOY_USER: ${{ vars.DEPLOY_SSH_USER != '' && vars.DEPLOY_SSH_USER || vars.VPS_USER }}
-      DEPLOY_PORT: ${{ vars.DEPLOY_SSH_PORT != '' && vars.DEPLOY_SSH_PORT || vars.VPS_PORT }}
+      DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST || vars.VPS_HOST }}
+      DEPLOY_USER: ${{ vars.DEPLOY_SSH_USER || vars.VPS_USER }}
+      DEPLOY_PORT: ${{ vars.DEPLOY_SSH_PORT || vars.VPS_PORT }}
       DEPLOY_COMMAND: ${{ vars.DEPLOY_SSH_COMMAND }}
       HEALTHCHECK_URL: ${{ vars.DEPLOY_HEALTHCHECK_URL }}
-      DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY != '' && secrets.DEPLOY_SSH_PRIVATE_KEY || secrets.VPS_SSH_KEY }}
+      DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY || secrets.VPS_SSH_KEY }}
       DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
       DEPLOY_SSH_STRICT_HOST_KEY_CHECKING: ${{ vars.DEPLOY_SSH_STRICT_HOST_KEY_CHECKING }}
 


### PR DESCRIPTION
Closes #897

## Problem
Production VPS (homedir.opensourcesantiago.io) stopped receiving deployments after v3.579.0, while GitHub releases continued through v3.580.3. The release workflow's SSH deploy step was skipped because DEPLOY_HOST/USER/PORT/DEPLOY_SSH_PRIVATE_KEY resolved to empty strings.

## Root Cause
The conditional expression syntax `${{ vars.X != '' && vars.X || vars.Y }}` in release.yml was not properly evaluating fallbacks to VPS_* variables (which DO exist: VPS_HOST=72.60.141.165, VPS_USER=root, VPS_PORT=22, VPS_SSH_KEY=configured).

## Solution
Simplified expressions to use direct `||` operator:
```yaml
DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST || vars.VPS_HOST }}
DEPLOY_USER: ${{ vars.DEPLOY_SSH_USER || vars.VPS_USER }}
DEPLOY_PORT: ${{ vars.DEPLOY_SSH_PORT || vars.VPS_PORT }}
DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY || secrets.VPS_SSH_KEY }}
```

This matches GitHub Actions expression semantics where both empty strings and undefined variables trigger the `||` fallback correctly.

## Validation
- Changed file: `.github/workflows/release.yml` (lines 33-38)
- Scope: narrow fix, no other workflow changes
- Next step: merge → trigger next push to main → observe production deploy succeeds
- Expected: homedir.opensourcesantiago.io updates to latest release tag

## Test plan
- [ ] Merge this PR
- [ ] Next push to main triggers release workflow
- [ ] Verify "Resolve deploy configuration" step shows enabled=true
- [ ] Verify SSH deploy executes (no skip)
- [ ] Verify production healthcheck passes
- [ ] Confirm homedir.opensourcesantiago.io shows latest version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimización de la lógica de configuración de variables de entorno en el flujo de despliegue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->