### PR TITLE
fix(a11y): add prefers-reduced-motion across all CSS files (#1037)

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/community-page.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/community-page.css
@@ -1356,7 +1356,9 @@
     }
 
     .community-item-card,
-    .community-vote-btn {
+    .community-vote-btn,
+    .community-media-btn,
+    .community-topic-btn {
       transition: none;
     }
   }

--- a/quarkus-app/src/main/resources/META-INF/resources/css/dev-login.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/dev-login.css
@@ -182,7 +182,9 @@ body.dev-login-page {
   *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+    animation-delay: 0.01ms !important;
     transition-duration: 0.01ms !important;
+    transition-delay: 0.01ms !important;
     scroll-behavior: auto !important;
   }
 }

--- a/quarkus-app/src/main/resources/META-INF/resources/css/dev-login.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/dev-login.css
@@ -175,3 +175,14 @@ body.dev-login-page {
 .dev-back-link:hover {
     color: #ffd700;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -6268,3 +6268,14 @@ footer {
   font-size: 3rem;
   margin-bottom: 1rem;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -6275,7 +6275,9 @@ footer {
   *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+    animation-delay: 0.01ms !important;
     transition-duration: 0.01ms !important;
+    transition-delay: 0.01ms !important;
     scroll-behavior: auto !important;
   }
 }

--- a/quarkus-app/src/main/resources/META-INF/resources/css/retro-theme.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/retro-theme.css
@@ -3584,7 +3584,9 @@
   *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+    animation-delay: 0.01ms !important;
     transition-duration: 0.01ms !important;
+    transition-delay: 0.01ms !important;
     scroll-behavior: auto !important;
   }
 }

--- a/quarkus-app/src/main/resources/META-INF/resources/css/retro-theme.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/retro-theme.css
@@ -3577,3 +3577,14 @@
     .btn-search-submit .material-symbols-outlined {
       font-size: 1.2rem;
     }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/css/trending.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/trending.css
@@ -130,7 +130,9 @@
   *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+    animation-delay: 0.01ms !important;
     transition-duration: 0.01ms !important;
+    transition-delay: 0.01ms !important;
     scroll-behavior: auto !important;
   }
 }

--- a/quarkus-app/src/main/resources/META-INF/resources/css/trending.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/trending.css
@@ -123,3 +123,14 @@
     flex-wrap: wrap;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/css/wrapped.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/wrapped.css
@@ -507,7 +507,9 @@
   *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+    animation-delay: 0.01ms !important;
     transition-duration: 0.01ms !important;
+    transition-delay: 0.01ms !important;
     scroll-behavior: auto !important;
   }
 }

--- a/quarkus-app/src/main/resources/META-INF/resources/css/wrapped.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/wrapped.css
@@ -500,3 +500,14 @@
     transform: translateY(0);
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Descripción
Solo `notifications.css` tenía un bloque `@media (prefers-reduced-motion: reduce)`, dejando ~170 reglas de animación/transición/transform sin cubrir en otros 6 archivos CSS.

## Cambios
- **homedir.css**, **retro-theme.css**, **wrapped.css**, **trending.css**, **dev-login.css**: Añadido bloque universal WCAG que reduce toda animación/transición a 0.01ms
- **community-page.css**: Extendido bloque existente para cubrir `.community-media-btn` y `.community-topic-btn`

## Impacto
- ✅ Usuarios con `prefers-reduced-motion: reduce` ya no experimentan movimiento no deseado
- ✅ Sin cambios visuales para el resto de usuarios
- ✅ Approach universal (misma técnica usada por Bootstrap y Tailwind)

Closes #1037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved reduced-motion support across multiple pages and themes, making animations, transitions, and smooth scrolling less distracting for users who prefer minimal motion.
  * Expanded reduced-motion handling to cover more interactive page elements, creating a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->