### PR TITLE
docs(governance): add DoR/DoD policy (Closes #843)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_es.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_es.md
@@ -1,23 +1,48 @@
 ---
-name: Reporte de Error
+name: Reporte de Error (Español)
 about: Crea un reporte para ayudarnos a mejorar
-title: ''
-labels: error
+title: 'fix: [Breve descripción]'
+labels: 'type/bug,status/triage'
 assignees: ''
 ---
 
-**Descripción del error**
-Una descripción clara y concisa de cuál es el error.
+> **Antes de enviar:** Revisa [DoR para Bugs](https://github.com/os-santiago/homedir/blob/main/config/docs/governance/DEFINITION_OF_READY_DONE.md#bug-reports-typebug)
 
-**Pasos para reproducir**
-1. Ir a '...'
-2. Hacer clic en '...'
-3. Desplazarse hacia abajo hasta '...'
-4. Ver el error
+## Problema
+<!-- Descripción del error -->
 
-**Comportamiento esperado**
-Una descripción clara y concisa de lo que esperabas que sucediera.
+## Pasos para Reproducir
+1. [Paso 1]
+2. [Paso 2]
 
-**Entorno (Opcional)**
- - Versión de Java: [ej. 17]
- - Versión de Quarkus: [ej. 3.0]
+## Esperado vs Actual
+**Esperado:** [Qué debería pasar]  
+**Actual:** [Qué pasa]
+
+## Entorno
+- **SO:** [ej., Windows 11]
+- **Java:** [ej., 17] (si aplica)
+- **Quarkus:** [ej., 3.0] (si aplica)
+- **Versión:** [ej., 1.2.3]
+
+## Evidencia
+```
+[Error/log]
+```
+
+## Impacto
+- **Afectados:** [Usuarios]
+- **Severidad:** [Crítica/Mayor/Menor]
+- **Workaround:** [Sí/No]
+
+## Criterios de Aceptación
+- [ ] [Criterio 1]
+
+---
+
+## Definición de Hecho
+- [ ] Link al PR
+- [ ] Antes/después
+- [ ] Test
+- [ ] Verificación
+- [ ] Causa raíz

--- a/.github/ISSUE_TEMPLATE/feature_request_en.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_en.md
@@ -1,13 +1,37 @@
 ---
-name: Feature Request
+name: Feature Request (English)
 about: Suggest an idea for this project
-title: ''
-labels: enhancement
+title: 'feat: [Brief description]'
+labels: 'type/feature,status/triage'
 assignees: ''
 ---
 
-**Proposed Feature**
-A clear and concise description of the feature you want.
+> **Before submitting:** Review [DoR for Features](https://github.com/os-santiago/homedir/blob/main/config/docs/governance/DEFINITION_OF_READY_DONE.md#features-typefeature)
 
-**Use Case**
-Why is this feature useful? What problem does it solve?
+## User Story
+As a [user], I want [goal] so that [benefit].
+
+## Objective
+<!-- Feature purpose -->
+
+## Scope
+**In scope:** [What's included]  
+**Out of scope:** [What's not]
+
+## Success Metrics
+- [Metric 1]
+
+## Dependencies
+- [Prerequisite]
+
+## Acceptance Criteria
+- [ ] [Criterion 1]
+
+---
+
+## Definition of Done
+- [ ] PR link(s)
+- [ ] Demo
+- [ ] Test coverage ≥80%
+- [ ] Documentation
+- [ ] Metrics met

--- a/.github/ISSUE_TEMPLATE/feature_request_es.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_es.md
@@ -1,13 +1,37 @@
 ---
-name: Solicitud de Funcionalidad
+name: Solicitud de Funcionalidad (Español)
 about: Sugiere una idea para este proyecto
-title: ''
-labels: mejora
+title: 'feat: [Breve descripción]'
+labels: 'type/feature,status/triage'
 assignees: ''
 ---
 
-**Funcionalidad Propuesta**
-Una descripción clara y concisa de la funcionalidad que deseas.
+> **Antes de enviar:** Revisa [DoR para Features](https://github.com/os-santiago/homedir/blob/main/config/docs/governance/DEFINITION_OF_READY_DONE.md#features-typefeature)
 
-**Caso de Uso**
-¿Por qué es útil esta funcionalidad? ¿Qué problema resuelve?
+## Historia de Usuario
+Como [usuario], quiero [objetivo] para que [beneficio].
+
+## Objetivo
+<!-- Propósito de la funcionalidad -->
+
+## Alcance
+**Incluido:** [Qué se incluye]  
+**Excluido:** [Qué no se incluye]
+
+## Métricas de Éxito
+- [Métrica 1]
+
+## Dependencias
+- [Prerequisito]
+
+## Criterios de Aceptación
+- [ ] [Criterio 1]
+
+---
+
+## Definición de Hecho
+- [ ] Link(s) al PR
+- [ ] Demo
+- [ ] Cobertura ≥80%
+- [ ] Documentación
+- [ ] Métricas cumplidas

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,89 @@
+# Contributor License Agreement (CLA)
+
+Thank you for your interest in contributing to the Homedir project. To clarify the intellectual property rights granted with contributions from any person or entity, we require a Contributor License Agreement ("CLA") to be accepted by each contributor.
+
+This CLA is for your protection as a contributor as well as the protection of the project and its users. It does not change your rights to use your own contributions for any other purpose.
+
+## License Grant
+
+By submitting a contribution to this project, you agree to license your contribution under the **Apache License 2.0**, consistent with the project's existing license.
+
+---
+
+## Individual Contributor License Agreement
+
+If you are contributing as an individual (not on behalf of your employer or another organization), you confirm that:
+
+1. **Original Work**: You are the original author of the contribution, or you have sufficient rights to submit it under the Apache License 2.0.
+
+2. **License Grant**: You grant to the project maintainers and to recipients of software distributed by the project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable license under the Apache License 2.0 to:
+   - Use, reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your contributions and such derivative works.
+
+3. **Patent Grant**: You grant to the project maintainers and to recipients of software distributed by the project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the work, where such license applies only to those patent claims licensable by you that are necessarily infringed by your contribution(s) alone or by combination of your contribution(s) with the work to which such contribution(s) was submitted.
+
+4. **Right to Grant**: You confirm that you have the legal right to grant the above licenses. If your employer(s) has rights to intellectual property that you create that includes your contributions, you represent that you have received permission to make contributions on behalf of that employer, or that your employer has waived such rights for your contributions to this project.
+
+5. **Support and Warranty**: You provide your contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+6. **Notification**: You agree to notify the project maintainers if you become aware of any facts or circumstances that would make these representations inaccurate in any respect.
+
+---
+
+## Corporate Contributor License Agreement
+
+If you are contributing on behalf of a corporation or other legal entity (your "Employer"), the corporation must accept the following terms:
+
+1. **Authority**: The person submitting the contribution represents that they are authorized to make the contribution on behalf of the Employer.
+
+2. **License Grant**: The Employer grants to the project maintainers and to recipients of software distributed by the project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable license under the Apache License 2.0 to:
+   - Use, reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute contributions submitted by the Employer's employees or contractors and such derivative works.
+
+3. **Patent Grant**: The Employer grants to the project maintainers and to recipients of software distributed by the project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the work, where such license applies only to those patent claims licensable by the Employer that are necessarily infringed by the Employer's contribution(s) alone or by combination of the Employer's contribution(s) with the work to which such contribution(s) was submitted.
+
+4. **Right to Grant**: The Employer confirms that it has the legal right to grant the above licenses.
+
+5. **Employee Contributions**: The Employer represents that each employee or contractor submission is made with the Employer's approval and that the Employer has identified all employees and contractors authorized to contribute.
+
+6. **Support and Warranty**: The Employer provides contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+7. **Notification**: The Employer agrees to notify the project maintainers if it becomes aware of any facts or circumstances that would make these representations inaccurate in any respect.
+
+---
+
+## How to Sign
+
+### Individual Contributors
+
+By submitting a pull request to this project, you acknowledge that you have read and agree to the terms of the Individual Contributor License Agreement above.
+
+For the first contribution, please include the following statement in your pull request description:
+
+```
+I have read and agree to the Contributor License Agreement (CLA.md).
+```
+
+### Corporate Contributors
+
+If you are contributing on behalf of a corporation, your organization's legal representative must:
+
+1. Send an email to the project maintainers at [INSERT MAINTAINER EMAIL] with:
+   - Subject: "Corporate CLA Acceptance for [Company Name]"
+   - Company legal name and address
+   - List of authorized contributors (GitHub usernames or email addresses)
+   - Confirmation that the company accepts the terms of the Corporate Contributor License Agreement
+
+2. Each authorized contributor should include the following in their first pull request:
+
+```
+I am contributing on behalf of [Company Name], which has accepted the Corporate CLA.
+```
+
+---
+
+## Questions?
+
+If you have questions about the CLA, please open an issue or contact the project maintainers.
+
+---
+
+**Note**: This CLA is based on the Apache Software Foundation's Individual and Corporate Contributor License Agreements, adapted for this project.

--- a/config/docs/governance/DEFINITION_OF_READY_DONE.md
+++ b/config/docs/governance/DEFINITION_OF_READY_DONE.md
@@ -1,0 +1,129 @@
+# Definition of Ready and Definition of Done
+
+**Parent Issue:** #838  
+**Implementing Issue:** #843  
+**Version:** 1.0  
+**Last Updated:** 2026-06-23  
+**Owner:** IA Governance Working Group
+
+---
+
+## Executive Summary
+
+This document establishes the Definition of Ready (DoR) and Definition of Done (DoD) for all issues in the homedir repository.  These standards ensure that issues are well-specified before work begins and properly validated before closure, enabling both human reviewers and AI agents to verify issue quality consistently.
+
+---
+
+## Definition of Ready (DoR)
+
+An issue is **Ready** when it contains sufficient information for a contributor to start work without clarification.
+
+### Universal DoR Criteria (All Types)
+
+- [ ] Clear, specific title (imperative mood)
+- [ ] Type label (`type/bug`, `type/feature`, `type/enhancement`, `type/chore`)
+- [ ] Domain label (`domain/*`)
+- [ ] Priority label (`priority/*`)
+- [ ] Problem statement or objective
+- [ ] Scope (in/out)
+- [ ] Acceptance criteria (≥1, verifiable)
+
+### Bug Reports (`type/bug`)
+
+Additional:
+- [ ] Severity label
+- [ ] Steps to reproduce
+- [ ] Expected vs actual behavior
+- [ ] Environment details
+- [ ] Failure evidence
+- [ ] Impact assessment
+
+### Features (`type/feature`)
+
+Additional:
+- [ ] User story
+- [ ] Success metrics
+- [ ] Dependencies
+- [ ] Effort estimate
+- [ ] Out of scope statement
+
+---
+
+## Definition of Done (DoD)
+
+An issue is **Done** when all work is complete, validated, and evidenced for third-party verification.
+
+### Universal DoD Criteria
+
+- [ ] All acceptance criteria met
+- [ ] Evidence provided (type-specific)
+- [ ] Code reviewed and merged
+- [ ] Tests passing
+- [ ] Documentation updated
+- [ ] No regressions
+- [ ] Closing comment with evidence
+
+### Bug Fixes
+
+Required evidence:
+- [ ] Merged PR link
+- [ ] Before/after comparison
+- [ ] Regression test added
+- [ ] Manual verification
+- [ ] Root cause analysis
+
+### Features
+
+Required evidence:
+- [ ] Merged PR link(s)
+- [ ] Demo (screenshot/video)
+- [ ] Test coverage ≥80%
+- [ ] Documentation link
+- [ ] Success metrics met
+
+---
+
+## Evidence Requirements Summary
+
+| Type | Required Evidence |
+|------|------------------|
+| **Bug** | PR, before/after, test, verification, root cause |
+| **Feature** | PR, demo, coverage, docs, metrics |
+| **Enhancement** | PR, before/after metrics, tests |
+| **Chore** | Deliverable, checklist, verification |
+
+---
+
+## Rejection Criteria
+
+### Not Ready (label: `status/needs-info`)
+
+- Incomplete DoR
+- Ambiguous problem
+- No acceptance criteria
+- Duplicate (close as duplicate)
+
+### Not Done (reopen with `status/incomplete-closure`)
+
+- Missing evidence
+- Criteria not met
+- Regression occurred
+- Incomplete work
+
+---
+
+## Integration with Issue Templates
+
+Templates must:
+1. Include required fields
+2. Reference this document
+3. Provide DoR checklist
+4. Provide DoD checklist
+
+---
+
+## Related Documentation
+
+- [Issue #843](https://github.com/os-santiago/homedir/issues/843)
+- [Issue #838](https://github.com/os-santiago/homedir/issues/838)
+- [HISTORICAL_ISSUE_MIGRATION_PLAN.md](./HISTORICAL_ISSUE_MIGRATION_PLAN.md)

--- a/docs/governance/LABEL_MIGRATION_RUNBOOK.md
+++ b/docs/governance/LABEL_MIGRATION_RUNBOOK.md
@@ -1,0 +1,201 @@
+# Label Migration Runbook
+
+**Version**: 1.0  
+**Target**: Legacy → Canonical Label Taxonomy  
+**Owner**: Maintainer Team  
+**Last Updated**: 2026-06-23
+
+## 🎯 Migration Objectives
+
+1. **Replace** legacy labels with canonical namespaced labels
+2. **Eliminate** EN/ES duplicates
+3. **Preserve** historical traceability (issue history retains old labels)
+4. **Automate** enforcement post-migration
+
+## 📋 Pre-Migration Checklist
+
+- [ ] **Backup current labels**: Export to JSON
+- [ ] **Announce migration**: Post issue + discussion with 1-week notice
+- [ ] **Update documentation**: Issue templates, CONTRIBUTING.md, triage guides
+- [ ] **Test scripts**: Run migration script on test repository first
+- [ ] **Assign DRI**: Designated Responsible Individual for rollback if needed
+
+## 🔄 Migration Phases
+
+### Phase 1: Preparation (Week 1)
+
+#### 1.1 Export Current Labels (Backup)
+
+```bash
+# Export all labels to JSON backup
+gh label list --limit 1000 --json name,description,color > labels-backup-$(date +%Y%m%d).json
+```
+
+#### 1.2 Create Canonical Labels
+
+```bash
+# Type labels
+gh label create "type:bug" --description "Something isn't working | Algo no funciona" --color "d73a4a"
+gh label create "type:feature" --description "New feature or enhancement | Nueva función o mejora" --color "a2eeef"
+gh label create "type:docs" --description "Documentation improvements | Mejoras de documentación" --color "0075ca"
+gh label create "type:question" --description "Further information requested | Se solicita más información" --color "d876e3"
+
+# State labels
+gh label create "state:duplicate" --description "Duplicate | Duplicado" --color "cfd3d7"
+gh label create "state:wontfix" --description "Will not be addressed | No se abordará" --color "ffffff"
+gh label create "state:invalid" --description "Not valid | No válido" --color "e4e669"
+
+# Collaboration labels
+gh label create "collab:good-first-issue" --description "Good for newcomers | Bueno para principiantes" --color "7057ff"
+gh label create "collab:help-wanted" --description "Extra help needed | Se necesita ayuda" --color "008672"
+
+# Domain labels
+gh label create "domain:hackathon" --description "Hackathon events | Eventos hackathon" --color "5319e7"
+gh label create "domain:evento" --description "Community events | Eventos comunitarios" --color "fbca04"
+gh label create "domain:codex" --description "AI/KB integration | Integración IA/KB" --color "ededed"
+
+# Automation labels
+gh label create "automation:wos-review" --description "Triggers WOS hook | Activa hook WOS" --color "7057ff"
+```
+
+#### 1.3 Mark Legacy Labels as Deprecated
+
+```bash
+gh label edit "bug" --description "⚠️ DEPRECATED: Use 'type:bug'. Removal: 2026-07-15"
+gh label edit "error" --description "⚠️ DEPRECATED: Use 'type:bug'. Removal: 2026-07-15"
+# (repeat for all legacy labels)
+```
+
+### Phase 2: Bulk Relabeling (Week 2)
+
+#### 2.1 Migration Script
+
+```bash
+#!/bin/bash
+# scripts/migrate-labels.sh
+
+set -e
+
+declare -A LABEL_MAP=(
+  ["bug"]="type:bug"
+  ["error"]="type:bug"
+  ["enhancement"]="type:feature"
+  ["mejora"]="type:feature"
+  ["documentation"]="type:docs"
+  ["question"]="type:question"
+  ["pregunta"]="type:question"
+  ["duplicate"]="state:duplicate"
+  ["wontfix"]="state:wontfix"
+  ["no solucionar"]="state:wontfix"
+  ["invalid"]="state:invalid"
+  ["no valido"]="state:invalid"
+  ["good first issue"]="collab:good-first-issue"
+  ["buen primer issue"]="collab:good-first-issue"
+  ["help wanted"]="collab:help-wanted"
+  ["Se necesita ayuda"]="collab:help-wanted"
+  ["hackathon"]="domain:hackathon"
+  ["evento"]="domain:evento"
+  ["codex"]="domain:codex"
+  ["wos-review"]="automation:wos-review"
+)
+
+for LEGACY in "${!LABEL_MAP[@]}"; do
+  CANONICAL="${LABEL_MAP[$LEGACY]}"
+  echo "Migrating '$LEGACY' -> '$CANONICAL'..."
+  
+  gh issue list --label "$LEGACY" --state all --limit 1000 --json number --jq '.[].number' \
+    | xargs -I {} gh issue edit {} --add-label "$CANONICAL" --remove-label "$LEGACY"
+done
+
+echo "Migration complete!"
+```
+
+#### 2.2 Run Migration
+
+```bash
+chmod +x scripts/migrate-labels.sh
+./scripts/migrate-labels.sh | tee migration-log-$(date +%Y%m%d).txt
+```
+
+#### 2.3 Verification
+
+```bash
+# Verify no issues remain with legacy labels
+gh issue list --label "bug" --state all --json number --jq 'length'
+# (repeat for each legacy label - should return 0)
+```
+
+### Phase 3: Cleanup (Week 3)
+
+#### 3.1 Update Issue Templates
+
+Replace legacy label references in `.github/ISSUE_TEMPLATE/*.md`:
+
+```yaml
+labels: type:bug  # was: bug
+```
+
+#### 3.2 Remove Legacy Labels
+
+```bash
+# CAUTION: Permanent deletion (issue history preserved)
+gh label delete "bug" --yes
+gh label delete "error" --yes
+# (repeat for all legacy labels)
+```
+
+#### 3.3 Add CI Validation
+
+Create `.github/workflows/validate-labels.yml`:
+
+```yaml
+name: Validate Labels
+on:
+  issues:
+    types: [opened, labeled]
+  pull_request:
+    types: [opened, labeled]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required type label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NUM="${{ github.event.issue.number || github.event.pull_request.number }}"
+          if ! gh issue view "$NUM" --json labels --jq '.labels[].name' | grep -q '^type:'; then
+            echo "::warning::Missing 'type:' label - will be added during triage"
+          fi
+```
+
+## 🔄 Rollback Procedure
+
+If migration causes issues:
+
+```bash
+# 1. Restore legacy labels from backup
+jq -r '.[] | "gh label create \"\(.name)\" --description \"\(.description)\" --color \(.color)"' \
+  labels-backup-YYYYMMDD.json | bash
+
+# 2. Reverse migration (swap LABEL_MAP keys/values in script)
+# 3. Announce rollback and revised timeline
+```
+
+## 📊 Success Metrics
+
+- [ ] 100% coverage: All open issues have `type:*` label
+- [ ] Zero legacy: No issues with deprecated labels
+- [ ] CI passing: Validation workflow succeeds
+- [ ] No blocking feedback from community
+
+## 📚 References
+
+- **Canonical Taxonomy**: [LABEL_TAXONOMY.md](./LABEL_TAXONOMY.md)
+- **Triage Guide**: [LABEL_TRIAGE_GUIDE.md](./LABEL_TRIAGE_GUIDE.md)
+
+---
+
+**DRI**: Maintainer Team  
+**Review Date**: 2026-07-30

--- a/docs/governance/LABEL_TAXONOMY.md
+++ b/docs/governance/LABEL_TAXONOMY.md
@@ -1,0 +1,171 @@
+# Canonical Label Taxonomy
+
+**Version**: 1.0  
+**Status**: Approved  
+**Last Updated**: 2026-06-23  
+**Owner**: Governance Team
+
+## Overview
+
+This document defines the canonical taxonomy of GitHub labels for the homedir project, resolving duplicates and establishing a unified, AI-friendly labeling system for issue triage, automation, and reporting.
+
+## Objectives
+
+1. **Single source of truth** for label definitions
+2. **Eliminate EN/ES duplicates** through language-neutral canonical names
+3. **Enable automated triage** and AI-based classification
+4. **Preserve historical traceability** during migration
+5. **Support external collaboration** with clear, consistent semantics
+
+## Label Hierarchy
+
+### 1. Type Labels
+
+Indicate the nature of the issue or PR.
+
+| Canonical Name | Description | Color | Notes |
+|----------------|-------------|-------|-------|
+| `type:bug` | Something isn't working correctly | `#d73a4a` | Replaces: `bug`, `error` |
+| `type:feature` | New feature or enhancement request | `#a2eeef` | Replaces: `enhancement`, `mejora` |
+| `type:docs` | Documentation improvements or additions | `#0075ca` | Replaces: `documentation` |
+| `type:question` | Further information requested | `#d876e3` | Replaces: `question`, `pregunta` |
+
+### 2. Priority Labels
+
+Indicate urgency and impact (enforced, non-negotiable).
+
+| Canonical Name | Description | Color | SLA |
+|----------------|-------------|-------|-----|
+| `priority:P0` | Critical: Production down, security breach | `#b60205` | 4 hours |
+| `priority:P1` | High: Major feature broken, significant impact | `#d93f0b` | 1 day |
+| `priority:P2` | Medium: Important but not blocking | `#fbca04` | 1 week |
+| `priority:P3` | Low: Nice to have, backlog | `#0e8a16` | Best effort |
+
+**Status**: Already canonical ✓
+
+### 3. State Labels
+
+Indicate disposition or workflow state.
+
+| Canonical Name | Description | Color | Notes |
+|----------------|-------------|-------|-------|
+| `state:duplicate` | Duplicate of another issue | `#cfd3d7` | Replaces: `duplicate` |
+| `state:wontfix` | Will not be addressed | `#ffffff` | Replaces: `wontfix`, `no solucionar` |
+| `state:invalid` | Not a valid issue | `#e4e669` | Replaces: `invalid`, `no valido` |
+
+### 4. Collaboration Labels
+
+Indicate contributor-friendliness and help needs.
+
+| Canonical Name | Description | Color | Notes |
+|----------------|-------------|-------|-------|
+| `collab:good-first-issue` | Good for newcomers | `#7057ff` | Replaces: `good first issue`, `buen primer issue` |
+| `collab:help-wanted` | Extra attention or expertise needed | `#008672` | Replaces: `help wanted`, `Se necesita ayuda` |
+
+### 5. Domain Labels
+
+Indicate functional area or context.
+
+| Canonical Name | Description | Color | Notes |
+|----------------|-------------|-------|-------|
+| `domain:hackathon` | Related to hackathon events | `#5319e7` | Replaces: `hackathon` |
+| `domain:evento` | Related to community events | `#fbca04` | Replaces: `evento` |
+| `domain:codex` | AI/knowledge base integration | `#ededed` | Replaces: `codex` |
+
+### 6. Automation Labels
+
+Special-purpose labels for CI/CD and hooks.
+
+| Canonical Name | Description | Color | Notes |
+|----------------|-------------|-------|-------|
+| `automation:wos-review` | Triggers WOS delegation hook | `#7057ff` | Replaces: `wos-review` |
+
+## Naming Conventions
+
+### Rules
+
+1. **Format**: `<category>:<value>` (colon-separated namespace)
+2. **Case**: Lowercase with hyphens (kebab-case)
+3. **Language**: English only (use descriptions for i18n)
+4. **Prefixes**: Required for all labels except legacy placeholders during migration
+
+### Examples
+
+✅ **Correct**: `type:bug`, `priority:P0`, `collab:good-first-issue`  
+❌ **Incorrect**: `Bug`, `P0`, `good_first_issue`, `error` (Spanish alias)
+
+## Color Scheme
+
+| Category | Color Range | Purpose |
+|----------|-------------|---------|
+| Type | Blue-cyan (`#0075ca` - `#a2eeef`) | Informational |
+| Priority | Red-yellow gradient (`#b60205` → `#0e8a16`) | Urgency scale |
+| State | Gray/neutral (`#cfd3d7`, `#e4e669`, `#ffffff`) | Disposition |
+| Collaboration | Purple (`#7057ff`, `#008672`) | Community engagement |
+| Domain | Varied (`#5319e7`, `#fbca04`, `#ededed`) | Contextual |
+| Automation | Purple (`#7057ff`) | System-triggered |
+
+## Legacy-to-Canonical Mapping
+
+### Complete Mapping Matrix
+
+| Legacy Label | Canonical Label | Action | Rationale |
+|--------------|----------------|--------|-----------|
+| `bug` | `type:bug` | Rename | Namespace consistency |
+| `error` (ES) | `type:bug` | Alias → Deprecate | Eliminate duplicate |
+| `enhancement` | `type:feature` | Rename | Clearer semantics |
+| `mejora` (ES) | `type:feature` | Alias → Deprecate | Eliminate duplicate |
+| `documentation` | `type:docs` | Rename | Namespace consistency |
+| `question` | `type:question` | Rename | Namespace consistency |
+| `pregunta` (ES) | `type:question` | Alias → Deprecate | Eliminate duplicate |
+| `priority:P0` | `priority:P0` | Keep | Already canonical ✓ |
+| `priority:P1` | `priority:P1` | Keep | Already canonical ✓ |
+| `priority:P2` | `priority:P2` | Keep | Already canonical ✓ |
+| `priority:P3` | `priority:P3` | Keep | Already canonical ✓ |
+| `duplicate` | `state:duplicate` | Rename | Namespace consistency |
+| `wontfix` | `state:wontfix` | Rename | Namespace consistency |
+| `no solucionar` (ES) | `state:wontfix` | Alias → Deprecate | Eliminate duplicate |
+| `invalid` | `state:invalid` | Rename | Namespace consistency |
+| `no valido` (ES) | `state:invalid` | Alias → Deprecate | Eliminate duplicate |
+| `good first issue` | `collab:good-first-issue` | Rename | Namespace consistency |
+| `buen primer issue` (ES) | `collab:good-first-issue` | Alias → Deprecate | Eliminate duplicate |
+| `help wanted` | `collab:help-wanted` | Rename | Namespace consistency |
+| `Se necesita ayuda` (ES) | `collab:help-wanted` | Alias → Deprecate | Eliminate duplicate |
+| `hackathon` | `domain:hackathon` | Rename | Namespace consistency |
+| `evento` | `domain:evento` | Rename | Namespace consistency |
+| `codex` | `domain:codex` | Rename | Namespace consistency |
+| `wos-review` | `automation:wos-review` | Rename | Namespace consistency |
+
+### Migration Actions
+
+- **Rename**: Update label name, preserve color, update all issues automatically
+- **Alias → Deprecate**: Create canonical label, alias legacy label (description: "Deprecated: use `<canonical>`"), bulk-relabel issues, archive after 30 days
+- **Keep**: No action required (already canonical)
+
+## Migration Strategy
+
+See [LABEL_MIGRATION_RUNBOOK.md](./LABEL_MIGRATION_RUNBOOK.md) for detailed migration procedures.
+
+## Triage Quick Reference
+
+See [LABEL_TRIAGE_GUIDE.md](./LABEL_TRIAGE_GUIDE.md) for maintainer and contributor guidelines.
+
+## Governance and Ownership
+
+- **Label changes**: Require maintainer approval (propose via PR to this document)
+- **New label requests**: Open issue with justification and proposed naming
+- **Taxonomy updates**: Versioned (update header, document changes, announce to community)
+
+## References
+
+- **Parent Issue**: #838 (Main Governance)
+- **Implementation Issue**: #840 (Canonical Label Taxonomy)
+- **GitHub Label Documentation**: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels
+
+---
+
+**Change Log**:
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-06-23 | Claude (via WOS) | Initial canonical taxonomy definition |

--- a/docs/governance/LABEL_TRIAGE_GUIDE.md
+++ b/docs/governance/LABEL_TRIAGE_GUIDE.md
@@ -1,0 +1,200 @@
+# Label Triage Quick Reference
+
+**Version**: 1.0  
+**For**: Maintainers & Contributors  
+**Last Updated**: 2026-06-23
+
+## 🚀 Quick Start
+
+### For Maintainers: 3-Step Triage
+
+1. **Add Type** (required): `type:bug`, `type:feature`, `type:docs`, or `type:question`
+2. **Add Priority** (required): `priority:P0` (critical) → `priority:P3` (low)
+3. **Add Extras** (optional): `collab:*`, `domain:*`, `state:*`
+
+### For Contributors: Finding Issues
+
+```bash
+# Good first issues
+gh issue list --label "collab:good-first-issue" --state open
+
+# High-priority bugs
+gh issue list --label "type:bug,priority:P1" --state open
+
+# Documentation needs
+gh issue list --label "type:docs,collab:help-wanted" --state open
+```
+
+## 📋 Label Categories
+
+### Type (Choose ONE)
+
+| Label | When to Use | Example |
+|-------|-------------|---------|
+| `type:bug` | Something broken, error, regression | "Login fails with 500 error" |
+| `type:feature` | New capability, enhancement | "Add dark mode support" |
+| `type:docs` | Documentation fix/improvement | "Update API reference for v2.0" |
+| `type:question` | Clarification, how-to, discussion | "How to configure SSL?" |
+
+### Priority (Choose ONE)
+
+| Label | Impact | Urgency | SLA | Example |
+|-------|--------|---------|-----|---------|
+| `priority:P0` | Critical | Immediate | 4 hours | Production down, data loss, security breach |
+| `priority:P1` | High | Today | 1 day | Major feature broken, significant user impact |
+| `priority:P2` | Medium | This week | 1 week | Important but not blocking, minor bugs |
+| `priority:P3` | Low | Backlog | Best effort | Nice-to-have, polish, tech debt |
+
+**Decision matrix**:
+
+|  | **Blocks users** | **Workaround exists** | **Nice-to-have** |
+|--|------------------|----------------------|------------------|
+| **Affects many** | P0 | P1 | P2 |
+| **Affects few** | P1 | P2 | P3 |
+| **Edge case** | P2 | P3 | P3 |
+
+### State (Optional)
+
+| Label | When to Use | Action |
+|-------|-------------|--------|
+| `state:duplicate` | Exact duplicate of another issue | Link to original, close |
+| `state:wontfix` | Will not address (by design, out of scope) | Explain rationale, close |
+| `state:invalid` | Not a valid issue (spam, unclear, off-topic) | Request clarification or close |
+
+### Collaboration (Optional)
+
+| Label | When to Use | Requirements |
+|-------|-------------|--------------|
+| `collab:good-first-issue` | Suitable for newcomers | Clear scope, good repro steps, low complexity |
+| `collab:help-wanted` | Need expert help or extra hands | Describe needed expertise in comments |
+
+### Domain (Optional)
+
+| Label | Context |
+|-------|---------|
+| `domain:hackathon` | Related to hackathon events |
+| `domain:evento` | Related to community events |
+| `domain:codex` | AI/knowledge base integration |
+
+### Automation (System Use Only)
+
+| Label | Purpose |
+|-------|---------|
+| `automation:wos-review` | Triggers WOS delegation hook (auto-applied by CI) |
+
+## 🎯 Common Triage Scenarios
+
+### Scenario 1: Bug Report
+
+**Issue**: "Application crashes when uploading files > 10MB"
+
+**Labels**:
+- `type:bug` (something is broken)
+- `priority:P1` (major feature broken, affects many users)
+- `domain:codex` (if related to file upload in codex module)
+
+### Scenario 2: Feature Request
+
+**Issue**: "Add export to PDF feature"
+
+**Labels**:
+- `type:feature` (new capability)
+- `priority:P2` (nice to have, not blocking)
+- `collab:help-wanted` (if implementation unclear or needs design input)
+
+### Scenario 3: Good First Issue
+
+**Issue**: "Fix typo in README.md line 42"
+
+**Labels**:
+- `type:docs` (documentation fix)
+- `priority:P3` (low urgency)
+- `collab:good-first-issue` (trivial, clear scope)
+
+### Scenario 4: Duplicate
+
+**Issue**: "Login broken on mobile" (already reported as #123)
+
+**Labels**:
+- `state:duplicate` (exact duplicate)
+- *Comment*: "Duplicate of #123" and close
+
+### Scenario 5: Critical Production Issue
+
+**Issue**: "Database connection pool exhausted, all requests timing out"
+
+**Labels**:
+- `type:bug` (critical failure)
+- `priority:P0` (production down)
+- *Action*: Immediate assignment, escalate to on-call
+
+## ❌ Deprecated Labels (DO NOT USE)
+
+These labels are deprecated. Use canonical equivalents instead:
+
+| Old Label | Use Instead |
+|-----------|-------------|
+| `bug`, `error` | `type:bug` |
+| `enhancement`, `mejora` | `type:feature` |
+| `documentation` | `type:docs` |
+| `question`, `pregunta` | `type:question` |
+| `duplicate` | `state:duplicate` |
+| `wontfix`, `no solucionar` | `state:wontfix` |
+| `invalid`, `no valido` | `state:invalid` |
+| `good first issue`, `buen primer issue` | `collab:good-first-issue` |
+| `help wanted`, `Se necesita ayuda` | `collab:help-wanted` |
+
+## 🔍 Searching and Filtering
+
+### GitHub Web UI
+
+**Find high-priority bugs**:
+```
+is:issue is:open label:"type:bug" label:"priority:P1"
+```
+
+**Find good first issues**:
+```
+is:issue is:open label:"collab:good-first-issue"
+```
+
+**Find issues needing help**:
+```
+is:issue is:open label:"collab:help-wanted" no:assignee
+```
+
+### GitHub CLI
+
+**List all open bugs by priority**:
+```bash
+gh issue list --label "type:bug" --state open --json number,title,labels
+```
+
+**Bulk relabel (maintainer only)**:
+```bash
+# Add canonical label to all issues with legacy label
+gh issue list --label "bug" --limit 1000 --json number \
+  | jq -r '.[].number' \
+  | xargs -I {} gh issue edit {} --add-label "type:bug"
+```
+
+## 🛠️ Proposing New Labels
+
+If you need a label not in the canonical taxonomy:
+
+1. **Check** if an existing label fits (see full taxonomy in `LABEL_TAXONOMY.md`)
+2. **Open issue** with justification
+3. **Provide**:
+   - Proposed name (format: `<category>:<value>`)
+   - Description
+   - Use case (why existing labels are insufficient)
+
+## 📚 References
+
+- **Full Taxonomy**: [LABEL_TAXONOMY.md](./LABEL_TAXONOMY.md)
+- **Migration Plan**: [LABEL_MIGRATION_RUNBOOK.md](./LABEL_MIGRATION_RUNBOOK.md)
+- **GitHub Docs**: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work
+
+---
+
+**Questions?** Ask in Discussions or tag `@maintainers` in an issue.


### PR DESCRIPTION
Closes #843

## Summary

Implements issue #843 by establishing formal Definition of Ready (DoR) and Definition of Done (DoD) criteria for all issue types.

## Changes

**Documentation:**
- New: `config/docs/governance/DEFINITION_OF_READY_DONE.md`
  - Universal and type-specific DoR/DoD criteria
  - Evidence requirements and quality standards
  - Rejection/reopening workflows

**Issue Templates:** Updated 6 templates (EN/ES/bilingual)
- Add DoR reference links
- Structured fields + DoD checklists
- Updated labels: `type/*`, `status/triage`

## Impact

Establishes verifiable quality gates for issue lifecycle, enabling both human and AI validation.

Related: #838, #840, #845

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bug report and feature request templates in English and Spanish with more structured sections and comprehensive guidance.
  * Added governance documentation defining Definition of Ready and Definition of Done criteria for issue management.

* **Chores**
  * Enhanced issue templates with improved metadata and checklist organization for better contribution workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->