### PR TITLE
refactor(i18n): replace data-i18n attributes with JS object literal in notification center (#1024)

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
@@ -4,7 +4,7 @@
     return;
   }
 
-  const i18n = window.__NOTIF_I18N__ || {
+  const I18N_DEFAULTS = {
     toggleMarkRead: 'Mark as read',
     toggleMarkUnread: 'Mark as unread',
     linkViewTalk: 'View talk',
@@ -21,6 +21,7 @@
     sampleCommunity: 'A community pick you follow receives traction.',
     sampleProject: 'Important project release and delivery updates.'
   };
+  const i18n = Object.assign({}, I18N_DEFAULTS, window.__NOTIF_I18N__);
 
   const LS_KEY = 'ef_global_notifs'; // array de notifs [{id, title, message, createdAt, readAt?, dismissedAt?, targetUrl?}]
   const UNREAD_KEY = 'ef_global_unread_count';

--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
@@ -4,22 +4,22 @@
     return;
   }
 
-  const i18n = {
-    toggleMarkRead: root.dataset.i18nToggleMarkRead || 'Mark as read',
-    toggleMarkUnread: root.dataset.i18nToggleMarkUnread || 'Mark as unread',
-    linkViewTalk: root.dataset.i18nLinkViewTalk || 'View talk',
-    linkOpen: root.dataset.i18nLinkOpen || 'Open',
-    defaultTitle: root.dataset.i18nDefaultTitle || 'Notification',
-    catEvent: root.dataset.i18nCatEvent || 'Event',
-    catTalk: root.dataset.i18nCatTalk || 'Talk',
-    catBreak: root.dataset.i18nCatBreak || 'Break',
-    catAnnouncement: root.dataset.i18nCatAnnouncement || 'Announcement',
-    selectAll: root.dataset.i18nSelectAll || 'Select all',
-    deselectAll: root.dataset.i18nDeselectAll || 'Deselect all',
-    sampleTitle: root.dataset.i18nSampleTitle || 'What you will see here',
-    sampleEvent: root.dataset.i18nSampleEvent || 'New event or agenda update is published.',
-    sampleCommunity: root.dataset.i18nSampleCommunity || 'A community pick you follow receives traction.',
-    sampleProject: root.dataset.i18nSampleProject || 'Important project release and delivery updates.'
+  const i18n = window.__NOTIF_I18N__ || {
+    toggleMarkRead: 'Mark as read',
+    toggleMarkUnread: 'Mark as unread',
+    linkViewTalk: 'View talk',
+    linkOpen: 'Open',
+    defaultTitle: 'Notification',
+    catEvent: 'Event',
+    catTalk: 'Talk',
+    catBreak: 'Break',
+    catAnnouncement: 'Announcement',
+    selectAll: 'Select all',
+    deselectAll: 'Deselect all',
+    sampleTitle: 'What you will see here',
+    sampleEvent: 'New event or agenda update is published.',
+    sampleCommunity: 'A community pick you follow receives traction.',
+    sampleProject: 'Important project release and delivery updates.'
   };
 
   const LS_KEY = 'ef_global_notifs'; // array de notifs [{id, title, message, createdAt, readAt?, dismissedAt?, targetUrl?}]

--- a/quarkus-app/src/main/resources/templates/notifications/center.html
+++ b/quarkus-app/src/main/resources/templates/notifications/center.html
@@ -2,22 +2,7 @@
 {#title}{i18n:notifications_center_title}{/title}
 
 {#body}
-<section class="notifications-center"
-  data-i18n-toggle-mark-read="{i18n:notifications_center_js_toggle_mark_read}"
-  data-i18n-toggle-mark-unread="{i18n:notifications_center_js_toggle_mark_unread}"
-  data-i18n-link-view-talk="{i18n:notifications_center_js_link_view_talk}"
-  data-i18n-link-open="{i18n:notifications_center_js_link_open}"
-  data-i18n-default-title="{i18n:notifications_center_js_default_title}"
-  data-i18n-cat-event="{i18n:notifications_center_js_category_event}"
-  data-i18n-cat-talk="{i18n:notifications_center_js_category_talk}"
-  data-i18n-cat-break="{i18n:notifications_center_js_category_break}"
-  data-i18n-cat-announcement="{i18n:notifications_center_js_category_announcement}"
-  data-i18n-select-all="{i18n:notifications_center_js_select_all}"
-  data-i18n-deselect-all="{i18n:notifications_center_js_deselect_all}"
-  data-i18n-sample-title="{i18n:notifications_center_js_sample_title}"
-  data-i18n-sample-event="{i18n:notifications_center_js_sample_event}"
-  data-i18n-sample-community="{i18n:notifications_center_js_sample_community}"
-  data-i18n-sample-project="{i18n:notifications_center_js_sample_project}">
+<section class="notifications-center">
   {#include fragments/page-header}
   <h1 class="page-title">{i18n:notifications_center_title}</h1>
   <p class="section-subtitle">
@@ -67,6 +52,25 @@
     </div>
   </dialog>
 
+  <script>
+    window.__NOTIF_I18N__ = {
+      toggleMarkRead: '{i18n:notifications_center_js_toggle_mark_read}',
+      toggleMarkUnread: '{i18n:notifications_center_js_toggle_mark_unread}',
+      linkViewTalk: '{i18n:notifications_center_js_link_view_talk}',
+      linkOpen: '{i18n:notifications_center_js_link_open}',
+      defaultTitle: '{i18n:notifications_center_js_default_title}',
+      catEvent: '{i18n:notifications_center_js_category_event}',
+      catTalk: '{i18n:notifications_center_js_category_talk}',
+      catBreak: '{i18n:notifications_center_js_category_break}',
+      catAnnouncement: '{i18n:notifications_center_js_category_announcement}',
+      selectAll: '{i18n:notifications_center_js_select_all}',
+      deselectAll: '{i18n:notifications_center_js_deselect_all}',
+      sampleTitle: '{i18n:notifications_center_js_sample_title}',
+      sampleEvent: '{i18n:notifications_center_js_sample_event}',
+      sampleCommunity: '{i18n:notifications_center_js_sample_community}',
+      sampleProject: '{i18n:notifications_center_js_sample_project}'
+    };
+  </script>
   <script defer src="/js/notifications-center.js"></script>
 </section>
 {/body}


### PR DESCRIPTION
## Descripción
Reemplaza 15 atributos `data-i18n-*` en el elemento `<section>` del centro de notificaciones por un bloque `<script>` inline con `window.__NOTIF_I18N__`.

## Cambios
- `center.html`: Eliminados 15 `data-i18n-*` atributos; añadido bloque `<script>` con el objeto i18n
- `notifications-center.js`: Lee de `window.__NOTIF_I18N__` con fallback a defaults en inglés

## Impacto
- ✅ HTML más limpio sin 15 atributos data- en el elemento raíz
- ✅ Misma funcionalidad (fallback incluido)
- ✅ Fácil de extender con nuevas claves i18n

Closes #1024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the notifications center to load its labels and sample text from a new client-side source, keeping the visible interface behavior the same.
  * Simplified how notification text is delivered to the page, making the interface setup more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->