### PR TITLE
fix(deploy): use VPS_* variables directly for SSH deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,12 @@ jobs:
       contents: write
       packages: write
     env:
-      DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST }}
-      DEPLOY_USER: ${{ vars.DEPLOY_SSH_USER }}
-      DEPLOY_PORT: ${{ vars.DEPLOY_SSH_PORT }}
+      DEPLOY_HOST: ${{ vars.VPS_HOST }}
+      DEPLOY_USER: ${{ vars.VPS_USER }}
+      DEPLOY_PORT: ${{ vars.VPS_PORT }}
       DEPLOY_COMMAND: ${{ vars.DEPLOY_SSH_COMMAND }}
       HEALTHCHECK_URL: ${{ vars.DEPLOY_HEALTHCHECK_URL }}
-      DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+      DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_KEY }}
       DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
       DEPLOY_SSH_STRICT_HOST_KEY_CHECKING: ${{ vars.DEPLOY_SSH_STRICT_HOST_KEY_CHECKING }}
 


### PR DESCRIPTION
Closes #897

## Problem
Production VPS was not receiving deployments for releases v3.580.0-v3.580.3. The SSH deploy step was skipped because `DEPLOY_HOST`, `DEPLOY_USER`, and `DEPLOY_SSH_PRIVATE_KEY` resolved to empty strings.

## Root Cause
The workflow referenced `DEPLOY_SSH_HOST`, `DEPLOY_SSH_USER`, `DEPLOY_SSH_PORT`, and `DEPLOY_SSH_PRIVATE_KEY` variables that don't exist in GitHub Actions settings.

## Solution
Changed to use the existing `VPS_*` variables directly:
- `DEPLOY_HOST`: `vars.VPS_HOST` (72.60.141.165)
- `DEPLOY_USER`: `vars.VPS_USER` (root)
- `DEPLOY_PORT`: `vars.VPS_PORT` (22)
- `DEPLOY_SSH_PRIVATE_KEY`: `secrets.VPS_SSH_KEY`

## Validation
Next release workflow will:
1. Resolve deploy configuration correctly (`enabled=true`)
2. Execute SSH deploy to VPS
3. Verify production healthcheck

## Changed Files
- `.github/workflows/release.yml`: Updated env vars to use VPS_* instead of non-existent DEPLOY_SSH_*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de lanzamiento

* **Chores**
  * Se actualizó la configuración del flujo de despliegue automático para utilizar nuevas referencias a variables y secretos del entorno de implementación.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->