### PR TITLE
fix(security): escapeAttr XSS and validate targetUrl

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
@@ -103,7 +103,9 @@
       const checked = selected.has(n.id) ? 'checked' : '';
       const readLabel = n.readAt ? i18n.toggleMarkUnread : i18n.toggleMarkRead;
       const chip = chipFor(n);
-      const url = n.targetUrl || (n.talkId ? `/talks/${encodeURIComponent(n.talkId)}` : '/notifications/center');
+      let url = n.targetUrl;
+      if (url && !isValidUrl(url)) url = null;
+      url = url || (n.talkId ? `/talks/${encodeURIComponent(n.talkId)}` : '/notifications/center');
       const linkLabel = n.talkId ? i18n.linkViewTalk : i18n.linkOpen;
 
       div.innerHTML = `
@@ -161,7 +163,14 @@
     }[m]));
   }
   function escapeAttr(s) {
-    return String(s).replace(/"/g, '&quot;');
+    return escapeHtml(s);
+  }
+
+  function isValidUrl(str) {
+    try {
+      const url = new URL(str, window.location.origin);
+      return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch { return false; }
   }
 
   function updateSelectAllBtn() {


### PR DESCRIPTION
## Summary

Fix two security issues in `notifications-center.js`: incomplete HTML escaping in `escapeAttr` and unvalidated `targetUrl` in notification links.

## Changes

1. **escapeAttr now delegates to escapeHtml** — previously only escaped `"`, now escapes `&`, `<`, `>`, `"`, `'` like escapeHtml does. Prevents attribute injection when user-influenced values end up in attribute positions.

2. **targetUrl validated with isValidUrl()** — uses the URL constructor to reject `javascript:`, `data:`, and other non-HTTP(S) schemes. Falls back to `/notifications/center` when the stored URL is invalid.

## Scope

- `quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js` (+11/-2)

## Verification

- `escapeAttr("test\"&\'<>")` now returns safe escaped string
- `isValidUrl("javascript:alert(1)")` returns false
- `isValidUrl("/relative/path")` returns true
- `isValidUrl("https://example.com")` returns true

Closes #1021


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification “open” links now use a safe fallback URL when a target link is missing or invalid.
  * Improved link validation to allow only standard web URLs, reducing the chance of broken or unsafe navigation.
  * Strengthened attribute escaping to better protect displayed link values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->