### PR TITLE
fix(a11y): add aria-hidden to decorative emoji and icons (#1036)

### DIFF
--- a/quarkus-app/src/main/resources/templates/fragments/header.html
+++ b/quarkus-app/src/main/resources/templates/fragments/header.html
@@ -61,7 +61,7 @@
           {/if}
           <span class="user-name">
             {#if userSession.questClass}
-            <span title="{userSession.questClass.displayName}" class="user-class-icon">
+            <span title="{userSession.questClass.displayName}" class="user-class-icon" aria-hidden="true">
               {#switch userSession.questClass.toString()}
               {#case 'ENGINEER'}<span class="material-symbols-outlined">engineering</span>{/case}
               {#case 'SCIENTIST'}<span class="material-symbols-outlined">science</span>{/case}

--- a/quarkus-app/src/main/resources/templates/publicChallenge.qute.html
+++ b/quarkus-app/src/main/resources/templates/publicChallenge.qute.html
@@ -16,7 +16,7 @@
                 {/if}
                 <div class="wrapped-rank-badge">{questClass}</div>
             </div>
-            <p class="wrapped-subtitle">{questClassEmoji} {i18n:public_profile_challenge_share_eyebrow}</p>
+            <p class="wrapped-subtitle"><span aria-hidden="true">{questClassEmoji}</span> {i18n:public_profile_challenge_share_eyebrow}</p>
             <h1 class="wrapped-title">{challenge.title}</h1>
             <p class="wrapped-subtext wrapped-share-intro">{challenge.description}</p>
         </header>
@@ -28,7 +28,7 @@
                     <h2 class="wrapped-share-owner">{displayName}</h2>
                 </div>
                 <div class="wrapped-meta-row">
-                    <span class="wrapped-badge-pill">{challenge.classEmoji} {challenge.className}</span>
+                    <span class="wrapped-badge-pill"><span aria-hidden="true">{challenge.classEmoji}</span> {challenge.className}</span>
                     <span class="wrapped-badge-pill">{challenge.rewardLabel}</span>
                     <span class="wrapped-badge-pill">{challenge.progressLabel}</span>
                 </div>

--- a/quarkus-app/src/main/resources/templates/publicProfile.qute.html
+++ b/quarkus-app/src/main/resources/templates/publicProfile.qute.html
@@ -70,7 +70,7 @@
                     {#for cls in classProgress}
                     <div class="wrapped-class-item">
                         <div class="wrapped-class-header">
-                            <span aria-hidden="true">{cls.emoji}</span> <span>{cls.className}</span>
+                            <span><span aria-hidden="true">{cls.emoji}</span> {cls.className}</span>
                             <span>{cls.xp} XP</span>
                         </div>
                         <div class="wrapped-xp-channel wrapped-class-bar">

--- a/quarkus-app/src/main/resources/templates/publicProfile.qute.html
+++ b/quarkus-app/src/main/resources/templates/publicProfile.qute.html
@@ -22,7 +22,7 @@
             </div>
             <h1 class="wrapped-title">{displayName}</h1>
             <p class="wrapped-subtitle">
-                <span class="wrapped-stat-value gold" style="font-size: 1.2rem;">{i18n:public_profile_level_badge(level)}</span> • {questClassEmoji}
+                <span class="wrapped-stat-value gold" style="font-size: 1.2rem;">{i18n:public_profile_level_badge(level)}</span> • <span aria-hidden="true">{questClassEmoji}</span>
                 {i18n:public_profile_guild_badge(questClass)}
             </p>
             {#if hasProfileGlow}
@@ -70,7 +70,7 @@
                     {#for cls in classProgress}
                     <div class="wrapped-class-item">
                         <div class="wrapped-class-header">
-                            <span>{cls.emoji} {cls.className}</span>
+                            <span aria-hidden="true">{cls.emoji}</span> <span>{cls.className}</span>
                             <span>{cls.xp} XP</span>
                         </div>
                         <div class="wrapped-xp-channel wrapped-class-bar">
@@ -447,7 +447,7 @@
                         </div>
                         <p class="wrapped-subtext">{challenge.description}</p>
                         <div class="wrapped-meta-row">
-                            <span class="wrapped-badge-pill">{challenge.classEmoji} {challenge.className}</span>
+                            <span class="wrapped-badge-pill"><span aria-hidden="true">{challenge.classEmoji}</span> {challenge.className}</span>
                             <span class="wrapped-badge-pill">{challenge.progressLabel}</span>
                             <span class="wrapped-badge-pill">{challenge.completedLabel}</span>
                         </div>


### PR DESCRIPTION
## Descripción
Los caracteres emoji (questClassEmoji, cls.emoji, challenge.classEmoji) y los iconos Material Symbols de clase en el header no tenían `aria-hidden=true`, causando que lectores de pantalla anunciaran caracteres decorativos (ej. "varios 5" en vez de ignorarlos).

## Cambios
- `publicProfile.qute.html`: 3 emoji envueltos en `<span aria-hidden=true>`
- `publicChallenge.qute.html`: 2 emoji envueltos en `<span aria-hidden=true>`
- `header.html`: `aria-hidden=true` en el contenedor del icono de clase de usuario

## Nota
La auditoría completa de `<img>` tags confirmó que **los 38 tags en todos los templates ya tienen alt text** — este issue quedaba pendiente solo por los emoji decorativos.

Closes #1036

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility by marking decorative emoji and class icons as hidden from screen readers.
  * Updated public profile, challenge, and header displays so assistive technologies focus on meaningful text instead of icon-only content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->