### PR TITLE
feat(platform): add autonomous homedir AI SDLC runner

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.md text eol=lf
+*.sh text eol=lf
+.gitattributes text eol=lf
+platform/systemd/** text eol=lf
+platform/ansible/** text eol=lf
+platform/env*.example text eol=lf

--- a/docs/en/development/autonomous-sdlc.md
+++ b/docs/en/development/autonomous-sdlc.md
@@ -1,0 +1,179 @@
+# Autonomous SDLC Operating Model
+
+This document defines the issue-driven autonomous SDLC for HomeDir.
+
+## Principle
+
+Automation is autonomous only inside repository rules. It must never bypass, weaken,
+or overwrite branch protection, repository rulesets, required checks, required
+reviews, secret handling, or deployment gates.
+
+If a rule blocks progress, the automation reports the blocker and moves the issue
+to a human-needed state.
+
+The autonomous SDLC must be managed by the SSH server, not by a developer
+workstation. Local machines may bootstrap or update the server, but the normal
+listener, worker, credentials, logs, queue, GitHub authentication, SCC runtime,
+and repository worktree all live on the server.
+
+## Trigger
+
+An issue is eligible only when all conditions are true:
+
+- The issue is open.
+- The issue author is `scanalesespinoza`.
+- The issue has the `ready-to-implement` label.
+- The issue does not have an active terminal or in-progress automation label.
+- The issue metadata is clear enough to implement and validate.
+
+OpenClaw may act as the event listener. The worker may also poll GitHub as a
+fallback. Both paths must apply the same eligibility rules.
+
+## Lifecycle Labels
+
+Use these labels for automation state:
+
+| Label | Meaning |
+| --- | --- |
+| `ready-to-implement` | Human-approved trigger for autonomous implementation |
+| `scc-running` | The SCC worker has claimed the issue |
+| `scc-pr-open` | A pull request was opened for the issue |
+| `scc-merged` | The PR was merged and the `Production Release` workflow succeeded |
+| `scc-failed` | Automation failed after allowed retries |
+| `needs-human` | A repository rule, unclear requirement, security concern, or repeated failure requires human action |
+
+Existing `wos-review` triage can remain separate. It should not trigger
+implementation unless `ready-to-implement` is also present.
+
+## Worker Flow
+
+1. Acquire a lock so only one worker instance mutates the repository at a time.
+2. Fetch eligible issues from GitHub.
+3. Claim one issue by adding `scc-running`.
+4. Create or reset a clean local worktree from `origin/main`.
+5. Create branch `scc/issue-<number>-<slug>`.
+6. Run `scc -yq` with the controlled implementation prompt.
+7. Require a PR branch and pull request, never a direct push to `main`.
+8. Run local validation appropriate to the change.
+9. Push the branch and create/update a PR with `Closes #<issue>`.
+10. Enable normal auto-merge only when repository protection allows it.
+11. Monitor CI and release workflows.
+12. Comment the result and update lifecycle labels.
+
+## Server Ownership
+
+The VPS is the system of record for autonomous execution:
+
+- Runtime user: `homedir-sdlc`
+- Runtime repo checkout: `/home/homedir-sdlc/.local/share/homedir-sdlc/worktrees/homedir`
+- Worker state: `/home/homedir-sdlc/.local/state/homedir-sdlc`
+- Worker logs: `/home/homedir-sdlc/.local/state/homedir-sdlc/logs/worker.log`
+- SCC install: `/home/homedir-sdlc/.local/share/sc-agent-cli`
+- SCC wrapper: `/home/homedir-sdlc/.local/bin/scc`
+- Worker service: `homedir-sdlc-worker.service`
+- Worker schedule: `homedir-sdlc-worker.timer`
+
+The server must be able to recover after reboot without this workstation:
+
+- systemd starts the timer.
+- `gh` auth and SCC provider credentials are configured on the server under the `homedir-sdlc` account.
+- The worker fetches from GitHub directly.
+- Branches and PRs are pushed from the server.
+- GitHub Actions owns release and deployment after merge.
+- The worker reconciles closed SDLC issues and only applies `scc-merged`
+  after the closing PR is merged and the matching `Production Release`
+  run for the merge commit succeeds.
+
+The worker must exit without processing issues when server-side GitHub
+authentication is missing. It must not rely on a workstation `gh` session,
+browser login, mounted Windows credential store, or local environment variable.
+
+Use `platform/scripts/homedir-sdlc-bootstrap.sh` on the server for first install
+or repair. It installs Ansible locally, pulls this repository, and applies the
+local runner playbook against `localhost`.
+
+When the SSH account does not have passwordless root/sudo access, use
+`platform/scripts/homedir-sdlc-user-bootstrap.sh` instead. That mode installs
+the runner under the SSH user's home directory:
+
+- Platform checkout: `$HOME/.local/share/homedir-platform`
+- SCC checkout: `$HOME/.local/share/sc-agent-cli`
+- Node runtime: `$HOME/.local/opt/node-*`
+- Worker wrapper: `$HOME/.local/bin/homedir-sdlc-worker.sh`
+- Worker env: `$HOME/.config/homedir-sdlc/env`
+- User units: `$HOME/.config/systemd/user/homedir-sdlc-worker.*`
+- Logs and state: `$HOME/.local/state/homedir-sdlc`
+
+This still satisfies server ownership because the normal worker runtime,
+credentials, logs, queue, and repository worktree remain on the SSH server.
+
+For production operation, prefer a dedicated non-root account named
+`homedir-sdlc`. Root may bootstrap, repair, or rotate credentials, but the
+worker service and timer should run as `homedir-sdlc`, not as root.
+
+## Non-Bypass Rules
+
+The worker and SCC prompt must forbid:
+
+- `git push origin main`
+- `git push --force` against protected branches
+- `gh pr merge --admin`
+- GitHub API changes to branch protection
+- GitHub API changes to repository rulesets
+- Disabling or removing required status checks
+- Printing, echoing, or embedding tokens in logs
+- Editing secrets or secret files unless a human explicitly requested a rotation
+
+Allowed operations:
+
+- Create implementation branches.
+- Commit and push branch changes.
+- Create or update pull requests.
+- Add status comments and automation labels.
+- Request or enable normal auto-merge when branch protection permits it.
+
+## Approval and Merge
+
+If `main` requires one approval, automation must satisfy that rule with normal
+GitHub mechanisms. SCC must not approve its own PR and must not use administrator
+bypass. Valid options are:
+
+- A separate GitHub App or bot identity reviews only policy-compliant PRs.
+- A human reviewer approves.
+- Repository rules explicitly define an approved automation path.
+
+Until one of those options exists, autonomous implementation can open PRs, but
+full autonomous merge is intentionally blocked by governance.
+
+## Failure Handling
+
+Move to `needs-human` when:
+
+- Requirements are ambiguous.
+- Local validation repeatedly fails.
+- CI fails after the configured retry limit.
+- Required review is missing and no compliant automation identity is available.
+- Branch protection or rulesets block merge.
+- Production release verification fails after merge.
+- The issue requests security-policy changes, secret access, or bypass behavior.
+
+Move to `scc-failed` only for execution failures that do not need clarification,
+such as missing tools, provider errors, or repository checkout failures.
+
+## Audit Trail
+
+Every cycle must leave:
+
+- Issue comment with branch, PR, validation, and final state.
+- Branch name tied to issue number.
+- PR body with `Closes #<issue>`.
+- Conventional commit or squash title.
+- Worker logs under `/var/log/homedir-sdlc-worker.log`.
+- State under `/var/lib/homedir-sdlc`.
+
+## Deployment Boundary
+
+The autonomous SDLC does not deploy directly. It merges through the normal PR
+path. The existing `Production Release` GitHub Actions workflow owns build,
+image publishing, SSH deployment, fallback timer reconciliation, and production
+health verification.

--- a/platform/README.md
+++ b/platform/README.md
@@ -15,9 +15,13 @@ Configs and scripts to provision the VPS that runs HomeDir. All secrets are stri
 - `scripts/homedir-dr-recover.sh` – one-command disaster recovery orchestrator for a pre-provisioned VM.
 - `scripts/homedir-dr-restore.py` – safe archive extractor used by DR recovery (blocks path traversal/symlinks).
 - `scripts/homedir-secrets-rotate.sh` – rotates internal runtime secrets with backup + optional service restart.
+- `scripts/homedir-sdlc-bootstrap.sh` – server-side bootstrap that installs/repairs the autonomous SDLC runner without depending on a workstation.
+- `scripts/homedir-sdlc-user-bootstrap.sh` – user-owned server-side bootstrap for SSH accounts without passwordless root/sudo.
+- `scripts/homedir-sdlc-worker.sh` – optional issue-driven SCC worker for autonomous PR creation under repository rules.
 - `systemd/homedir-webhook.service` – runs the optional webhook listener.
 - `systemd/homedir-auto-deploy.service` / `systemd/homedir-auto-deploy.timer` – periodic fallback auto-deploy from Quay.
 - `systemd/homedir-cfp-traffic-guard.service` / `systemd/homedir-cfp-traffic-guard.timer` – periodic CFP route resilience monitoring.
+- `systemd/homedir-sdlc-worker.service` / `systemd/homedir-sdlc-worker.timer` – optional autonomous SDLC worker timer.
 - `systemd/homedir-update.service` / `systemd/homedir-update.timer` – optional manual/timer runner; keep disabled unless you set a tag.
 - `nginx/homedir.conf`, `nginx/int.conf` – HTTPS reverse proxies with a maintenance page for 502/503/504.
 - `nginx/snippets/homedir-incident-guard.conf` – lock-file based emergency shield to force maintenance mode during incidents.
@@ -148,6 +152,8 @@ What it automates:
 - Run `/usr/local/bin/homedir-security-hardening.sh audit` periodically and after each DR recovery.
 - Rotate internal runtime secrets periodically (monthly or after incident):
   - `/usr/local/bin/homedir-secrets-rotate.sh --restart-services`
+- Autonomous SDLC is governed by `docs/en/development/autonomous-sdlc.md`: it may create branches and PRs, but it must not bypass branch protection, reviews, required checks, repository rulesets, or secret controls.
+- The autonomous SDLC must run from the VPS. A workstation may SSH in to trigger bootstrap, but normal operation must not depend on WSL, PowerShell, local paths, or local credentials.
 
 ## Autonomous SDLC service account
 

--- a/platform/ansible/inventory.example.ini
+++ b/platform/ansible/inventory.example.ini
@@ -1,0 +1,4 @@
+[homedir_sdlc]
+# Optional remote-control inventory. Normal autonomous SDLC operation is
+# server-owned; prefer running the playbook on the server with inventory.local.ini.
+homedir-vps.example ansible_user=root ansible_ssh_private_key_file=/home/scanales/.ssh/id_ed25519

--- a/platform/ansible/inventory.local.ini
+++ b/platform/ansible/inventory.local.ini
@@ -1,0 +1,2 @@
+[homedir_sdlc]
+localhost ansible_connection=local

--- a/platform/ansible/playbooks/sdlc-runner.yml
+++ b/platform/ansible/playbooks/sdlc-runner.yml
@@ -1,0 +1,213 @@
+---
+- name: Provision HomeDir autonomous SDLC runner
+  hosts: homedir_sdlc
+  become: true
+  vars:
+    homedir_sdlc_user: "homedir-sdlc"
+    homedir_sdlc_group: "homedir-sdlc"
+    homedir_sdlc_home: "/home/homedir-sdlc"
+    sc_agent_repo: "https://github.com/os-santiago/sc-agent-cli.git"
+    sc_agent_dir: "/home/homedir-sdlc/.local/share/sc-agent-cli"
+    homedir_platform_dir: "/home/homedir-sdlc/.local/share/homedir-platform"
+    homedir_sdlc_dir: "/home/homedir-sdlc/.local/share/homedir-sdlc"
+    homedir_sdlc_state_dir: "/home/homedir-sdlc/.local/state/homedir-sdlc"
+    homedir_sdlc_env_file: "/home/homedir-sdlc/.config/homedir-sdlc/env"
+    homedir_sdlc_local_bin: "/home/homedir-sdlc/.local/bin"
+    homedir_sdlc_user_systemd_dir: "/home/homedir-sdlc/.config/systemd/user"
+  tasks:
+    - name: Install package repository prerequisites
+      ansible.builtin.apt:
+        name:
+          - ca-certificates
+          - curl
+          - gnupg
+          - python3
+        state: present
+        update_cache: true
+
+    - name: Ensure apt keyring directory exists
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Download NodeSource signing key
+      ansible.builtin.get_url:
+        url: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+        dest: /etc/apt/keyrings/nodesource.asc
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Convert NodeSource signing key
+      ansible.builtin.command:
+        cmd: gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg /etc/apt/keyrings/nodesource.asc
+        creates: /etc/apt/keyrings/nodesource.gpg
+
+    - name: Add NodeSource Node.js 20 repository
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main"
+        filename: nodesource
+        state: present
+
+    - name: Download GitHub CLI signing key
+      ansible.builtin.get_url:
+        url: https://cli.github.com/packages/githubcli-archive-keyring.gpg
+        dest: /etc/apt/keyrings/githubcli-archive-keyring.gpg
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Add GitHub CLI repository
+      ansible.builtin.apt_repository:
+        repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main"
+        filename: github-cli
+        state: present
+
+    - name: Install runner packages
+      ansible.builtin.apt:
+        name:
+          - git
+          - gh
+          - jq
+          - nodejs
+          - python3
+        state: present
+        update_cache: true
+
+    - name: Ensure SDLC runtime group exists
+      ansible.builtin.group:
+        name: "{{ homedir_sdlc_group }}"
+        system: true
+        state: present
+
+    - name: Ensure SDLC runtime user exists
+      ansible.builtin.user:
+        name: "{{ homedir_sdlc_user }}"
+        group: "{{ homedir_sdlc_group }}"
+        home: "{{ homedir_sdlc_home }}"
+        create_home: true
+        shell: /usr/sbin/nologin
+        system: true
+        state: present
+
+    - name: Read SDLC runtime user account facts
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ homedir_sdlc_user }}"
+
+    - name: Ensure runner directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ homedir_sdlc_user }}"
+        group: "{{ homedir_sdlc_group }}"
+        mode: "0755"
+      loop:
+        - "{{ homedir_platform_dir }}"
+        - "{{ homedir_sdlc_local_bin }}"
+        - "{{ homedir_sdlc_home }}/.config/homedir-sdlc"
+        - "{{ homedir_sdlc_user_systemd_dir }}"
+        - "{{ homedir_sdlc_dir }}"
+        - "{{ homedir_sdlc_dir }}/worktrees"
+        - "{{ homedir_sdlc_state_dir }}"
+        - "{{ homedir_sdlc_state_dir }}/logs"
+
+    - name: Clone or update sc-agent-cli
+      ansible.builtin.git:
+        repo: "{{ sc_agent_repo }}"
+        dest: "{{ sc_agent_dir }}"
+        version: main
+        update: true
+      become_user: "{{ homedir_sdlc_user }}"
+      environment:
+        HOME: "{{ homedir_sdlc_home }}"
+
+    - name: Install SCC dependencies
+      ansible.builtin.command: npm ci
+      args:
+        chdir: "{{ sc_agent_dir }}"
+        creates: "{{ sc_agent_dir }}/node_modules"
+      become_user: "{{ homedir_sdlc_user }}"
+      environment:
+        HOME: "{{ homedir_sdlc_home }}"
+
+    - name: Build SCC
+      ansible.builtin.command: npm run build
+      args:
+        chdir: "{{ sc_agent_dir }}"
+      become_user: "{{ homedir_sdlc_user }}"
+      environment:
+        HOME: "{{ homedir_sdlc_home }}"
+
+    - name: Install SCC wrapper
+      ansible.builtin.copy:
+        dest: "{{ homedir_sdlc_local_bin }}/scc"
+        owner: "{{ homedir_sdlc_user }}"
+        group: "{{ homedir_sdlc_group }}"
+        mode: "0755"
+        content: |
+          #!/usr/bin/env bash
+          exec node {{ sc_agent_dir }}/bin/sc.js "$@"
+
+    - name: Install SDLC worker script
+      ansible.builtin.copy:
+        src: ../../scripts/homedir-sdlc-worker.sh
+        dest: "{{ homedir_sdlc_local_bin }}/homedir-sdlc-worker.sh"
+        owner: "{{ homedir_sdlc_user }}"
+        group: "{{ homedir_sdlc_group }}"
+        mode: "0755"
+
+    - name: Install SDLC environment example when env is absent
+      ansible.builtin.copy:
+        src: ../../env.sdlc.example
+        dest: "{{ homedir_sdlc_env_file }}"
+        owner: "{{ homedir_sdlc_user }}"
+        group: "{{ homedir_sdlc_group }}"
+        mode: "0600"
+        force: false
+
+    - name: Install user systemd units
+      ansible.builtin.copy:
+        src: "../../systemd/user/{{ item }}"
+        dest: "{{ homedir_sdlc_user_systemd_dir }}/{{ item }}"
+        owner: "{{ homedir_sdlc_user }}"
+        group: "{{ homedir_sdlc_group }}"
+        mode: "0644"
+      loop:
+        - homedir-sdlc-worker.service
+        - homedir-sdlc-worker.timer
+
+    - name: Enable linger for SDLC runtime user
+      ansible.builtin.command:
+        cmd: "loginctl enable-linger {{ homedir_sdlc_user }}"
+        creates: "/var/lib/systemd/linger/{{ homedir_sdlc_user }}"
+
+    - name: Ensure user timer wants directory exists
+      ansible.builtin.file:
+        path: "{{ homedir_sdlc_user_systemd_dir }}/timers.target.wants"
+        state: directory
+        owner: "{{ homedir_sdlc_user }}"
+        group: "{{ homedir_sdlc_group }}"
+        mode: "0755"
+
+    - name: Enable user SDLC worker timer
+      ansible.builtin.file:
+        src: "../homedir-sdlc-worker.timer"
+        dest: "{{ homedir_sdlc_user_systemd_dir }}/timers.target.wants/homedir-sdlc-worker.timer"
+        state: link
+        owner: "{{ homedir_sdlc_user }}"
+        group: "{{ homedir_sdlc_group }}"
+
+    - name: Start user SDLC worker timer when user manager is available
+      ansible.builtin.command:
+        cmd: "runuser -u {{ homedir_sdlc_user }} -- env HOME={{ homedir_sdlc_home }} XDG_RUNTIME_DIR=/run/user/{{ ansible_facts.getent_passwd[homedir_sdlc_user][1] }} PATH={{ homedir_sdlc_local_bin }}:/usr/bin:/bin systemctl --user enable --now homedir-sdlc-worker.timer"
+      register: homedir_sdlc_timer_start
+      changed_when: homedir_sdlc_timer_start.rc == 0
+      failed_when: false
+
+    - name: Print post-install note
+      ansible.builtin.debug:
+        msg: "Configure gh auth and SCC provider credentials under {{ homedir_sdlc_user }} before expecting autonomous work."

--- a/platform/env.sdlc.example
+++ b/platform/env.sdlc.example
@@ -1,0 +1,33 @@
+# HomeDir autonomous SDLC worker environment.
+# Install as /home/homedir-sdlc/.config/homedir-sdlc/env for the dedicated
+# runtime account, or copy to /etc/homedir-sdlc.env for a system unit.
+
+HOMEDIR_SDLC_REPO=os-santiago/homedir
+HOMEDIR_SDLC_AUTHOR=scanalesespinoza
+HOMEDIR_SDLC_TRIGGER_LABEL=ready-to-implement
+HOMEDIR_SDLC_RUNNING_LABEL=scc-running
+HOMEDIR_SDLC_PR_LABEL=scc-pr-open
+HOMEDIR_SDLC_FAILED_LABEL=scc-failed
+HOMEDIR_SDLC_NEEDS_HUMAN_LABEL=needs-human
+HOMEDIR_SDLC_MERGED_LABEL=scc-merged
+
+HOMEDIR_SDLC_WORKDIR=/home/homedir-sdlc/.local/share/homedir-sdlc/worktrees/homedir
+HOMEDIR_SDLC_STATE_DIR=/home/homedir-sdlc/.local/state/homedir-sdlc
+HOMEDIR_SDLC_LOGFILE=/home/homedir-sdlc/.local/state/homedir-sdlc/logs/worker.log
+HOMEDIR_SDLC_MAX_ISSUES_PER_RUN=1
+# Enables normal GitHub auto-merge only. The worker must never use --admin.
+HOMEDIR_SDLC_ENABLE_AUTOMERGE=false
+HOMEDIR_SDLC_VALIDATION_COMMAND=
+HOMEDIR_SDLC_GIT_USER_NAME=homedir-sdlc[bot]
+HOMEDIR_SDLC_GIT_USER_EMAIL=homedir-sdlc@users.noreply.github.com
+
+# Command used to invoke SCC. The bootstrap installs this wrapper.
+SCC_BIN=/home/homedir-sdlc/.local/bin/scc
+
+# GitHub auth should be configured with gh auth login or GH_TOKEN in the service
+# environment. Do not place tokens directly in this file if logs or backups may
+# expose it; prefer systemd credentials or an EnvironmentFile generated from a
+# secret manager.
+
+# SCC model credentials should be provided through the SCC profile, systemd
+# credentials, or secure environment injection.

--- a/platform/scripts/homedir-sdlc-bootstrap.sh
+++ b/platform/scripts/homedir-sdlc-bootstrap.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Server-side bootstrap for the HomeDir autonomous SDLC runner.
+
+set -euo pipefail
+
+HOMEDIR_PLATFORM_REPO="${HOMEDIR_PLATFORM_REPO:-https://github.com/os-santiago/homedir.git}"
+HOMEDIR_PLATFORM_REF="${HOMEDIR_PLATFORM_REF:-main}"
+HOMEDIR_PLATFORM_DIR="${HOMEDIR_PLATFORM_DIR:-/opt/homedir-platform}"
+PLAYBOOK="${HOMEDIR_PLATFORM_DIR}/platform/ansible/playbooks/sdlc-runner.yml"
+INVENTORY="${HOMEDIR_PLATFORM_DIR}/platform/ansible/inventory.local.ini"
+
+log() {
+  printf '%s [homedir-sdlc-bootstrap] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "Run as root on the VPS." >&2
+  exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+log "installing bootstrap packages"
+apt-get update
+apt-get install -y ca-certificates git python3 python3-venv python3-pip
+
+if ! command -v ansible-playbook >/dev/null 2>&1; then
+  log "installing ansible"
+  apt-get install -y ansible
+fi
+
+if [[ ! -d "${HOMEDIR_PLATFORM_DIR}/.git" ]]; then
+  log "cloning ${HOMEDIR_PLATFORM_REPO} into ${HOMEDIR_PLATFORM_DIR}"
+  git clone "${HOMEDIR_PLATFORM_REPO}" "${HOMEDIR_PLATFORM_DIR}"
+fi
+
+log "updating platform checkout to ${HOMEDIR_PLATFORM_REF}"
+git -C "${HOMEDIR_PLATFORM_DIR}" fetch origin "${HOMEDIR_PLATFORM_REF}" --tags
+git -C "${HOMEDIR_PLATFORM_DIR}" checkout "${HOMEDIR_PLATFORM_REF}"
+git -C "${HOMEDIR_PLATFORM_DIR}" pull --ff-only origin "${HOMEDIR_PLATFORM_REF}" || true
+
+log "applying local SDLC runner playbook"
+ansible-playbook -i "${INVENTORY}" "${PLAYBOOK}"
+
+log "bootstrap complete"
+log "next: configure gh auth and SCC provider credentials on this server"

--- a/platform/scripts/homedir-sdlc-labels.sh
+++ b/platform/scripts/homedir-sdlc-labels.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Ensure GitHub labels required by the HomeDir autonomous SDLC exist.
+
+set -euo pipefail
+
+REPO="${HOMEDIR_SDLC_REPO:-os-santiago/homedir}"
+GH_BIN="${GH_BIN:-${HOME}/.local/bin/gh}"
+
+if [[ ! -x "${GH_BIN}" ]]; then
+  GH_BIN="$(command -v gh)"
+fi
+
+ensure_label() {
+  local name="$1"
+  local color="$2"
+  local description="$3"
+
+  if "${GH_BIN}" label view "${name}" --repo "${REPO}" >/dev/null 2>&1; then
+    "${GH_BIN}" label edit "${name}" --repo "${REPO}" --color "${color}" --description "${description}" >/dev/null
+  else
+    "${GH_BIN}" label create "${name}" --repo "${REPO}" --color "${color}" --description "${description}" >/dev/null
+  fi
+}
+
+ensure_label "ready-to-implement" "0E8A16" "Approved trigger for autonomous SCC implementation"
+ensure_label "scc-running" "FBCA04" "Autonomous SCC worker has claimed this issue"
+ensure_label "scc-pr-open" "1D76DB" "Autonomous SCC worker opened a pull request"
+ensure_label "scc-failed" "D73A4A" "Autonomous SCC worker failed and needs inspection"
+ensure_label "needs-human" "B60205" "Human decision or intervention required"
+ensure_label "scc-merged" "5319E7" "Autonomous SCC PR merged or completed"
+
+echo "Autonomous SDLC labels ensured for ${REPO}"

--- a/platform/scripts/homedir-sdlc-user-bootstrap.sh
+++ b/platform/scripts/homedir-sdlc-user-bootstrap.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# User-owned server-side bootstrap for the HomeDir autonomous SDLC runner.
+
+set -euo pipefail
+
+HOMEDIR_PLATFORM_REPO="${HOMEDIR_PLATFORM_REPO:-https://github.com/os-santiago/homedir.git}"
+HOMEDIR_PLATFORM_REF="${HOMEDIR_PLATFORM_REF:-main}"
+HOMEDIR_PLATFORM_DIR="${HOMEDIR_PLATFORM_DIR:-$HOME/.local/share/homedir-platform}"
+SC_AGENT_REPO="${SC_AGENT_REPO:-https://github.com/os-santiago/sc-agent-cli.git}"
+SC_AGENT_REF="${SC_AGENT_REF:-main}"
+SC_AGENT_DIR="${SC_AGENT_DIR:-$HOME/.local/share/sc-agent-cli}"
+NODE_VERSION="${NODE_VERSION:-20.19.5}"
+NODE_DIR="${NODE_DIR:-$HOME/.local/opt/node-v${NODE_VERSION}-linux-x64}"
+GH_VERSION="${GH_VERSION:-2.74.2}"
+JQ_VERSION="${JQ_VERSION:-1.7.1}"
+LOCAL_BIN="${LOCAL_BIN:-$HOME/.local/bin}"
+CONFIG_DIR="${CONFIG_DIR:-$HOME/.config/homedir-sdlc}"
+STATE_DIR="${STATE_DIR:-$HOME/.local/state/homedir-sdlc}"
+WORKDIR="${WORKDIR:-$HOME/.local/share/homedir-sdlc/worktrees/homedir}"
+LOG_DIR="${LOG_DIR:-$HOME/.local/state/homedir-sdlc/logs}"
+SYSTEMD_USER_DIR="${SYSTEMD_USER_DIR:-$HOME/.config/systemd/user}"
+
+log() {
+  printf '%s [homedir-sdlc-user-bootstrap] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+clone_or_update() {
+  local repo="$1"
+  local ref="$2"
+  local dest="$3"
+  if [[ -d "${dest}" && ! -d "${dest}/.git" ]]; then
+    log "using existing non-git snapshot at ${dest}"
+    return 0
+  fi
+
+  if [[ ! -d "${dest}/.git" ]]; then
+    log "cloning ${repo} into ${dest}"
+    mkdir -p "$(dirname "${dest}")"
+    git clone "${repo}" "${dest}"
+  fi
+  log "updating ${dest} to ${ref}"
+  git -C "${dest}" fetch origin "${ref}" --tags
+  git -C "${dest}" checkout "${ref}"
+  git -C "${dest}" pull --ff-only origin "${ref}" || true
+}
+
+install_node() {
+  if [[ -x "${NODE_DIR}/bin/node" ]]; then
+    return 0
+  fi
+
+  local archive tmp
+  archive="node-v${NODE_VERSION}-linux-x64.tar.xz"
+  tmp="$(mktemp -d)"
+  log "installing Node.js ${NODE_VERSION} under ${NODE_DIR}"
+  curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/${archive}" -o "${tmp}/${archive}"
+  mkdir -p "$(dirname "${NODE_DIR}")"
+  tar -xJf "${tmp}/${archive}" -C "$(dirname "${NODE_DIR}")"
+  rm -rf "${tmp}"
+}
+
+install_jq() {
+  if [[ -x "${LOCAL_BIN}/jq" ]]; then
+    return 0
+  fi
+
+  local arch jq_asset
+  arch="$(uname -m)"
+  case "${arch}" in
+    x86_64|amd64)
+      jq_asset="jq-linux-amd64"
+      ;;
+    aarch64|arm64)
+      jq_asset="jq-linux-arm64"
+      ;;
+    *)
+      echo "Unsupported architecture for jq bootstrap: ${arch}" >&2
+      exit 1
+      ;;
+  esac
+
+  mkdir -p "${LOCAL_BIN}"
+  log "installing jq ${JQ_VERSION} under ${LOCAL_BIN}"
+  curl -fsSL "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/${jq_asset}" -o "${LOCAL_BIN}/jq"
+  chmod 0755 "${LOCAL_BIN}/jq"
+}
+
+install_gh() {
+  if command -v gh >/dev/null 2>&1 || [[ -x "${LOCAL_BIN}/gh" ]]; then
+    return 0
+  fi
+
+  local arch gh_arch archive tmp
+  arch="$(uname -m)"
+  case "${arch}" in
+    x86_64|amd64)
+      gh_arch="linux_amd64"
+      ;;
+    aarch64|arm64)
+      gh_arch="linux_arm64"
+      ;;
+    *)
+      echo "Unsupported architecture for gh bootstrap: ${arch}" >&2
+      exit 1
+      ;;
+  esac
+
+  archive="gh_${GH_VERSION}_${gh_arch}.tar.gz"
+  tmp="$(mktemp -d)"
+  log "installing GitHub CLI ${GH_VERSION} under ${LOCAL_BIN}"
+  curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${archive}" -o "${tmp}/${archive}"
+  tar -xzf "${tmp}/${archive}" -C "${tmp}"
+  mkdir -p "${LOCAL_BIN}"
+  install -m 0755 "${tmp}/gh_${GH_VERSION}_${gh_arch}/bin/gh" "${LOCAL_BIN}/gh"
+  rm -rf "${tmp}"
+}
+
+write_env() {
+  local env_file="${CONFIG_DIR}/env"
+  mkdir -p "${CONFIG_DIR}" "${STATE_DIR}" "${LOG_DIR}" "$(dirname "${WORKDIR}")"
+  if [[ -f "${env_file}" ]]; then
+    log "keeping existing ${env_file}"
+    return 0
+  fi
+
+  log "writing ${env_file}"
+  cat >"${env_file}" <<EOF
+PATH=${NODE_DIR}/bin:${LOCAL_BIN}:/usr/local/bin:/usr/bin:/bin
+HOMEDIR_SDLC_REPO=os-santiago/homedir
+HOMEDIR_SDLC_AUTHOR=scanalesespinoza
+HOMEDIR_SDLC_TRIGGER_LABEL=ready-to-implement
+HOMEDIR_SDLC_RUNNING_LABEL=scc-running
+HOMEDIR_SDLC_PR_LABEL=scc-pr-open
+HOMEDIR_SDLC_FAILED_LABEL=scc-failed
+HOMEDIR_SDLC_NEEDS_HUMAN_LABEL=needs-human
+HOMEDIR_SDLC_MERGED_LABEL=scc-merged
+HOMEDIR_SDLC_WORKDIR=${WORKDIR}
+HOMEDIR_SDLC_STATE_DIR=${STATE_DIR}
+HOMEDIR_SDLC_LOGFILE=${LOG_DIR}/worker.log
+HOMEDIR_SDLC_MAX_ISSUES_PER_RUN=1
+HOMEDIR_SDLC_ENABLE_AUTOMERGE=false
+SCC_BIN=${LOCAL_BIN}/scc
+EOF
+  chmod 0600 "${env_file}"
+}
+
+install_scc() {
+  export PATH="${NODE_DIR}/bin:${PATH}"
+  log "installing SCC dependencies"
+  npm ci --prefix "${SC_AGENT_DIR}"
+  npm run build --prefix "${SC_AGENT_DIR}"
+
+  mkdir -p "${LOCAL_BIN}"
+  cat >"${LOCAL_BIN}/scc" <<EOF
+#!/usr/bin/env bash
+export PATH="${NODE_DIR}/bin:\$PATH"
+exec "${NODE_DIR}/bin/node" "${SC_AGENT_DIR}/bin/sc.js" "\$@"
+EOF
+  chmod 0755 "${LOCAL_BIN}/scc"
+}
+
+install_worker() {
+  mkdir -p "${LOCAL_BIN}" "${SYSTEMD_USER_DIR}"
+  install -m 0755 "${HOMEDIR_PLATFORM_DIR}/platform/scripts/homedir-sdlc-worker.sh" "${LOCAL_BIN}/homedir-sdlc-worker.sh"
+  install -m 0644 "${HOMEDIR_PLATFORM_DIR}/platform/systemd/user/homedir-sdlc-worker.service" "${SYSTEMD_USER_DIR}/homedir-sdlc-worker.service"
+  install -m 0644 "${HOMEDIR_PLATFORM_DIR}/platform/systemd/user/homedir-sdlc-worker.timer" "${SYSTEMD_USER_DIR}/homedir-sdlc-worker.timer"
+}
+
+enable_timer() {
+  if ! systemctl --user is-system-running >/dev/null 2>&1; then
+    log "systemd user manager is not available; installed files but did not enable timer"
+    return 0
+  fi
+  systemctl --user daemon-reload
+  systemctl --user enable --now homedir-sdlc-worker.timer
+}
+
+main() {
+  need_cmd git
+  need_cmd curl
+  need_cmd tar
+  clone_or_update "${HOMEDIR_PLATFORM_REPO}" "${HOMEDIR_PLATFORM_REF}" "${HOMEDIR_PLATFORM_DIR}"
+  clone_or_update "${SC_AGENT_REPO}" "${SC_AGENT_REF}" "${SC_AGENT_DIR}"
+  install_gh
+  install_node
+  install_jq
+  write_env
+  install_scc
+  install_worker
+  enable_timer
+
+  log "bootstrap complete"
+  log "server-owned files:"
+  log "  platform=${HOMEDIR_PLATFORM_DIR}"
+  log "  scc=${SC_AGENT_DIR}"
+  log "  env=${CONFIG_DIR}/env"
+  log "  state=${STATE_DIR}"
+  log "  workdir=${WORKDIR}"
+  log "next: configure gh auth and SCC provider credentials on this server"
+}
+
+main "$@"

--- a/platform/scripts/homedir-sdlc-worker.sh
+++ b/platform/scripts/homedir-sdlc-worker.sh
@@ -1,0 +1,456 @@
+#!/usr/bin/env bash
+# Issue-driven SCC worker for the HomeDir autonomous SDLC.
+
+set -euo pipefail
+
+ENV_FILE="${HOMEDIR_SDLC_ENV_FILE:-/etc/homedir-sdlc.env}"
+if [[ -f "${ENV_FILE}" ]]; then
+  # shellcheck disable=SC1090
+  source "${ENV_FILE}"
+fi
+
+REPO="${HOMEDIR_SDLC_REPO:-os-santiago/homedir}"
+AUTHOR="${HOMEDIR_SDLC_AUTHOR:-scanalesespinoza}"
+TRIGGER_LABEL="${HOMEDIR_SDLC_TRIGGER_LABEL:-ready-to-implement}"
+RUNNING_LABEL="${HOMEDIR_SDLC_RUNNING_LABEL:-scc-running}"
+PR_LABEL="${HOMEDIR_SDLC_PR_LABEL:-scc-pr-open}"
+FAILED_LABEL="${HOMEDIR_SDLC_FAILED_LABEL:-scc-failed}"
+NEEDS_HUMAN_LABEL="${HOMEDIR_SDLC_NEEDS_HUMAN_LABEL:-needs-human}"
+MERGED_LABEL="${HOMEDIR_SDLC_MERGED_LABEL:-scc-merged}"
+WORKDIR="${HOMEDIR_SDLC_WORKDIR:-/srv/homedir-sdlc/worktrees/homedir}"
+STATE_DIR="${HOMEDIR_SDLC_STATE_DIR:-/var/lib/homedir-sdlc}"
+LOGFILE="${HOMEDIR_SDLC_LOGFILE:-/var/log/homedir-sdlc-worker.log}"
+MAX_ISSUES="${HOMEDIR_SDLC_MAX_ISSUES_PER_RUN:-1}"
+ENABLE_AUTOMERGE="${HOMEDIR_SDLC_ENABLE_AUTOMERGE:-false}"
+VALIDATION_COMMAND="${HOMEDIR_SDLC_VALIDATION_COMMAND:-}"
+GIT_USER_NAME="${HOMEDIR_SDLC_GIT_USER_NAME:-homedir-sdlc[bot]}"
+GIT_USER_EMAIL="${HOMEDIR_SDLC_GIT_USER_EMAIL:-homedir-sdlc@users.noreply.github.com}"
+SCC_BIN="${SCC_BIN:-/usr/local/bin/scc}"
+LOCK_FILE="${STATE_DIR}/worker.lock"
+ISSUE_STATE_DIR="${STATE_DIR}/issues"
+
+mkdir -p "${STATE_DIR}" "${ISSUE_STATE_DIR}" "$(dirname "${LOGFILE}")"
+touch "${LOGFILE}"
+
+log() {
+  printf '%s [homedir-sdlc-worker] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "${LOGFILE}" >&2
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    log "missing required command: $1"
+    exit 1
+  fi
+}
+
+require_gh_auth() {
+  if ! gh auth status >/dev/null 2>&1; then
+    log "GitHub CLI is not authenticated on this server; configure gh auth or GH_TOKEN before running autonomous SDLC"
+    exit 0
+  fi
+}
+
+safe_slug() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+    | cut -c1-48
+}
+
+issue_has_label() {
+  local labels_json="$1"
+  local wanted="$2"
+  jq -e --arg wanted "${wanted}" 'index($wanted) != null' >/dev/null <<<"${labels_json}"
+}
+
+add_label() {
+  local issue="$1"
+  local label="$2"
+  gh issue edit "${issue}" --repo "${REPO}" --add-label "${label}" >/dev/null
+}
+
+remove_label() {
+  local issue="$1"
+  local label="$2"
+  gh issue edit "${issue}" --repo "${REPO}" --remove-label "${label}" >/dev/null 2>&1 || true
+}
+
+comment_issue() {
+  local issue="$1"
+  local body="$2"
+  gh issue comment "${issue}" --repo "${REPO}" --body "${body}" >/dev/null
+}
+
+mark_needs_human() {
+  local issue="$1"
+  local reason="$2"
+  add_label "${issue}" "${NEEDS_HUMAN_LABEL}"
+  remove_label "${issue}" "${RUNNING_LABEL}"
+  comment_issue "${issue}" "Autonomous SDLC paused: ${reason}"
+}
+
+mark_failed() {
+  local issue="$1"
+  local reason="$2"
+  add_label "${issue}" "${FAILED_LABEL}"
+  remove_label "${issue}" "${RUNNING_LABEL}"
+  comment_issue "${issue}" "Autonomous SDLC failed: ${reason}"
+}
+
+write_issue_state() {
+  local issue="$1"
+  local branch="$2"
+  local pr_url="$3"
+  local pr_number
+
+  pr_number="$(sed -nE 's#.*/pull/([0-9]+).*#\1#p' <<<"${pr_url}" | head -n1)"
+  jq -n \
+    --arg issue "${issue}" \
+    --arg branch "${branch}" \
+    --arg pr_url "${pr_url}" \
+    --arg pr_number "${pr_number}" \
+    --arg updated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{issue: ($issue|tonumber), branch: $branch, pr_url: $pr_url, pr_number: ($pr_number|tonumber?), updated_at: $updated_at}' \
+    > "${ISSUE_STATE_DIR}/issue-${issue}.json"
+}
+
+release_status_for_pr() {
+  local pr_number="$1"
+  local pr_json merge_sha runs_json run_status run_conclusion run_url
+
+  pr_json="$(gh pr view "${pr_number}" --repo "${REPO}" --json mergeCommit,mergedAt,url)"
+  merge_sha="$(jq -r '.mergeCommit.oid // ""' <<<"${pr_json}")"
+  if [[ -z "${merge_sha}" ]]; then
+    echo "pending|No merge commit is available yet|"
+    return 0
+  fi
+
+  runs_json="$(gh run list \
+    --repo "${REPO}" \
+    --workflow release.yml \
+    --commit "${merge_sha}" \
+    --limit 1 \
+    --json status,conclusion,url \
+    --jq '.')"
+
+  if [[ "${runs_json}" == "[]" ]]; then
+    echo "pending|Production Release has not started for ${merge_sha}|"
+    return 0
+  fi
+
+  run_status="$(jq -r '.[0].status // ""' <<<"${runs_json}")"
+  run_conclusion="$(jq -r '.[0].conclusion // ""' <<<"${runs_json}")"
+  run_url="$(jq -r '.[0].url // ""' <<<"${runs_json}")"
+
+  if [[ "${run_status}" == "completed" && "${run_conclusion}" == "success" ]]; then
+    echo "success|Production Release succeeded|${run_url}"
+  elif [[ "${run_status}" == "completed" ]]; then
+    echo "failure|Production Release completed with conclusion: ${run_conclusion}|${run_url}"
+  else
+    echo "pending|Production Release is ${run_status}|${run_url}"
+  fi
+}
+
+enable_auto_merge_for_state() {
+  local state_file="$1"
+  local issue pr_number branch pr_json pr_state auto_merge pr_url
+
+  issue="$(jq -r '.issue' "${state_file}")"
+  pr_number="$(jq -r '.pr_number // ""' "${state_file}")"
+  branch="$(jq -r '.branch' "${state_file}")"
+
+  if [[ -z "${pr_number}" || "${pr_number}" == "null" ]]; then
+    return 0
+  fi
+
+  pr_json="$(gh pr view "${pr_number}" --repo "${REPO}" --json state,autoMergeRequest,url 2>/dev/null || true)"
+  if [[ -z "${pr_json}" ]]; then
+    return 0
+  fi
+
+  pr_state="$(jq -r '.state' <<<"${pr_json}")"
+  auto_merge="$(jq -r '.autoMergeRequest != null' <<<"${pr_json}")"
+  pr_url="$(jq -r '.url' <<<"${pr_json}")"
+
+  if [[ "${pr_state}" != "OPEN" || "${auto_merge}" == "true" || "${ENABLE_AUTOMERGE}" != "true" ]]; then
+    return 0
+  fi
+
+  if gh pr merge "${branch}" --repo "${REPO}" --squash --auto >/dev/null 2>&1; then
+    log "enabled normal auto-merge for issue #${issue} PR #${pr_number}"
+  else
+    add_label "${issue}" "${NEEDS_HUMAN_LABEL}"
+    comment_issue "${issue}" "Autonomous SDLC could not enable normal auto-merge for ${pr_url}. Repository rules still apply; no admin bypass was used."
+  fi
+}
+
+reconcile_open_prs() {
+  local state_file
+
+  while IFS= read -r state_file; do
+    enable_auto_merge_for_state "${state_file}"
+  done < <(find "${ISSUE_STATE_DIR}" -maxdepth 1 -name 'issue-*.json' -type f 2>/dev/null)
+}
+
+reconcile_completed_issue() {
+  local issue_json="$1"
+  local number labels issue_detail prs_json pr_number pr_url release_status release_message release_url
+
+  number="$(jq -r '.number' <<<"${issue_json}")"
+  labels="$(jq -c '[.labels[].name]' <<<"${issue_json}")"
+
+  if issue_has_label "${labels}" "${MERGED_LABEL}"; then
+    return 0
+  fi
+
+  issue_detail="$(gh issue view "${number}" \
+    --repo "${REPO}" \
+    --json number,state,closedByPullRequestsReferences,labels)"
+
+  prs_json="$(jq -c '.closedByPullRequestsReferences // []' <<<"${issue_detail}")"
+  if [[ "$(jq 'length' <<<"${prs_json}")" -eq 0 ]]; then
+    log "closed issue #${number} has ${PR_LABEL} but no closing PR reference"
+    return 0
+  fi
+
+  pr_number="$(jq -r '.[0].number' <<<"${prs_json}")"
+  pr_url="$(jq -r '.[0].url' <<<"${prs_json}")"
+
+  IFS='|' read -r release_status release_message release_url < <(release_status_for_pr "${pr_number}")
+
+  if [[ "${release_status}" == "pending" ]]; then
+    log "issue #${number} PR #${pr_number} merged; waiting for release verification: ${release_message}"
+    return 0
+  fi
+
+  if [[ "${release_status}" == "failure" ]]; then
+    add_label "${number}" "${NEEDS_HUMAN_LABEL}"
+    comment_issue "${number}" "Autonomous SDLC merge completed, but release verification failed for PR #${pr_number}: ${release_message} ${release_url}"
+    log "issue #${number} release verification failed for PR #${pr_number}"
+    return 0
+  fi
+
+  add_label "${number}" "${MERGED_LABEL}"
+  remove_label "${number}" "${PR_LABEL}"
+  remove_label "${number}" "${RUNNING_LABEL}"
+  remove_label "${number}" "${FAILED_LABEL}"
+  remove_label "${number}" "${NEEDS_HUMAN_LABEL}"
+  remove_label "${number}" "${TRIGGER_LABEL}"
+  comment_issue "${number}" "Autonomous SDLC completed: PR #${pr_number} was merged (${pr_url}) and release verification succeeded. ${release_url}"
+  log "reconciled completed issue #${number} via PR #${pr_number}; release verified"
+}
+
+reconcile_completed_issues() {
+  local issues_json
+
+  issues_json="$(gh issue list \
+    --repo "${REPO}" \
+    --state closed \
+    --label "${PR_LABEL}" \
+    --limit 50 \
+    --json number,labels)"
+
+  if [[ "${issues_json}" == "[]" ]]; then
+    return 0
+  fi
+
+  jq -c '.[]' <<<"${issues_json}" | while IFS= read -r issue_json; do
+    reconcile_completed_issue "${issue_json}"
+  done
+}
+
+prepare_workdir() {
+  if [[ ! -d "${WORKDIR}/.git" ]]; then
+    mkdir -p "$(dirname "${WORKDIR}")"
+    git clone "https://github.com/${REPO}.git" "${WORKDIR}"
+  fi
+
+  git -C "${WORKDIR}" fetch origin main --prune
+  git -C "${WORKDIR}" checkout main
+  git -C "${WORKDIR}" reset --hard origin/main
+  git -C "${WORKDIR}" clean -fdx
+  git -C "${WORKDIR}" config user.name "${GIT_USER_NAME}"
+  git -C "${WORKDIR}" config user.email "${GIT_USER_EMAIL}"
+}
+
+run_issue() {
+  local issue_json="$1"
+  local number title author labels body url branch slug prompt pr_url validation_summary
+
+  number="$(jq -r '.number' <<<"${issue_json}")"
+  title="$(jq -r '.title' <<<"${issue_json}")"
+  author="$(jq -r '.author.login' <<<"${issue_json}")"
+  labels="$(jq -c '[.labels[].name]' <<<"${issue_json}")"
+  body="$(jq -r '.body // ""' <<<"${issue_json}")"
+  url="$(jq -r '.url // ""' <<<"${issue_json}")"
+
+  if [[ "${author}" != "${AUTHOR}" ]]; then
+    log "skipping issue #${number}: author ${author} is not ${AUTHOR}"
+    return 0
+  fi
+
+  if issue_has_label "${labels}" "${RUNNING_LABEL}" \
+    || issue_has_label "${labels}" "${PR_LABEL}" \
+    || issue_has_label "${labels}" "${FAILED_LABEL}" \
+    || issue_has_label "${labels}" "${NEEDS_HUMAN_LABEL}" \
+    || issue_has_label "${labels}" "${MERGED_LABEL}"; then
+    log "skipping issue #${number}: already has automation lifecycle label"
+    return 0
+  fi
+
+  slug="$(safe_slug "${title}")"
+  if [[ -z "${slug}" ]]; then
+    slug="work"
+  fi
+  branch="scc/issue-${number}-${slug}"
+
+  log "claiming issue #${number}: ${title}"
+  add_label "${number}" "${RUNNING_LABEL}"
+  comment_issue "${number}" "Autonomous SDLC claimed this issue. Branch: \`${branch}\`. The worker will obey repository rules and will not use admin bypass."
+
+  prepare_workdir
+  git -C "${WORKDIR}" checkout -B "${branch}" origin/main
+
+  prompt="$(cat <<EOF
+Implement GitHub issue #${number} in ${REPO}.
+
+Issue title:
+${title}
+
+Issue URL:
+${url}
+
+Issue body:
+${body}
+
+Rules:
+- Work only within the issue scope.
+- Use branch ${branch}; never push directly to main.
+- Make a focused implementation, then leave a concise summary of validation.
+- It is okay to edit files without committing; the worker will create the final commit if needed.
+- Run the smallest meaningful local validation and include evidence in the PR.
+- Do not use --admin.
+- Do not bypass branch protection, required checks, reviews, or repository rulesets.
+- Do not change branch protection, repository rulesets, required status checks, or secrets.
+- If repository rules block merge, report the blocker and stop.
+- If requirements are ambiguous or unsafe, add a clear issue comment and stop.
+EOF
+)"
+
+  log "running SCC for issue #${number}"
+  if ! (cd "${WORKDIR}" && "${SCC_BIN}" -yq "${prompt}"); then
+    log "SCC failed for issue #${number}"
+    mark_failed "${number}" "SCC exited non-zero. Check ${LOGFILE} on the runner."
+    return 0
+  fi
+
+  if [[ "$(git -C "${WORKDIR}" branch --show-current)" == "main" ]]; then
+    mark_needs_human "${number}" "SCC ended on main. Refusing to continue because autonomous work must use a PR branch."
+    return 0
+  fi
+
+  if [[ -n "$(git -C "${WORKDIR}" status --porcelain)" ]]; then
+    log "committing SCC changes for issue #${number}"
+    git -C "${WORKDIR}" add -A
+    git -C "${WORKDIR}" commit -m "chore(sdlc): implement issue #${number}" -m "Closes #${number}"
+  fi
+
+  if [[ -z "$(git -C "${WORKDIR}" log --oneline "origin/main..HEAD")" ]]; then
+    mark_needs_human "${number}" "SCC completed without producing any branch changes."
+    return 0
+  fi
+
+  validation_summary="Not run by worker"
+  if [[ -n "${VALIDATION_COMMAND}" ]]; then
+    log "running validation for issue #${number}: ${VALIDATION_COMMAND}"
+    if (cd "${WORKDIR}" && bash -lc "${VALIDATION_COMMAND}"); then
+      validation_summary="\`${VALIDATION_COMMAND}\` passed"
+    else
+      mark_failed "${number}" "Validation command failed: \`${VALIDATION_COMMAND}\`."
+      return 0
+    fi
+  fi
+
+  git -C "${WORKDIR}" push -u origin "${branch}"
+
+  pr_url="$(gh pr view "${branch}" --repo "${REPO}" --template '{{.url}}' 2>/dev/null || true)"
+  if [[ -z "${pr_url}" ]]; then
+    pr_url="$(gh pr create \
+      --repo "${REPO}" \
+      --base main \
+      --head "${branch}" \
+      --title "chore(sdlc): implement issue #${number}" \
+      --body "$(cat <<PRBODY
+## Summary
+
+Autonomous SCC implementation for issue #${number}: ${title}
+
+## Validation
+
+${validation_summary}
+
+## Governance
+
+- Branch protection, required checks, required reviews, and repository rules still apply.
+- No admin bypass was used.
+
+Closes #${number}
+PRBODY
+)")"
+  fi
+
+  add_label "${number}" "${PR_LABEL}"
+  remove_label "${number}" "${RUNNING_LABEL}"
+  write_issue_state "${number}" "${branch}" "${pr_url}"
+  comment_issue "${number}" "Autonomous SDLC opened PR: ${pr_url}"
+
+  if [[ "${ENABLE_AUTOMERGE}" == "true" ]]; then
+    if gh pr merge "${branch}" --repo "${REPO}" --squash --auto >/dev/null 2>&1; then
+      log "enabled normal auto-merge for issue #${number}"
+      comment_issue "${number}" "Normal GitHub auto-merge was enabled for ${pr_url}. Required checks and reviews still apply."
+    else
+      mark_needs_human "${number}" "Could not enable normal auto-merge. Required checks, review policy, or repository settings may be blocking."
+    fi
+  else
+    comment_issue "${number}" "Auto-merge is disabled for the autonomous SDLC. PR remains governed by normal review and branch protection."
+  fi
+}
+
+main() {
+  require_cmd gh
+  require_cmd git
+  require_cmd jq
+  require_cmd "${SCC_BIN}"
+  require_gh_auth
+
+  exec 9>"${LOCK_FILE}"
+  if ! flock -n 9; then
+    log "another worker instance is already running"
+    exit 0
+  fi
+
+  log "reconciling completed autonomous SDLC issues"
+  reconcile_completed_issues
+  reconcile_open_prs
+
+  log "checking eligible issues in ${REPO}"
+  mapfile -t issues < <(
+    gh issue list \
+      --repo "${REPO}" \
+      --state open \
+      --label "${TRIGGER_LABEL}" \
+      --limit "${MAX_ISSUES}" \
+      --json number,title,body,url,author,labels
+  )
+
+  if [[ "${#issues[@]}" -eq 0 || -z "${issues[0]:-}" || "${issues[0]}" == "[]" ]]; then
+    log "no eligible issues found"
+    exit 0
+  fi
+
+  jq -c '.[]' <<<"${issues[0]}" | while IFS= read -r issue_json; do
+    run_issue "${issue_json}"
+  done
+}
+
+main "$@"

