### PR TITLE
[IA Governance] Template maestro IA-first para issues (EN/ES)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,93 @@
+name: Bug Report
+description: Report a bug to help us improve
+title: "[Bug] "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please provide as much detail as possible.
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical (system down / data loss)
+        - High (feature broken, no workaround)
+        - Medium (feature broken, workaround exists)
+        - Low (cosmetic / minor issue)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - API / Backend
+        - Frontend / UI
+        - CI / DevOps
+        - Documentation
+        - Security
+        - Performance
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Clear and concise description of the bug
+      placeholder: When I try to..., the system returns...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Technical Context
+      description: Environment details (OS, browser, version, logs, screenshots)
+      placeholder: Homedir v3.x, Java 21, Chrome 120, Windows 11
+
+  - type: checkboxes
+    id: acceptance
+    attributes:
+      label: Definition of Ready
+      options:
+        - label: Impact and severity assessed
+        - label: Steps to reproduce are clear
+        - label: No duplicate issue exists
+        - label: Technical context provided
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/es/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/es/bug_report.yml
@@ -1,0 +1,84 @@
+name: Reporte de Bug
+description: Reporta un error para ayudarnos a mejorar
+title: "[Bug] "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Gracias por reportar un error. Proporciona la mayor cantidad de detalles posible.
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severidad
+      options:
+        - Critico (sistema caido / perdida de datos)
+        - Alto (funcionalidad rota, sin workaround)
+        - Medio (funcionalidad rota, con workaround)
+        - Bajo (cosmetico / menor)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - API / Backend
+        - Frontend / UI
+        - CI / DevOps
+        - Documentacion
+        - Seguridad
+        - Rendimiento
+        - Otro
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Descripcion
+      description: Descripcion clara y concisa del error
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Pasos para Reproducir
+      description: Pasos para reproducir el comportamiento
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Comportamiento Esperado
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Comportamiento Actual
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Contexto Tecnico
+      description: Entorno, logs, capturas de pantalla
+
+  - type: checkboxes
+    id: acceptance
+    attributes:
+      label: Definition of Ready
+      options:
+        - label: Impacto y severidad evaluados
+        - label: Pasos para reproducir claros
+        - label: No existe issue duplicado
+        - label: Contexto tecnico proporcionado
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/es/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/es/feature_request.yml
@@ -1,0 +1,70 @@
+name: Solicitud de Funcionalidad
+description: Sugiere una nueva funcionalidad o mejora
+title: "[Feature] "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Gracias por sugerir una funcionalidad. Describe el problema que resuelve.
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Prioridad
+      options:
+        - Critico (bloquea release)
+        - Alto (brecha importante)
+        - Medio (deseable)
+        - Bajo (consideracion futura)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - API / Backend
+        - Frontend / UI
+        - CI / DevOps
+        - Documentacion
+        - Seguridad
+        - Rendimiento
+        - Otro
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problema
+      description: Que problema resuelve esta funcionalidad?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solucion Propuesta
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Criterios de Aceptacion
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: definition
+    attributes:
+      label: Definition of Ready
+      options:
+        - label: Problema claramente definido
+        - label: Criterios de aceptacion definidos
+        - label: No existe issue duplicado
+        - label: Area identificada
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/es/task.yml
+++ b/.github/ISSUE_TEMPLATE/es/task.yml
@@ -1,0 +1,77 @@
+name: Tarea
+description: Una unidad de trabajo bien definida
+title: ""
+labels: []
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Tipo de Tarea
+      options:
+        - Implementacion
+        - Refactorizacion
+        - Documentacion
+        - Investigacion / Analisis
+        - Pruebas
+        - DevOps
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - API / Backend
+        - Frontend / UI
+        - CI / DevOps
+        - Documentacion
+        - Seguridad
+        - Rendimiento
+        - Gobernanza
+        - Otro
+    validations:
+      required: true
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objetivo
+      description: Que hay que hacer y por que?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Alcance
+      value: |
+        **In scope:**
+        -
+
+        **Out of scope:**
+        -
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Criterios de Aceptacion
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencias
+
+  - type: checkboxes
+    id: definition
+    attributes:
+      label: Definition of Ready
+      options:
+        - label: Objetivo claramente definido
+        - label: Criterios de aceptacion definidos y medibles
+        - label: Alcance definido (in/out)
+        - label: No existe issue duplicado
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,83 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[Feature] "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe the problem you're trying to solve.
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Critical (blocking release)
+        - High (important gap)
+        - Medium (nice to have)
+        - Low (future consideration)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - API / Backend
+        - Frontend / UI
+        - CI / DevOps
+        - Documentation
+        - Security
+        - Performance
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve?
+      placeholder: Users currently cannot...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds?
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: What must be true for this to be considered complete?
+      placeholder: |
+        - [ ] Feature works in X scenario
+        - [ ] Documentation updated
+        - [ ] Tests pass
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: definition
+    attributes:
+      label: Definition of Ready
+      options:
+        - label: Problem clearly defined
+        - label: Acceptance criteria defined
+        - label: No duplicate issue exists
+        - label: Area identified
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,91 @@
+name: Task
+description: A well-defined unit of work
+title: ""
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for well-defined tasks. For bugs, use the Bug Report template.
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Task Type
+      options:
+        - Implementation
+        - Refactoring
+        - Documentation
+        - Research / Analysis
+        - Testing
+        - DevOps
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - API / Backend
+        - Frontend / UI
+        - CI / DevOps
+        - Documentation
+        - Security
+        - Performance
+        - Governance
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What needs to be done and why?
+      placeholder: Implement X to enable Y...
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is in scope and out of scope?
+      value: |
+        **In scope:**
+        -
+
+        **Out of scope:**
+        -
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Measurable completion criteria
+      placeholder: |
+        - [ ] Feature X implemented
+        - [ ] Tests added
+        - [ ] Documentation updated
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Blocked by or blocking other work
+      placeholder: "Blocked by: #123\nBlocks: #456"
+
+  - type: checkboxes
+    id: definition
+    attributes:
+      label: Definition of Ready
+      options:
+        - label: Objective clearly defined
+        - label: Acceptance criteria defined and measurable
+        - label: Scope defined (in/out)
+        - label: No duplicate issue exists
+    validations:
+      required: true


### PR DESCRIPTION
Closes #839

## Summary
Create IA-first issue templates with structured fields for bug reports, feature requests, and tasks in both English and Spanish.

## Changes
- Added `.github/ISSUE_TEMPLATE/bug_report.yml` (EN)
- Added `.github/ISSUE_TEMPLATE/feature_request.yml` (EN)
- Added `.github/ISSUE_TEMPLATE/task.yml` (EN)
- Added `.github/ISSUE_TEMPLATE/es/bug_report.yml` (ES)
- Added `.github/ISSUE_TEMPLATE/es/feature_request.yml` (ES)
- Added `.github/ISSUE_TEMPLATE/es/task.yml` (ES)

## Fields per template
- **Bug**: severity, area, description, steps, expected/actual, context, DoR checklist
- **Feature**: priority, area, problem, solution, alternatives, acceptance criteria, DoR checklist
- **Task**: type, area, objective, scope (in/out), acceptance criteria, dependencies, DoR checklist

## Acceptance
- [x] Template specification exists (EN/ES)
- [x] Required vs optional fields defined
- [x] Examples of well-formed issues included
- [x] Quality checklist (DoR) for issue opening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added standardized GitHub issue templates for bug reports, feature requests, and tasks in both English and Spanish, providing structured forms to improve issue reporting consistency and information completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->