### PR TITLE
fix: resolve ProfileResourceTest flaky test race condition

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/service/PersistenceService.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/service/PersistenceService.java
@@ -342,6 +342,12 @@ public class PersistenceService {
     scheduleWrite(scheduleFile(year), schedules);
   }
 
+  /** Persists user schedules for the given year synchronously. */
+  public void saveUserSchedulesSync(
+      int year, Map<String, Map<String, UserScheduleService.TalkDetails>> schedules) {
+    writeSync(scheduleFile(year), schedules);
+  }
+
   /** Loads events from disk or returns an empty map if none. */
   public Map<String, Event> loadEvents() {
     return read(eventsFile, new TypeReference<Map<String, Event>>() {

--- a/quarkus-app/src/main/java/com/scanales/homedir/service/UserScheduleService.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/service/UserScheduleService.java
@@ -228,9 +228,13 @@ public class UserScheduleService {
 
   /** Clears all schedules and historical data (testing only). */
   public void reset() {
+    if (refreshTask != null) {
+      refreshTask.cancel(false);
+      refreshTask = null;
+    }
     schedules.clear();
     historical.clear();
-    persistence.saveUserSchedules(activeYear, schedules);
+    persistence.saveUserSchedulesSync(activeYear, schedules);
   }
 
   /** Result codes for loading historical data. */


### PR DESCRIPTION
### Description
This PR resolves the flaky test failure in `ProfileResourceTest.addTalkJson` on the `main` branch.

### Cause of the Failure
The test was failing because `UserScheduleService.reset()` (called in `@BeforeEach setup()`) clears the in-memory state and calls `persistence.saveUserSchedules(activeYear, schedules)`. However, `persistence.saveUserSchedules` is **asynchronous** and **debounced**. It returns immediately before the empty state is written to disk.
If the background scheduled executor task `refreshSnapshot()` fires before the write finishes, it reads the old schedule file from disk (which still contains the talk `t1` from a previous test run or execution) and re-populates the in-memory `schedules` map. When the test later tries to add `t1` and expects a status of `"added"`, it instead gets `"exists"`, failing the test.

### Solution
1. Added `saveUserSchedulesSync` in `PersistenceService.java` to allow synchronous writes of user schedules.
2. Updated `UserScheduleService.reset()` to:
   - Cancel any pending background refresh task (`refreshTask.cancel(false)`) to prevent concurrent modifications during the test transition.
   - Call `persistence.saveUserSchedulesSync(activeYear, schedules)` to write the empty schedules to disk **synchronously**.

This ensures that the disk file is immediately and guaranteed to be empty before the next test runs, eliminating the race condition.
All 25 tests in `ProfileResourceTest` now pass successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resetting schedules now clears any pending refresh activity before wiping stored data.
  * Cleared schedule data is now saved immediately, helping ensure the app reflects the reset right away.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->