### PR TITLE
[OSS] Add NOTICE file with trademark information

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,21 @@
+Homedir - DevRel, OpenSource, InnerSource Community Platform
+Copyright 2024-2026 Workspace OS Contributors
+
+This product includes software developed by The Apache Software Foundation (http://www.apache.org/).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+---
+
+Trademarks: "Homedir" and the Homedir logo are trademarks of Workspace OS Contributors.
+All other trademarks are the property of their respective owners.


### PR DESCRIPTION
Closes #926 (sub-item: NOTICE file)

## Summary
Add NOTICE file with trademark information and required Apache attribution.

## Changes
- Created NOTICE file in repository root
- Copyright notice for Workspace OS Contributors
- Apache 2.0 license reference
- Trademark notice for Homedir and logo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project license notices with Apache License Version 2.0 text, including warranty and disclaimer language
  * Added trademark attribution for Homedir and related assets
  * Updated copyright years (2024–2026) and contributor information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->