### PR TITLE
fix(templates): remove inline styles and !important from notification center (#1020)

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
@@ -273,6 +273,26 @@
   border: 0;
 }
 
+/* Notification center filter buttons */
+.notif-filter-btn {
+  background: transparent;
+  border: none !important;
+  outline: none;
+}
+
+.notif-section-body {
+  min-height: 400px;
+}
+
+#confirmDeleteAll {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  margin: 0;
+  z-index: 100;
+}
+
 /* Bell in navigation bar */
 .notifications-bell {
   position: relative;

--- a/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
@@ -276,8 +276,13 @@
 /* Notification center filter buttons */
 .notif-filter-btn {
   background: transparent;
-  border: none !important;
+  border: none;
   outline: none;
+}
+
+.notif-filter-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 .notif-section-body {

--- a/quarkus-app/src/main/resources/templates/notifications/center.html
+++ b/quarkus-app/src/main/resources/templates/notifications/center.html
@@ -11,14 +11,14 @@
   {/include}
 
   <div class="page-grid section-grid-full">
-    <div class="section-body flex flex-col" style="min-height: 400px;">
+    <div class="section-body flex flex-col notif-section-body">
       <div class="hd-tabs quest-tabs mb-6">
-        <div class="quest-tabs-links" style="border: none !important;">
-          <button class="hd-tab active btn-link-filter filter-btn bg-transparent border-0 cursor-pointer text-base"
-            style="background: transparent; border: none !important;" data-filter="all">{i18n:notifications_center_filter_all}</button>
+        <div class="quest-tabs-links">
+          <button class="hd-tab active btn-link-filter notif-filter-btn"
+            data-filter="all">{i18n:notifications_center_filter_all}</button>
           <span class="quest-tab-separator">|</span>
-          <button class="hd-tab btn-link-filter filter-btn bg-transparent border-0 cursor-pointer text-base"
-            style="background: transparent; border: none !important;" data-filter="unread">{i18n:notifications_center_filter_unread}</button>
+          <button class="hd-tab btn-link-filter notif-filter-btn"
+            data-filter="unread">{i18n:notifications_center_filter_unread}</button>
         </div>
         <div class="actions-right ml-auto flex gap-2">
           <button class="btn-primary btn-sm" id="selectAll">{i18n:notifications_center_action_select_all}</button>
@@ -42,8 +42,7 @@
     </div>
   </div>
 
-  <dialog id="confirmDeleteAll" class="section-body"
-    style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); margin: 0; z-index: 100;">
+  <dialog id="confirmDeleteAll" class="section-body">
     <h2 class="text-xl mb-4 font-bold">{i18n:notifications_center_confirm_title}</h2>
     <p class="mb-4">{i18n:notifications_center_confirm_desc}</p>
     <div class="actions flex gap-4 justify-end">


### PR DESCRIPTION
## Descripción
Remueve todos los estilos inline (incluyendo 3 con `!important`) del template del centro de notificaciones y los mueve a CSS con clases apropiadas.

## Cambios
- `notifications.css`: Nuevas clases `.notif-filter-btn`, `.notif-section-body` y reglas para `#confirmDeleteAll`
- `center.html`: Eliminados 5 atributos `style=""` (3 con `!important`)
- Se removieron clases utilitarias (`bg-transparent`, `border-0`, `cursor-pointer`, `text-base`) que no tenían definición CSS asociada

## Impacto
- ✅ Sin inline styles ni !important en el template del notification center
- ✅ Misma apariencia visual (los valores CSS son idénticos)
- ✅ Mejor mantenibilidad — cambios de estilo desde CSS, no desde HTML

Closes #1020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the notifications center layout and spacing, including a taller content area for better readability.
  * Updated filter controls to use consistent styling with clearer keyboard focus visibility.
  * Centered the “Delete all” confirmation dialog on screen for a cleaner, more predictable display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->