### PR TITLE
fix: center spotlight eyebrow with icon on home page

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -5523,6 +5523,14 @@ footer {
   border-left-color: rgba(255, 215, 0, 0.85);
 }
 
+.home-priority-spotlight-head {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
 .home-priority-spotlight h2,
 .home-priority-card h2 {
   margin: 0;

--- a/quarkus-app/src/main/resources/templates/home.qute.html
+++ b/quarkus-app/src/main/resources/templates/home.qute.html
@@ -15,8 +15,10 @@
       </div>
     </div>
     <aside class="section-card home-priority-spotlight" aria-label="{i18n:home_priority_events_title}">
-      <span class="home-priority-icon material-symbols-outlined" aria-hidden="true">event</span>
-      <p class="section-subtitle">{i18n:home_priority_events_eyebrow}</p>
+      <div class="home-priority-spotlight-head">
+        <span class="home-priority-icon material-symbols-outlined" aria-hidden="true">event</span>
+        <p class="section-subtitle">{i18n:home_priority_events_eyebrow}</p>
+      </div>
       <h2>{i18n:home_priority_events_title}</h2>
       <p>{i18n:home_priority_events_desc}</p>
       <div class="home-priority-actions">


### PR DESCRIPTION
Closes #937

## Summary
- Centers the spotlight card eyebrow ("Eventos") next to its icon on the home page
- Renders them in a single centered row with responsive flex-wrap layout

## Changes
- **home.qute.html**: Wrapped icon + eyebrow in `.home-priority-spotlight-head` container
- **homedir.css**: Added inline-flex centering styles with responsive wrap

## Implementation
- Uses `inline-flex` with `justify-content: center` and `flex-wrap: wrap`
- Zero JavaScript, zero new dependencies
- Only affects `home-priority-spotlight`, other home-priority-card-head instances remain unchanged

## Validation
- ✅ Responsive across desktop and mobile (flex-wrap handles overflow)
- ✅ Follows existing Homedir CSS conventions
- ✅ Atomic change: 2 files (HTML + CSS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the home page spotlight section with improved visual alignment and spacing between event icons and their details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->