### PR TITLE
fix(ci): stabilize required main gates with summary checks

### DIFF
--- a/.github/workflows/pr-ci-build-native-sbom.yml
+++ b/.github/workflows/pr-ci-build-native-sbom.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches: [ main ]
     types: [opened, reopened, synchronize, ready_for_review]
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
   workflow_dispatch:
 
 permissions:
@@ -43,3 +40,25 @@ jobs:
           name: sbom-${{ github.sha }}
           path: quarkus-app/target/bom.json
           retention-days: 30
+
+  ci-summary:
+    name: CI Summary
+    needs: [sbom]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize CI gates
+        run: |
+          echo "### PR CI Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Gate | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| sbom | ${{ needs.sbom.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${{ needs.sbom.result }}" != "success" ]; then
+            echo "**Result:** FAILED - SBOM generation did not pass" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "**Result:** PASSED - SBOM generation passed" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr-ci-build-native-sbom.yml
+++ b/.github/workflows/pr-ci-build-native-sbom.yml
@@ -49,6 +49,13 @@ jobs:
     steps:
       - name: Summarize CI gates
         run: |
+          gate_ok() {
+            case "$1" in
+              success|skipped) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
           echo "### PR CI Summary" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Gate | Status |" >> "$GITHUB_STEP_SUMMARY"
@@ -56,7 +63,7 @@ jobs:
           echo "| sbom | ${{ needs.sbom.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "${{ needs.sbom.result }}" != "success" ]; then
+          if ! gate_ok "${{ needs.sbom.result }}"; then
             echo "**Result:** FAILED - SBOM generation did not pass" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi

--- a/.github/workflows/pr-quality-suite.yml
+++ b/.github/workflows/pr-quality-suite.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches: [ main ]
     types: [opened, reopened, synchronize, ready_for_review]
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
   workflow_dispatch:
 
 permissions:
@@ -116,3 +113,33 @@ jobs:
       - name: Dependency analysis
         working-directory: quarkus-app
         run: ./mvnw dependency:analyze -B -q
+
+  quality-summary:
+    name: Quality Summary
+    needs: [style, static, arch, tests_cov, deps]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize quality gates
+        run: |
+          echo "### PR Quality Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Gate | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| style | ${{ needs.style.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| static | ${{ needs.static.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| arch | ${{ needs.arch.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| tests_cov | ${{ needs.tests_cov.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| deps | ${{ needs.deps.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${{ needs.style.result }}" != "success" ] || \
+             [ "${{ needs.static.result }}" != "success" ] || \
+             [ "${{ needs.arch.result }}" != "success" ] || \
+             [ "${{ needs.tests_cov.result }}" != "success" ] || \
+             [ "${{ needs.deps.result }}" != "success" ]; then
+            echo "**Result:** FAILED - One or more PR quality checks did not pass" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "**Result:** PASSED - All PR quality checks passed" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr-quality-suite.yml
+++ b/.github/workflows/pr-quality-suite.yml
@@ -122,6 +122,13 @@ jobs:
     steps:
       - name: Summarize quality gates
         run: |
+          gate_ok() {
+            case "$1" in
+              success|skipped) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
           echo "### PR Quality Summary" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Gate | Status |" >> "$GITHUB_STEP_SUMMARY"
@@ -133,11 +140,11 @@ jobs:
           echo "| deps | ${{ needs.deps.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "${{ needs.style.result }}" != "success" ] || \
-             [ "${{ needs.static.result }}" != "success" ] || \
-             [ "${{ needs.arch.result }}" != "success" ] || \
-             [ "${{ needs.tests_cov.result }}" != "success" ] || \
-             [ "${{ needs.deps.result }}" != "success" ]; then
+          if ! gate_ok "${{ needs.style.result }}" || \
+             ! gate_ok "${{ needs.static.result }}" || \
+             ! gate_ok "${{ needs.arch.result }}" || \
+             ! gate_ok "${{ needs.tests_cov.result }}" || \
+             ! gate_ok "${{ needs.deps.result }}"; then
             echo "**Result:** FAILED - One or more PR quality checks did not pass" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches: [ main ]
     types: [opened, reopened, synchronize, ready_for_review]
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
   push:
     branches: [ main ]
   workflow_dispatch:


### PR DESCRIPTION
## Summary\n\nThis changes branch protection from granular job checks to stable summary gates that still fail if any underlying quality or security job fails. It also removes workflow-level docs-only path ignores from the required PR workflows so the required checks are always reported on PRs to main.\n\n### What changed\n- Added Quality Summary to PR Quality — Suite.\n- Added CI Summary to PR CI (Build, Native, SBOM/Scan).\n- Kept Quality Gate Summary as the security summary gate.\n- Removed paths-ignore from the required PR workflows so the gates are always emitted.\n- Updated the main branch ruleset to require the summary checks instead of the granular job checks.\n\n### Why\n\nThe previous ruleset was requiring individual job contexts that were being left pending inconsistently across PRs, even after equivalent checks had completed successfully. The summary gates preserve quality and security coverage while giving GitHub a smaller, stable set of required contexts to evaluate.\n\n### Validation\n- YAML parses cleanly for all modified workflows.\n- The main ruleset now requires:\n  - PR Quality — Suite / Quality Summary\n  - PR CI (Build, Native, SBOM/Scan) / CI Summary\n  - Quality Gates / Quality Gate Summary\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow step summaries that report CI (SBOM) and quality-gate status directly in the run output.
* **Bug Fixes**
  * PR CI/quality checks now run even when changes are limited to documentation or markdown files, instead of being skipped.
  * Workflow summaries now explicitly mark results as **PASSED** or **FAILED** and fail the job when required checks don’t succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->