### PR TITLE
docs: add root-level SECURITY.md with vulnerability disclosure process

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,97 @@
+# Security Policy
+
+Homedir takes the security of our users and contributors seriously. If you believe you've found a vulnerability, please follow the process below to help us fix it quickly and responsibly.
+
+---
+
+## Supported Versions (Major-only)
+
+We support **only the currently active major release line**. When a new major is released, all previous majors become **unsupported** (EOL) immediately.
+
+**Current active major: `2.x`**
+
+| Version | Supported |
+|--------:|-----------|
+| 2.x     | Active    |
+| < 2.x   | Unsupported |
+
+> This major-only policy keeps the project fast and secure in line with our trunk-based development approach.
+
+---
+
+## Reporting a Vulnerability
+
+**Please do not open a public Issue or Discussion for security problems.**
+
+Use one of these private channels:
+
+1. **GitHub – Private vulnerability report (preferred)**
+   Go to the repository **Security** tab → **Report a vulnerability** and follow the form.
+
+2. **Email**
+   Send details to **sergio.canales.e@gmail.com** with the subject:
+   `HOMEDIR SECURITY: <short title>`
+
+Please include (as applicable):
+- Affected versions (e.g., `2.2.1`)
+- Environment (local/Docker/Kubernetes/OpenShift)
+- Impact summary (what can an attacker do?)
+- Reproduction steps or proof-of-concept
+- Relevant logs/config (redact secrets)
+- Any known workarounds or mitigations
+
+---
+
+## Our Response & Timelines
+
+We aim for the following SLAs:
+
+- **Acknowledgement:** within **48 hours**
+- **Triage & initial assessment:** within **5 business days**
+- **Status updates:** at least **weekly** until resolution
+
+**Guideline targets** (aligned to our P0–P3 severity scale):
+
+| Severity | Target to Fix | Disclosure Window* |
+|---------|----------------|--------------------|
+| P0 (Critical) | ASAP, typically ≤ **7 days** | Coordinated, typically ≤ **30 days** |
+| P1 (High)     | Typically ≤ **14–21 days**   | Coordinated, typically ≤ **60 days** |
+| P2 (Medium)   | Next scheduled release       | Coordinated, typically ≤ **90 days** |
+| P3 (Low)      | As time permits              | Batched notes / next release         |
+
+\* We practice **coordinated disclosure** with the reporter.
+
+---
+
+## Disclosure & CVE
+
+- We will publish a **GitHub Security Advisory** with details, credits (if desired), and fixed versions.
+- When appropriate, we will request a **CVE ID** and reference it in the advisory and release notes.
+
+---
+
+## Safe Harbor for Good-Faith Research
+
+We do not pursue or support legal action for **good-faith security research** that:
+- Avoids privacy violations, service degradation, or data destruction/exfiltration
+- Respects rate limits and only uses your own accounts/data
+- Stops testing and reports immediately upon finding a vulnerability
+- Keeps details confidential until a fix is available and a coordinated disclosure is agreed
+
+Out-of-scope activities include social engineering, physical attacks, spam, and DDoS.
+
+---
+
+## Security Contact
+
+For general security questions or concerns that are not vulnerability reports:
+- Email: sergio.canales.e@gmail.com
+- GitHub Discussions: Use the [Security category](https://github.com/os-santiago/homedir/discussions/categories/security)
+
+---
+
+## Additional Resources
+
+- Full security documentation: [docs/en/SECURITY.md](docs/en/SECURITY.md)
+- Security endpoint matrix: [docs/security/endpoint-authorization-matrix.yaml](docs/security/endpoint-authorization-matrix.yaml)
+- Pre-commit secret scanning guide: [docs/guides/pre-commit-secret-scanning.md](docs/guides/pre-commit-secret-scanning.md)


### PR DESCRIPTION
Closes #926 (partial - first component)

## Summary
Adds GitHub-standard SECURITY.md file in repository root with comprehensive vulnerability disclosure process.

## Changes
- ✅ Created `SECURITY.md` in repository root
- ✅ Supported versions policy (major-only)
- ✅ Vulnerability reporting process (GitHub Security tab + email)
- ✅ Response SLAs and severity targets (P0-P3)
- ✅ Coordinated disclosure and CVE workflow
- ✅ Safe harbor for good-faith security research
- ✅ Security contact information
- ✅ Links to detailed security documentation

## Rationale
GitHub Security tab requires a SECURITY.md file in the repository root to enable private vulnerability reporting. This is a critical requirement for open-source projects to handle security issues responsibly.

## Testing
- [x] File created with proper markdown formatting
- [x] All links are valid relative paths
- [x] Follows existing security documentation in docs/en/SECURITY.md
- [x] Complies with GitHub security advisory standards

## Part of OSS Preparation
This is the first component of issue #926 - comprehensive open-source governance documentation. Following ADEV workflow, each component is delivered in a separate atomic PR.

## Next Steps (separate PRs)
- CODE_OF_CONDUCT.md
- CLA.md
- GOVERNANCE.md
- MAINTAINERS.md
- Enhanced CONTRIBUTING.md
- NOTICE file
- Copyright headers in source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentación

* Se agregó una política de seguridad integral que incluye versiones soportadas, canales privados para reportar vulnerabilidades, SLAs definidos por severidad, proceso de divulgación responsable y protección para investigadores de buena fe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->