### PR TITLE
feat: add Contributor License Agreement

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,89 @@
+# Contributor License Agreement (CLA)
+
+Thank you for your interest in contributing to the Homedir project. To clarify the intellectual property rights granted with contributions from any person or entity, we require a Contributor License Agreement ("CLA") to be accepted by each contributor.
+
+This CLA is for your protection as a contributor as well as the protection of the project and its users. It does not change your rights to use your own contributions for any other purpose.
+
+## License Grant
+
+By submitting a contribution to this project, you agree to license your contribution under the **Apache License 2.0**, consistent with the project's existing license.
+
+---
+
+## Individual Contributor License Agreement
+
+If you are contributing as an individual (not on behalf of your employer or another organization), you confirm that:
+
+1. **Original Work**: You are the original author of the contribution, or you have sufficient rights to submit it under the Apache License 2.0.
+
+2. **License Grant**: You grant to the project maintainers and to recipients of software distributed by the project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable license under the Apache License 2.0 to:
+   - Use, reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your contributions and such derivative works.
+
+3. **Patent Grant**: You grant to the project maintainers and to recipients of software distributed by the project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the work, where such license applies only to those patent claims licensable by you that are necessarily infringed by your contribution(s) alone or by combination of your contribution(s) with the work to which such contribution(s) was submitted.
+
+4. **Right to Grant**: You confirm that you have the legal right to grant the above licenses. If your employer(s) has rights to intellectual property that you create that includes your contributions, you represent that you have received permission to make contributions on behalf of that employer, or that your employer has waived such rights for your contributions to this project.
+
+5. **Support and Warranty**: You provide your contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+6. **Notification**: You agree to notify the project maintainers if you become aware of any facts or circumstances that would make these representations inaccurate in any respect.
+
+---
+
+## Corporate Contributor License Agreement
+
+If you are contributing on behalf of a corporation or other legal entity (your "Employer"), the corporation must accept the following terms:
+
+1. **Authority**: The person submitting the contribution represents that they are authorized to make the contribution on behalf of the Employer.
+
+2. **License Grant**: The Employer grants to the project maintainers and to recipients of software distributed by the project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable license under the Apache License 2.0 to:
+   - Use, reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute contributions submitted by the Employer's employees or contractors and such derivative works.
+
+3. **Patent Grant**: The Employer grants to the project maintainers and to recipients of software distributed by the project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the work, where such license applies only to those patent claims licensable by the Employer that are necessarily infringed by the Employer's contribution(s) alone or by combination of the Employer's contribution(s) with the work to which such contribution(s) was submitted.
+
+4. **Right to Grant**: The Employer confirms that it has the legal right to grant the above licenses.
+
+5. **Employee Contributions**: The Employer represents that each employee or contractor submission is made with the Employer's approval and that the Employer has identified all employees and contractors authorized to contribute.
+
+6. **Support and Warranty**: The Employer provides contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+7. **Notification**: The Employer agrees to notify the project maintainers if it becomes aware of any facts or circumstances that would make these representations inaccurate in any respect.
+
+---
+
+## How to Sign
+
+### Individual Contributors
+
+By submitting a pull request to this project, you acknowledge that you have read and agree to the terms of the Individual Contributor License Agreement above.
+
+For the first contribution, please include the following statement in your pull request description:
+
+```
+I have read and agree to the Contributor License Agreement (CLA.md).
+```
+
+### Corporate Contributors
+
+If you are contributing on behalf of a corporation, your organization's legal representative must:
+
+1. Send an email to the project maintainers at [INSERT MAINTAINER EMAIL] with:
+   - Subject: "Corporate CLA Acceptance for [Company Name]"
+   - Company legal name and address
+   - List of authorized contributors (GitHub usernames or email addresses)
+   - Confirmation that the company accepts the terms of the Corporate Contributor License Agreement
+
+2. Each authorized contributor should include the following in their first pull request:
+
+```
+I am contributing on behalf of [Company Name], which has accepted the Corporate CLA.
+```
+
+---
+
+## Questions?
+
+If you have questions about the CLA, please open an issue or contact the project maintainers.
+
+---
+
+**Note**: This CLA is based on the Apache Software Foundation's Individual and Corporate Contributor License Agreements, adapted for this project.


### PR DESCRIPTION
Closes #935

Create CLA.md defining contributor license agreement for legal clarity.

**Changes**:
- Individual CLA section with license and patent grants under Apache 2.0  
- Corporate CLA section for organizational contributors
- Signing instructions for both contributor types
- Based on Apache Software Foundation CLA template

**ADEV Compliant**: Single atomic commit, dedicated branch, conventional commits format.