### PR TITLE
fix(responsive): adapt event cards grid for small mobile screens (#1015)

### DIFF
--- a/quarkus-app/src/main/resources/templates/EventsDirectoryResource/eventos.html
+++ b/quarkus-app/src/main/resources/templates/EventsDirectoryResource/eventos.html
@@ -491,6 +491,45 @@
       font-size: 1.12rem;
     }
   }
+
+  @media (max-width: 480px) {
+    .events-stats-container {
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    }
+
+    .event-highlight-card {
+      grid-template-columns: 56px minmax(0, 1fr);
+      gap: 0.55rem;
+      min-height: auto;
+    }
+
+    .event-highlight-media {
+      width: 56px;
+      height: 56px;
+    }
+
+    .event-highlight-content h3 {
+      font-size: 0.95rem;
+    }
+
+    .event-highlight-summary {
+      font-size: 0.78rem;
+    }
+
+    .event-past-card {
+      grid-template-columns: 40px minmax(0, 1fr) auto;
+      gap: 0.5rem;
+    }
+
+    .event-past-media {
+      width: 40px;
+      height: 40px;
+    }
+
+    .event-past-info h3 {
+      font-size: 0.82rem;
+    }
+  }
 </style>
 {/body}
 {/include}


### PR DESCRIPTION
## Descripción
La página de eventos no tenía un breakpoint para pantallas móviles pequeñas (<480px). En un dispositivo de 360-480px, las tarjetas de evento se veían comprimidas y las estadísticas ocupaban 3 columnas.

## Cambios
Nuevo breakpoint `@media (max-width: 480px)` en `eventos.html`:
- `.events-stats-container`: 3 columnas fijas → `auto-fit` con mínimo de 120px
- `.event-highlight-card`: media de 74px → 56px, gap reducido
- `.event-highlight-content h3`: 1.05rem → 0.95rem
- `.event-highlight-summary`: 0.83rem → 0.78rem
- `.event-past-card`: media de 48px → 40px, gap reducido
- `.event-past-info h3`: 0.9rem → 0.82rem

## Impacto
- ✅ Tarjetas de evento legibles en móviles de 360px+
- ✅ Estadísticas ya no se ven comprimidas en 3 columnas
- ✅ Sin cambios visuales en desktop/tablet

Closes #1015

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the event directory layout for very small screens, including better spacing, sizing, and typography for event cards, media, titles, summaries, and past events.
  * Added a mobile-friendly breakpoint to make the page easier to read and navigate on screens up to 480px wide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->