### PR TITLE
chore(runtime): clarify persistence file logs

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/service/PersistenceService.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/service/PersistenceService.java
@@ -2196,7 +2196,11 @@ public class PersistenceService {
 
   private <T> Map<String, T> read(Path file, TypeReference<Map<String, T>> type) {
     if (!Files.exists(file)) {
-      LOG.infof("No persistence file %s found - starting empty", logFileLabel(file));
+      if (isOptionalEmptyPersistenceFile(file)) {
+        LOG.debugf("No persistence file %s found - starting empty", logFileLabel(file));
+      } else {
+        LOG.infof("No persistence file %s found - starting empty", logFileLabel(file));
+      }
       return new ConcurrentHashMap<>();
     }
     try {
@@ -2209,7 +2213,7 @@ public class PersistenceService {
     }
   }
 
-  private String logFileLabel(Path file) {
+  String logFileLabel(Path file) {
     if (file == null) {
       return "unknown-file";
     }
@@ -2233,6 +2237,15 @@ public class PersistenceService {
     }
     if (file.equals(reputationStateFile)) {
       return "reputation-state.json";
+    }
+    if (file.equals(reputationGaObservationJournalFile)) {
+      return "reputation-ga-observation-journal.json";
+    }
+    if (file.equals(campaignStateFile)) {
+      return "campaign-state.json";
+    }
+    if (file.equals(campaignOperationsStateFile)) {
+      return "campaign-operations-state.json";
     }
     if (file.equals(communitySubmissionsFile)) {
       return "community-submissions.json";
@@ -2273,7 +2286,22 @@ public class PersistenceService {
     if (file.equals(cfpWalFile)) {
       return "cfp-submissions.wal";
     }
+    if (isUserScheduleFile(file)) {
+      return file.getFileName().toString();
+    }
     return "data-file";
+  }
+
+  private boolean isOptionalEmptyPersistenceFile(Path file) {
+    return isUserScheduleFile(file);
+  }
+
+  private boolean isUserScheduleFile(Path file) {
+    if (file == null || file.getFileName() == null) {
+      return false;
+    }
+    String name = file.getFileName().toString();
+    return name.startsWith(SCHEDULE_FILE_PREFIX) && name.endsWith(SCHEDULE_FILE_SUFFIX);
   }
 
   private void checkDiskSpace() {

--- a/quarkus-app/src/test/java/com/scanales/homedir/service/PersistenceServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/service/PersistenceServiceTest.java
@@ -80,6 +80,32 @@ public class PersistenceServiceTest {
   }
 
   @Test
+  void missingUserScheduleUsesSpecificPersistenceLabelAndStartsEmpty() {
+    service = newService();
+
+    int year = 2026;
+    Path scheduleFile = tempDir.resolve("user-schedule-" + year + ".json");
+
+    assertFalse(Files.exists(scheduleFile));
+    assertEquals("user-schedule-2026.json", service.logFileLabel(scheduleFile));
+    assertTrue(service.loadUserSchedules(year).isEmpty());
+  }
+
+  @Test
+  void knownStateFilesUseSpecificPersistenceLabels() {
+    service = newService();
+
+    assertEquals(
+        "reputation-ga-observation-journal.json",
+        service.logFileLabel(tempDir.resolve("reputation-ga-observation-journal.json")));
+    assertEquals(
+        "campaign-state.json", service.logFileLabel(tempDir.resolve("campaign-state.json")));
+    assertEquals(
+        "campaign-operations-state.json",
+        service.logFileLabel(tempDir.resolve("campaign-operations-state.json")));
+  }
+
+  @Test
   void flushDrainsDebouncedPendingWrites() {
     service = newService();
     service.writeCoalesceWindowMs = 5_000L;


### PR DESCRIPTION
## Summary

- labels user schedule persistence files as \user-schedule-YYYY.json\ instead of generic \data-file\`n- lowers missing user schedule files to DEBUG because an absent annual schedule file is an expected empty-state path
- adds explicit labels for campaign and reputation journal state files that were also falling back to \data-file\`n
## Operational check

- VPS health remained UP locally and publicly after prod moved to \3.595.0\`n- latest Production Release for \a2ced2d\ completed successfully
- auto-deploy reported \uto-deploy success tag=3.595.0\ and then \up-to-date\`n
## Validation

- \.\\mvnw.cmd test -Dtest=PersistenceServiceTest\ passed: 23 tests, 0 failures
- \git diff --check\ passed
- \.\\mvnw.cmd spotless:apply\ could not run locally because Spotless/google-java-format hit a JDK API incompatibility: \NoSuchMethodError: Log.getDiagnostics()\`n
Closes #1059

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing optional schedule files, reducing noisy log messages while still returning empty results as expected.
  * Expanded file labeling for several saved-state and schedule file types, making logs more accurate and easier to understand.

* **Tests**
  * Added coverage for missing schedule files and persistence label mappings to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->