### PR TITLE
chore(css): show link URLs in print output

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/print.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/print.css
@@ -56,6 +56,18 @@
     text-decoration: underline;
   }
 
+  a[href]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    font-weight: normal;
+    color: #555 !important;
+    text-decoration: none;
+  }
+
+  a[href^="/"]::after {
+    content: " (https://homedir.opensourcesantiago.io" attr(href) ")";
+  }
+
   h1, h2, h3, h4 {
     page-break-after: avoid;
   }

--- a/quarkus-app/src/main/resources/META-INF/resources/css/print.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/print.css
@@ -56,7 +56,7 @@
     text-decoration: underline;
   }
 
-  a[href]::after {
+  a[href]:not([href^="#"]):not([href^="javascript:"])::after {
     content: " (" attr(href) ")";
     font-size: 0.8em;
     font-weight: normal;
@@ -64,7 +64,7 @@
     text-decoration: none;
   }
 
-  a[href^="/"]::after {
+  a[href^="/"]:not([href^="//"])::after {
     content: " (https://homedir.opensourcesantiago.io" attr(href) ")";
   }
 


### PR DESCRIPTION
## Summary

Add link destination URLs to printed pages so they remain useful as physical documents. Without this, readers see underlined text but have no way to know where links go.

## Changes

- `a[href]::after` shows the full URL in parentheses after each link
- Relative paths (`/eventos`, `/comunidad`, etc.) are expanded to the full production URL
- Printed link URLs use smaller, muted styling to avoid visual clutter

## Scope

- `quarkus-app/src/main/resources/META-INF/resources/css/print.css` (+12)

Closes #1033


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Printed pages now automatically display the linked URL after each hyperlink, making references easier to follow on paper.
  * Relative and root-relative links are rendered in a clearer, more explicit format for improved print readability.
* **Style**
  * The appended URL text is shown in a smaller, subdued style (gray, no underline) to keep focus on the main content while preserving context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->