### PR TITLE
[OSS] Add MAINTAINERS.md listing project maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,38 @@
+# Maintainers
+
+## Current Maintainers
+
+| Name | GitHub | Role |
+|------|--------|------|
+| Sergio Canales | @scanalesespinoza | Lead Maintainer |
+| Sergio Canales (Automation) | @scanales-stack | Automation Maintainer |
+
+## Maintainer Responsibilities
+
+Maintainers are responsible for:
+
+- Reviewing and merging contributions
+- Setting technical direction and roadmap
+- Enforcing the Code of Conduct
+- Managing releases and versioning
+- Onboarding new contributors
+- Maintaining project documentation
+- Ensuring CI/CD pipeline health
+
+## Becoming a Maintainer
+
+To become a maintainer, a contributor should:
+
+1. Have at least 5 substantial contributions merged
+2. Demonstrate technical expertise in the project's domain
+3. Show commitment to the project's values and Code of Conduct
+4. Be nominated by an existing maintainer
+5. Receive consensus approval from existing maintainers
+
+## Maintainer Emeritus
+
+Maintainers who are no longer actively involved may transition to emeritus status. Emeritus maintainers retain their contributions history and may return to active status if they resume active participation.
+
+---
+
+*See [GOVERNANCE.md](docs/en/governance/GOVERNANCE.md) for the full governance model.*


### PR DESCRIPTION
Closes #926 (sub-item: maintainers document)

## Summary
Add MAINTAINERS.md listing current project maintainers and the process for onboarding new maintainers.

## Changes
- Created MAINTAINERS.md in repository root
- Listed current maintainers with roles
- Documented maintainer responsibilities
- Defined process for becoming a maintainer
- Added maintainer emeritus policy