--- a/platform/systemd/homedir-sdlc-worker.service
+++ b/platform/systemd/homedir-sdlc-worker.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=HomeDir autonomous SDLC SCC worker
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/homedir-sdlc.env
+ExecStart=/usr/local/bin/homedir-sdlc-worker.sh
+User=homedir-sdlc
+Group=homedir-sdlc
+Nice=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=tmpfs
+BindPaths=/home/homedir-sdlc
+ReadWritePaths=/home/homedir-sdlc/.local/share/homedir-sdlc /home/homedir-sdlc/.local/state/homedir-sdlc /home/homedir-sdlc/.sc-agent /home/homedir-sdlc/.config/gh
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/systemd/homedir-sdlc-worker.timer
+++ b/platform/systemd/homedir-sdlc-worker.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run HomeDir autonomous SDLC SCC worker periodically
+
+[Timer]
+OnBootSec=2min
+OnCalendar=*:0/5
+AccuracySec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/platform/systemd/user/homedir-sdlc-worker.service
+++ b/platform/systemd/user/homedir-sdlc-worker.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=HomeDir autonomous SDLC SCC worker (user)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=%h/.config/homedir-sdlc/env
+ExecStart=%h/.local/bin/homedir-sdlc-worker.sh
+Nice=5
+NoNewPrivileges=true
+
+[Install]
+WantedBy=default.target

