### PR TITLE
[OSS] Create CLA.md (Contributor License Agreement)

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,91 @@
+# Contributor License Agreement
+
+Thank you for your interest in contributing to Homedir ("Project"). This Contributor License Agreement ("CLA") sets out the terms under which you ("Contributor") grant certain licenses to the Project maintainers and the community.
+
+By submitting a contribution (code, documentation, or other material), you agree to the terms below. **If you are agreeing on behalf of a legal entity (e.g., your employer), ensure you have the authority to bind that entity.**
+
+---
+
+## 1. Definitions
+
+- **"You"** (or **"Contributor"**) means the individual or legal entity submitting a Contribution.
+- **"Contribution"** means any original work intentionally submitted for inclusion in the Project.
+- **"Project"** means the Homedir open-source project hosted at [github.com/os-santiago/homedir](https://github.com/os-santiago/homedir).
+
+## 2. Copyright License
+
+You grant the Project maintainers and all recipients of the Project a perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your Contributions and such derivative works.
+
+## 3. Patent License
+
+You grant the Project maintainers and all recipients of the Project a perpetual, worldwide, non-exclusive, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Project, where such license applies only to those patent claims licensable by you that are necessarily infringed by your Contribution(s) alone or by combination of your Contribution(s) with the Project.
+
+## 4. Representations
+
+- **You represent** that you are legally entitled to grant the above licenses.
+- **If your employer has rights** to intellectual property you create, you represent that you have received permission to make Contributions on behalf of that employer, or that your employer has waived such rights.
+- **You represent** that each Contribution is your original creation (or you have the necessary rights to submit it).
+
+## 5. Individual vs. Corporate CLA
+
+### 5.1 Individual Contributors
+
+If you are contributing as an individual (not on behalf of an employer), your signature on this CLA (via your commit's Signed-off-by line) confirms the above representations.
+
+### 5.2 Corporate Contributors
+
+If you are contributing on behalf of a legal entity (corporation, partnership, etc.), an authorized representative must additionally sign a **Corporate CLA**. Contact the maintainers at sergio.canales.e@gmail.com to receive the Corporate CLA form.
+
+## 6. Signing Process
+
+By adding a `Signed-off-by` trailer to your commits, you agree to this CLA:
+
+```bash
+git commit -s -m "feat: my contribution"
+```
+
+This generates a commit trailer:
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+This confirms:
+- You have read and agree to this CLA.
+- You have the right to submit the Contribution under the Project's license (Apache 2.0).
+- Your Contribution complies with the Project's [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+## 7. Disclaimer
+
+Your Contributions are provided "as is" without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and non-infringement.
+
+## 8. Governing Law
+
+This CLA shall be governed by the laws of the Republic of Panama, without regard to its conflict of law provisions.
+
+---
+
+## Appendix A: Individual CLA Signature
+
+```
+I have read and agree to the terms of this Contributor License Agreement.
+
+Name: ______________________________
+Email: _____________________________
+Date: ______________________________
+GitHub Username: ___________________
+```
+
+## Appendix B: Corporate CLA Signature
+
+```
+Corporation Name: __________________
+Authorized Representative: _________
+Title: _____________________________
+Email: _____________________________
+Date: ______________________________
+GitHub Organization: _______________
+```
+
+---
+
+*Adapted from the Apache Software Foundation Individual Contributor License Agreement v2.0 and the Google CLA.*


### PR DESCRIPTION
Closes #935

## Summary
Create CLA.md defining contributor license agreement for legal clarity on contributions.

## Changes
- Created CLA.md in repository root
- Individual Contributor License Agreement section
- Corporate Contributor License Agreement section  
- License grant under Apache 2.0
- Signing instructions via Signed-off-by trailers
- Signature forms (individual and corporate)

## Acceptance
- [x] CLA.md exists in repository root
- [x] Individual CLA section defined
- [x] Corporate CLA section defined
- [x] License grant clearly stated (Apache 2.0)
- [x] Signing instructions documented