### PR TITLE
fix: allow CFP catalog promotion before results published

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/CfpSubmissionApiResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/CfpSubmissionApiResource.java
@@ -786,7 +786,8 @@ public class CfpSubmissionApiResource {
       return Response.status(Response.Status.NOT_FOUND).entity(Map.of("error", "submission_not_found")).build();
     }
     CfpSubmission submission = existing.get();
-    if (cfpSubmissionService.visibleStatus(submission) != CfpSubmissionStatus.ACCEPTED) {
+    CfpSubmissionStatus internalStatus = submission.status() != null ? submission.status() : CfpSubmissionStatus.PENDING;
+    if (internalStatus != CfpSubmissionStatus.ACCEPTED) {
       return Response.status(Response.Status.CONFLICT).entity(Map.of("error", "submission_not_accepted")).build();
     }
 


### PR DESCRIPTION
Closes #1000

## Summary
- Fixed catalog promotion endpoint to check internal submission status instead of visible status
- Allows admins to promote internally-accepted CFP submissions to the catalog before publishing results

## Problem
When an admin accepted a CFP submission, the author still saw it as `under_review` in their profile. Additionally, attempting to promote the submission to the catalog failed with `submission_not_accepted` error.

## Root Cause
The `/promote` endpoint was checking `visibleStatus()`, which returns `UNDER_REVIEW` for accepted submissions when results haven't been published yet. This blocked the intended workflow:
1. Admin accepts submission internally
2. Admin promotes submission to catalog
3. Admin publishes results later

## Solution  
Changed the promotion check at `CfpSubmissionApiResource.java:789` to use the **internal status** (`submission.status()`) instead of `visibleStatus()`. Now admins can promote internally-accepted submissions regardless of result publication status.

## Testing
- Manual code review confirms the fix
- Changed files: 1 (CfpSubmissionApiResource.java)
- Lines changed: 2 insertions, 1 deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the submission promotion check so only accepted submissions can be promoted.
  * If a submission is not accepted, the API now returns a clear conflict response sooner, helping prevent invalid promotion attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->