--- a/platform/systemd/user/homedir-sdlc-worker.timer
+++ b/platform/systemd/user/homedir-sdlc-worker.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run HomeDir autonomous SDLC SCC worker periodically (user)
+
+[Timer]
+OnBootSec=2min
+OnCalendar=*:0/5
+AccuracySec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

- adds the issue-driven autonomous SDLC operating model and lifecycle labels
- adds server/user bootstrap scripts, Ansible provisioning, systemd timers, and env examples for the homedir-sdlc runtime account
- adds the SCC worker that creates branches/PRs, respects repository rules, enables normal auto-merge only when allowed, and reconciles release success before marking scc-merged

## Validation

- wsl bash -n platform/scripts/homedir-sdlc-worker.sh
- wsl bash -n platform/scripts/homedir-sdlc-labels.sh
- wsl bash -n platform/scripts/homedir-sdlc-bootstrap.sh
- wsl bash -n platform/scripts/homedir-sdlc-user-bootstrap.sh
- wsl ansible-playbook -i platform/ansible/inventory.local.ini platform/ansible/playbooks/sdlc-runner.yml --syntax-check
- deployed updated worker/platform snapshot to VPS and ran the worker successfully as homedir-sdlc

## Governance

The runner uses a dedicated non-root service account and does not bypass branch protection, required checks, reviews, repository rulesets, or release gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated SDLC setup and runner support for periodic, server-based issue processing.
  * Introduced new configuration examples and scheduled services to help run the workflow consistently.

* **Documentation**
  * Updated platform documentation with the new SDLC components and clarified required operating and governance guidelines.

* **Chores**
  * Standardized line endings for Markdown, shell scripts, and platform configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->