### PR TITLE
fix(deploy): correct SSH variable fallback in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,12 @@ jobs:
       contents: write
       packages: write
     env:
-      DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST != '' && vars.DEPLOY_SSH_HOST || vars.VPS_HOST }}
-      DEPLOY_USER: ${{ vars.DEPLOY_SSH_USER != '' && vars.DEPLOY_SSH_USER || vars.VPS_USER }}
-      DEPLOY_PORT: ${{ vars.DEPLOY_SSH_PORT != '' && vars.DEPLOY_SSH_PORT || vars.VPS_PORT }}
+      DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST || vars.VPS_HOST }}
+      DEPLOY_USER: ${{ vars.DEPLOY_SSH_USER || vars.VPS_USER }}
+      DEPLOY_PORT: ${{ vars.DEPLOY_SSH_PORT || vars.VPS_PORT }}
       DEPLOY_COMMAND: ${{ vars.DEPLOY_SSH_COMMAND }}
       HEALTHCHECK_URL: ${{ vars.DEPLOY_HEALTHCHECK_URL }}
-      DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY != '' && secrets.DEPLOY_SSH_PRIVATE_KEY || secrets.VPS_SSH_KEY }}
+      DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY || secrets.VPS_SSH_KEY }}
       DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
       DEPLOY_SSH_STRICT_HOST_KEY_CHECKING: ${{ vars.DEPLOY_SSH_STRICT_HOST_KEY_CHECKING }}
 


### PR DESCRIPTION
Closes #897

## Problem

The production VPS deployment was failing because environment variables in the release workflow were resolving to empty strings. The complex ternary expressions `${{ vars.X != '' && vars.X || vars.Y }}` were not correctly falling back to VPS_* variables even though they exist.

## Solution

Simplified the fallback expressions from `!= '' && X || Y` to just `X || Y`, which is the correct syntax for GitHub Actions expression fallback.

Changed:
- `DEPLOY_HOST`: `vars.DEPLOY_SSH_HOST || vars.VPS_HOST`
- `DEPLOY_USER`: `vars.DEPLOY_SSH_USER || vars.VPS_USER`  
- `DEPLOY_PORT`: `vars.DEPLOY_SSH_PORT || vars.VPS_PORT`
- `DEPLOY_SSH_PRIVATE_KEY`: `secrets.DEPLOY_SSH_PRIVATE_KEY || secrets.VPS_SSH_KEY`

## Validation

- ✅ Verified VPS_HOST, VPS_USER, VPS_PORT exist in Actions variables
- ✅ Confirmed VPS_SSH_KEY exists as Actions secret
- ✅ Simplified expression is the recommended GitHub Actions pattern for fallbacks

## Expected Impact

After merge, the next release workflow should:
1. Correctly resolve DEPLOY_* env vars to VPS_* fallback values
2. Enable SSH deployment (deploy_config.enabled will be 'true')
3. Successfully execute "Deploy to VPS via SSH" step
4. Update production to latest release version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimización de la configuración del flujo de despliegue de producción para mejorar la resolución de variables de despliegue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->