### PR TITLE
docs: finalize Apache 2.0 LICENSE with copyright attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024-2026 Workspace OS Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
Updates the Apache 2.0 LICENSE file to include proper copyright attribution to "Workspace OS Contributors" for years 2024-2026, replacing the placeholder text.

## Changes
- Updated LICENSE copyright line from placeholder to: `Copyright 2024-2026 Workspace OS Contributors`

## Context
Part of issue #926 - preparing repository for public open-source launch with complete legal documentation and enterprise standards.

## Test Plan
- [x] Verified LICENSE file contains standard Apache 2.0 text
- [x] Confirmed copyright attribution is properly filled in
- [x] No code changes - documentation only

Related to #926

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Actualizado el aviso de copyright en la licencia con el nuevo período y propietario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->