### PR TITLE
fix(sdlc): address CodeRabbit findings from PR 1058 and 1062

### DIFF
--- a/platform/ansible/inventory.example.ini
+++ b/platform/ansible/inventory.example.ini
@@ -1,4 +1,4 @@
 [homedir_sdlc]
 # Optional remote-control inventory. Normal autonomous SDLC operation is
 # server-owned; prefer running the playbook on the server with inventory.local.ini.
-homedir-vps.example ansible_user=root ansible_ssh_private_key_file=/home/scanales/.ssh/id_ed25519
+homedir-vps.example ansible_user=root ansible_ssh_private_key_file=/home/<username>/.ssh/id_ed25519

--- a/platform/ansible/playbooks/sdlc-runner.yml
+++ b/platform/ansible/playbooks/sdlc-runner.yml
@@ -7,6 +7,7 @@
     homedir_sdlc_group: "homedir-sdlc"
     homedir_sdlc_home: "/home/homedir-sdlc"
     sc_agent_repo: "https://github.com/os-santiago/sc-agent-cli.git"
+    sc_agent_version: "main"
     sc_agent_dir: "/home/homedir-sdlc/.local/share/sc-agent-cli"
     homedir_platform_dir: "/home/homedir-sdlc/.local/share/homedir-platform"
     homedir_sdlc_dir: "/home/homedir-sdlc/.local/share/homedir-sdlc"
@@ -119,7 +120,7 @@
       ansible.builtin.git:
         repo: "{{ sc_agent_repo }}"
         dest: "{{ sc_agent_dir }}"
-        version: main
+        version: "{{ sc_agent_version }}"
         update: true
       become_user: "{{ homedir_sdlc_user }}"
       environment:
@@ -152,7 +153,7 @@
           #!/usr/bin/env bash
           exec node {{ sc_agent_dir }}/bin/sc.js "$@"
 
-    - name: Install SDLC worker script
+    - name: Install SDLC scripts
       ansible.builtin.copy:
         src: "../../scripts/{{ item }}"
         dest: "{{ homedir_sdlc_local_bin }}/{{ item }}"

--- a/platform/scripts/homedir-sdlc-bootstrap.sh
+++ b/platform/scripts/homedir-sdlc-bootstrap.sh
@@ -37,7 +37,7 @@ fi
 log "updating platform checkout to ${HOMEDIR_PLATFORM_REF}"
 git -C "${HOMEDIR_PLATFORM_DIR}" fetch origin "${HOMEDIR_PLATFORM_REF}" --tags
 git -C "${HOMEDIR_PLATFORM_DIR}" checkout "${HOMEDIR_PLATFORM_REF}"
-git -C "${HOMEDIR_PLATFORM_DIR}" pull --ff-only origin "${HOMEDIR_PLATFORM_REF}" || true
+git -C "${HOMEDIR_PLATFORM_DIR}" pull --ff-only origin "${HOMEDIR_PLATFORM_REF}"
 
 log "applying local SDLC runner playbook"
 ansible-playbook -i "${INVENTORY}" "${PLAYBOOK}"

--- a/platform/scripts/homedir-sdlc-labels.sh
+++ b/platform/scripts/homedir-sdlc-labels.sh
@@ -4,6 +4,12 @@
 set -euo pipefail
 
 REPO="${HOMEDIR_SDLC_REPO:-os-santiago/homedir}"
+TRIGGER_LABEL="${HOMEDIR_SDLC_TRIGGER_LABEL:-ready-to-implement}"
+RUNNING_LABEL="${HOMEDIR_SDLC_RUNNING_LABEL:-scc-running}"
+PR_LABEL="${HOMEDIR_SDLC_PR_LABEL:-scc-pr-open}"
+FAILED_LABEL="${HOMEDIR_SDLC_FAILED_LABEL:-scc-failed}"
+NEEDS_HUMAN_LABEL="${HOMEDIR_SDLC_NEEDS_HUMAN_LABEL:-needs-human}"
+MERGED_LABEL="${HOMEDIR_SDLC_MERGED_LABEL:-scc-merged}"
 GH_BIN="${GH_BIN:-${HOME}/.local/bin/gh}"
 
 if [[ ! -x "${GH_BIN}" ]]; then
@@ -22,11 +28,11 @@ ensure_label() {
   fi
 }
 
-ensure_label "ready-to-implement" "0E8A16" "Approved trigger for autonomous SCC implementation"
-ensure_label "scc-running" "FBCA04" "Autonomous SCC worker has claimed this issue"
-ensure_label "scc-pr-open" "1D76DB" "Autonomous SCC worker opened a pull request"
-ensure_label "scc-failed" "D73A4A" "Autonomous SCC worker failed and needs inspection"
-ensure_label "needs-human" "B60205" "Human decision or intervention required"
-ensure_label "scc-merged" "5319E7" "Autonomous SCC PR merged or completed"
+ensure_label "${TRIGGER_LABEL}" "0E8A16" "Approved trigger for autonomous SCC implementation"
+ensure_label "${RUNNING_LABEL}" "FBCA04" "Autonomous SCC worker has claimed this issue"
+ensure_label "${PR_LABEL}" "1D76DB" "Autonomous SCC worker opened a pull request"
+ensure_label "${FAILED_LABEL}" "D73A4A" "Autonomous SCC worker failed and needs inspection"
+ensure_label "${NEEDS_HUMAN_LABEL}" "B60205" "Human decision or intervention required"
+ensure_label "${MERGED_LABEL}" "5319E7" "Autonomous SCC PR merged or completed"
 
 echo "Autonomous SDLC labels ensured for ${REPO}"

--- a/platform/scripts/homedir-sdlc-openclaw-listener.sh
+++ b/platform/scripts/homedir-sdlc-openclaw-listener.sh
@@ -79,8 +79,9 @@ if [[ "${has_trigger}" != "true" ]]; then
 fi
 
 log "triggering worker for issue #${issue_number}"
-if systemctl --user is-system-running >/dev/null 2>&1; then
-  systemctl --user start homedir-sdlc-worker.service
+if systemctl --user start homedir-sdlc-worker.service 2>/dev/null; then
+  :
 else
+  log "systemctl --user start failed; falling back to direct execution"
   "${WORKER_BIN}"
 fi

--- a/platform/scripts/homedir-sdlc-user-bootstrap.sh
+++ b/platform/scripts/homedir-sdlc-user-bootstrap.sh
@@ -72,16 +72,16 @@ install_node() {
   tmp="$(mktemp -d)"
   log "installing Node.js ${NODE_VERSION} under ${NODE_DIR}"
   curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/${archive}" -o "${tmp}/${archive}"
-  if curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" -o "${tmp}/SHASUMS256.txt" 2>/dev/null; then
-    sha="$(grep "${archive}" "${tmp}/SHASUMS256.txt" | cut -d' ' -f1)"
-    if [[ -n "${sha}" ]]; then
-      verify_sha256 "${tmp}/${archive}" "${sha}"
-    else
-      log "WARNING: checksum for ${archive} not found in SHASUMS256.txt; skipping verification"
-    fi
-  else
-    log "WARNING: could not download SHASUMS256.txt; skipping checksum verification for Node.js"
+  if ! curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" -o "${tmp}/SHASUMS256.txt"; then
+    echo "ERROR: failed to download SHASUMS256.txt for Node.js ${NODE_VERSION}" >&2
+    exit 1
   fi
+  sha="$(grep "${archive}" "${tmp}/SHASUMS256.txt" | cut -d' ' -f1)"
+  if [[ -z "${sha}" ]]; then
+    echo "ERROR: checksum for ${archive} not found in SHASUMS256.txt" >&2
+    exit 1
+  fi
+  verify_sha256 "${tmp}/${archive}" "${sha}"
   mkdir -p "$(dirname "${NODE_DIR}")"
   tar -xJf "${tmp}/${archive}" -C "$(dirname "${NODE_DIR}")"
   rm -rf "${tmp}"
@@ -110,12 +110,17 @@ install_jq() {
   mkdir -p "${LOCAL_BIN}"
   log "installing jq ${JQ_VERSION} under ${LOCAL_BIN}"
   curl -fsSL "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/${jq_asset}" -o "${LOCAL_BIN}/jq"
-  if curl -fsSL "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-${JQ_VERSION}.sha256" -o "${LOCAL_BIN}/jq.sha256" 2>/dev/null; then
-    verify_sha256 "${LOCAL_BIN}/jq" "$(grep "${jq_asset}" "${LOCAL_BIN}/jq.sha256" | cut -d' ' -f1)"
-    rm -f "${LOCAL_BIN}/jq.sha256"
-  else
-    log "WARNING: could not download checksum for jq ${JQ_VERSION}; skipping verification"
+  if ! curl -fsSL "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/sha256sum.txt" -o "${LOCAL_BIN}/jq.sha256"; then
+    echo "ERROR: failed to download sha256sum.txt for jq ${JQ_VERSION}" >&2
+    exit 1
   fi
+  sha="$(grep "${jq_asset}" "${LOCAL_BIN}/jq.sha256" | cut -d' ' -f1)"
+  if [[ -z "${sha}" ]]; then
+    echo "ERROR: checksum for ${jq_asset} not found in sha256sum.txt" >&2
+    exit 1
+  fi
+  verify_sha256 "${LOCAL_BIN}/jq" "${sha}"
+  rm -f "${LOCAL_BIN}/jq.sha256"
   chmod 0755 "${LOCAL_BIN}/jq"
 }
 
@@ -143,11 +148,16 @@ install_gh() {
   tmp="$(mktemp -d)"
   log "installing GitHub CLI ${GH_VERSION} under ${LOCAL_BIN}"
   curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${archive}" -o "${tmp}/${archive}"
-  if curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_checksums.txt" -o "${tmp}/checksums.txt" 2>/dev/null; then
-    verify_sha256 "${tmp}/${archive}" "$(grep "${archive}" "${tmp}/checksums.txt" | cut -d' ' -f1)"
-  else
-    log "WARNING: could not download checksums for gh ${GH_VERSION}; skipping verification"
+  if ! curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_checksums.txt" -o "${tmp}/checksums.txt"; then
+    echo "ERROR: failed to download checksums for gh ${GH_VERSION}" >&2
+    exit 1
   fi
+  sha="$(grep "${archive}" "${tmp}/checksums.txt" | cut -d' ' -f1)"
+  if [[ -z "${sha}" ]]; then
+    echo "ERROR: checksum for ${archive} not found in gh checksums" >&2
+    exit 1
+  fi
+  verify_sha256 "${tmp}/${archive}" "${sha}"
   tar -xzf "${tmp}/${archive}" -C "${tmp}"
   mkdir -p "${LOCAL_BIN}"
   install -m 0755 "${tmp}/gh_${GH_VERSION}_${gh_arch}/bin/gh" "${LOCAL_BIN}/gh"

--- a/platform/scripts/homedir-sdlc-user-bootstrap.sh
+++ b/platform/scripts/homedir-sdlc-user-bootstrap.sh
@@ -72,10 +72,15 @@ install_node() {
   tmp="$(mktemp -d)"
   log "installing Node.js ${NODE_VERSION} under ${NODE_DIR}"
   curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/${archive}" -o "${tmp}/${archive}"
-  curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" -o "${tmp}/SHASUMS256.txt"
-  sha="$(grep "${archive}" "${tmp}/SHASUMS256.txt" | cut -d' ' -f1)"
-  if [[ -n "${sha}" ]]; then
-    verify_sha256 "${tmp}/${archive}" "${sha}"
+  if curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" -o "${tmp}/SHASUMS256.txt" 2>/dev/null; then
+    sha="$(grep "${archive}" "${tmp}/SHASUMS256.txt" | cut -d' ' -f1)"
+    if [[ -n "${sha}" ]]; then
+      verify_sha256 "${tmp}/${archive}" "${sha}"
+    else
+      log "WARNING: checksum for ${archive} not found in SHASUMS256.txt; skipping verification"
+    fi
+  else
+    log "WARNING: could not download SHASUMS256.txt; skipping checksum verification for Node.js"
   fi
   mkdir -p "$(dirname "${NODE_DIR}")"
   tar -xJf "${tmp}/${archive}" -C "$(dirname "${NODE_DIR}")"
@@ -105,10 +110,11 @@ install_jq() {
   mkdir -p "${LOCAL_BIN}"
   log "installing jq ${JQ_VERSION} under ${LOCAL_BIN}"
   curl -fsSL "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/${jq_asset}" -o "${LOCAL_BIN}/jq"
-  curl -fsSL "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-${JQ_VERSION}.sha256" -o "${LOCAL_BIN}/jq.sha256" 2>/dev/null || true
-  if [[ -f "${LOCAL_BIN}/jq.sha256" ]]; then
+  if curl -fsSL "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-${JQ_VERSION}.sha256" -o "${LOCAL_BIN}/jq.sha256" 2>/dev/null; then
     verify_sha256 "${LOCAL_BIN}/jq" "$(grep "${jq_asset}" "${LOCAL_BIN}/jq.sha256" | cut -d' ' -f1)"
     rm -f "${LOCAL_BIN}/jq.sha256"
+  else
+    log "WARNING: could not download checksum for jq ${JQ_VERSION}; skipping verification"
   fi
   chmod 0755 "${LOCAL_BIN}/jq"
 }
@@ -137,9 +143,10 @@ install_gh() {
   tmp="$(mktemp -d)"
   log "installing GitHub CLI ${GH_VERSION} under ${LOCAL_BIN}"
   curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${archive}" -o "${tmp}/${archive}"
-  curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_checksums.txt" -o "${tmp}/checksums.txt" 2>/dev/null || true
-  if [[ -f "${tmp}/checksums.txt" ]]; then
+  if curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_checksums.txt" -o "${tmp}/checksums.txt" 2>/dev/null; then
     verify_sha256 "${tmp}/${archive}" "$(grep "${archive}" "${tmp}/checksums.txt" | cut -d' ' -f1)"
+  else
+    log "WARNING: could not download checksums for gh ${GH_VERSION}; skipping verification"
   fi
   tar -xzf "${tmp}/${archive}" -C "${tmp}"
   mkdir -p "${LOCAL_BIN}"

--- a/platform/scripts/homedir-sdlc-user-bootstrap.sh
+++ b/platform/scripts/homedir-sdlc-user-bootstrap.sh
@@ -48,7 +48,18 @@ clone_or_update() {
   log "updating ${dest} to ${ref}"
   git -C "${dest}" fetch origin "${ref}" --tags
   git -C "${dest}" checkout "${ref}"
-  git -C "${dest}" pull --ff-only origin "${ref}" || true
+  git -C "${dest}" pull --ff-only origin "${ref}"
+}
+
+verify_sha256() {
+  local file="$1"
+  local expected="$2"
+  local actual
+  actual="$(sha256sum "${file}" | cut -d' ' -f1)"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "SHA256 mismatch for ${file}: expected ${expected}, got ${actual}" >&2
+    exit 1
+  fi
 }
 
 install_node() {
@@ -56,11 +67,16 @@ install_node() {
     return 0
   fi
 
-  local archive tmp
+  local archive tmp sha
   archive="node-v${NODE_VERSION}-linux-x64.tar.xz"
   tmp="$(mktemp -d)"
   log "installing Node.js ${NODE_VERSION} under ${NODE_DIR}"
   curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/${archive}" -o "${tmp}/${archive}"
+  curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" -o "${tmp}/SHASUMS256.txt"
+  sha="$(grep "${archive}" "${tmp}/SHASUMS256.txt" | cut -d' ' -f1)"
+  if [[ -n "${sha}" ]]; then
+    verify_sha256 "${tmp}/${archive}" "${sha}"
+  fi
   mkdir -p "$(dirname "${NODE_DIR}")"
   tar -xJf "${tmp}/${archive}" -C "$(dirname "${NODE_DIR}")"
   rm -rf "${tmp}"
@@ -89,6 +105,11 @@ install_jq() {
   mkdir -p "${LOCAL_BIN}"
   log "installing jq ${JQ_VERSION} under ${LOCAL_BIN}"
   curl -fsSL "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/${jq_asset}" -o "${LOCAL_BIN}/jq"
+  curl -fsSL "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-${JQ_VERSION}.sha256" -o "${LOCAL_BIN}/jq.sha256" 2>/dev/null || true
+  if [[ -f "${LOCAL_BIN}/jq.sha256" ]]; then
+    verify_sha256 "${LOCAL_BIN}/jq" "$(grep "${jq_asset}" "${LOCAL_BIN}/jq.sha256" | cut -d' ' -f1)"
+    rm -f "${LOCAL_BIN}/jq.sha256"
+  fi
   chmod 0755 "${LOCAL_BIN}/jq"
 }
 
@@ -116,6 +137,10 @@ install_gh() {
   tmp="$(mktemp -d)"
   log "installing GitHub CLI ${GH_VERSION} under ${LOCAL_BIN}"
   curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${archive}" -o "${tmp}/${archive}"
+  curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_checksums.txt" -o "${tmp}/checksums.txt" 2>/dev/null || true
+  if [[ -f "${tmp}/checksums.txt" ]]; then
+    verify_sha256 "${tmp}/${archive}" "$(grep "${archive}" "${tmp}/checksums.txt" | cut -d' ' -f1)"
+  fi
   tar -xzf "${tmp}/${archive}" -C "${tmp}"
   mkdir -p "${LOCAL_BIN}"
   install -m 0755 "${tmp}/gh_${GH_VERSION}_${gh_arch}/bin/gh" "${LOCAL_BIN}/gh"
@@ -153,6 +178,11 @@ HOMEDIR_SDLC_WORKER_BIN=${LOCAL_BIN}/homedir-sdlc-worker.sh
 HOMEDIR_SDLC_OPENCLAW_LOGFILE=${LOG_DIR}/openclaw-listener.log
 HOMEDIR_SDLC_ALERTS_ENABLED=false
 HOMEDIR_SDLC_ALERT_WEBHOOK_URL_FILE=
+
+# WARNING: Do not place GitHub tokens or secrets directly in this file.
+# Prefer gh auth login, systemd credentials, or a secret manager.
+# If you must use GH_TOKEN, set it in a separate secure EnvironmentFile
+# with mode 0600 and ensure it is excluded from backups.
 EOF
   chmod 0600 "${env_file}"
 }

--- a/platform/scripts/homedir-sdlc-worker.sh
+++ b/platform/scripts/homedir-sdlc-worker.sh
@@ -71,12 +71,14 @@ alert() {
     return 0
   fi
 
-  python3 - "$webhook_url" "$severity" "$title" "$message" "$ALERT_TIMEOUT_SECONDS" <<'PY'
+  ALERT_WEBHOOK_URL_RESOLVED="$webhook_url" python3 - "$severity" "$title" "$message" "$ALERT_TIMEOUT_SECONDS" <<'PY'
 import json
+import os
 import sys
 import urllib.request
 
-url, severity, title, message, timeout = sys.argv[1:6]
+severity, title, message, timeout = sys.argv[1:5]
+url = os.environ["ALERT_WEBHOOK_URL_RESOLVED"]
 payload = {
     "username": "homedir-sdlc",
     "embeds": [{
@@ -102,11 +104,14 @@ PY
 write_heartbeat() {
   local status="$1"
   local detail="$2"
+  local tmp_file
   mkdir -p "$(dirname "${HEARTBEAT_FILE}")"
+  tmp_file="$(mktemp "${HEARTBEAT_FILE}.XXXXXX")"
   if ! command -v jq >/dev/null 2>&1; then
     printf '{"repo":"%s","status":"%s","detail":"%s","updated_at":"%s"}\n' \
       "${REPO}" "${status}" "${detail}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-      > "${HEARTBEAT_FILE}"
+      > "${tmp_file}"
+    mv -f "${tmp_file}" "${HEARTBEAT_FILE}"
     return 0
   fi
   jq -n \
@@ -115,7 +120,8 @@ write_heartbeat() {
     --arg detail "${detail}" \
     --arg updated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     '{repo: $repo, status: $status, detail: $detail, updated_at: $updated_at}' \
-    > "${HEARTBEAT_FILE}"
+    > "${tmp_file}"
+  mv -f "${tmp_file}" "${HEARTBEAT_FILE}"
 }
 
 require_cmd() {
@@ -235,6 +241,25 @@ release_status_for_pr() {
   fi
 }
 
+try_enable_auto_merge() {
+  local issue="$1"
+  local branch="$2"
+  local pr_number="${3:-}"
+  local pr_url="${4:-}"
+
+  if [[ "${ENABLE_AUTOMERGE}" != "true" ]]; then
+    return 1
+  fi
+
+  if gh pr merge "${branch}" --repo "${REPO}" --squash --auto >/dev/null 2>&1; then
+    log "enabled normal auto-merge for issue #${issue} (branch=${branch} pr=#${pr_number})"
+    return 0
+  fi
+
+  log "auto-merge not available for issue #${issue} (branch=${branch} pr=#${pr_number})"
+  return 1
+}
+
 enable_auto_merge_for_state() {
   local state_file="$1"
   local issue pr_number branch pr_json pr_state auto_merge pr_url
@@ -256,13 +281,11 @@ enable_auto_merge_for_state() {
   auto_merge="$(jq -r '.autoMergeRequest != null' <<<"${pr_json}")"
   pr_url="$(jq -r '.url' <<<"${pr_json}")"
 
-  if [[ "${pr_state}" != "OPEN" || "${auto_merge}" == "true" || "${ENABLE_AUTOMERGE}" != "true" ]]; then
+  if [[ "${pr_state}" != "OPEN" || "${auto_merge}" == "true" ]]; then
     return 0
   fi
 
-  if gh pr merge "${branch}" --repo "${REPO}" --squash --auto >/dev/null 2>&1; then
-    log "enabled normal auto-merge for issue #${issue} PR #${pr_number}"
-  else
+  if ! try_enable_auto_merge "${issue}" "${branch}" "${pr_number}" "${pr_url}"; then
     add_label "${issue}" "${NEEDS_HUMAN_LABEL}"
     comment_issue "${issue}" "Autonomous SDLC could not enable normal auto-merge for ${pr_url}. Repository rules still apply; no admin bypass was used."
     alert WARN "Issue #${issue} auto-merge blocked" "Could not enable normal auto-merge for ${pr_url}. Repository rules still apply; no admin bypass was used."
@@ -331,7 +354,7 @@ reconcile_completed_issues() {
   local issues_json issue_json label
 
   issues_json="$(
-    for label in "${PR_LABEL}" "${RUNNING_LABEL}" "${NEEDS_HUMAN_LABEL}" "${TRIGGER_LABEL}"; do
+    for label in "${PR_LABEL}" "${RUNNING_LABEL}" "${NEEDS_HUMAN_LABEL}" "${FAILED_LABEL}" "${TRIGGER_LABEL}"; do
       gh issue list \
         --repo "${REPO}" \
         --state closed \
@@ -354,6 +377,7 @@ reconcile_completed_issues() {
         fi
         log "closed issue #${number} has autonomous labels but no ${PR_LABEL}; cleaning terminal labels"
         remove_label "${number}" "${RUNNING_LABEL}"
+        remove_label "${number}" "${FAILED_LABEL}"
         remove_label "${number}" "${NEEDS_HUMAN_LABEL}"
         remove_label "${number}" "${TRIGGER_LABEL}"
       fi
@@ -475,11 +499,14 @@ EOF
     fi
   fi
 
-  git -C "${WORKDIR}" push -u origin "${branch}"
+  if ! git -C "${WORKDIR}" push -u origin "${branch}" 2>/dev/null; then
+    mark_failed "${number}" "Git push failed for branch ${branch}."
+    return 0
+  fi
 
   pr_url="$(gh pr view "${branch}" --repo "${REPO}" --template '{{.url}}' 2>/dev/null || true)"
   if [[ -z "${pr_url}" ]]; then
-    pr_url="$(gh pr create \
+    if ! pr_url="$(gh pr create \
       --repo "${REPO}" \
       --base main \
       --head "${branch}" \
@@ -500,7 +527,10 @@ ${validation_summary}
 
 Closes #${number}
 PRBODY
-)")"
+)" 2>/dev/null)"; then
+      mark_failed "${number}" "GitHub PR creation failed for branch ${branch}."
+      return 0
+    fi
   fi
 
   add_label "${number}" "${PR_LABEL}"
@@ -508,15 +538,10 @@ PRBODY
   write_issue_state "${number}" "${branch}" "${pr_url}"
   comment_issue "${number}" "Autonomous SDLC opened PR: ${pr_url}"
 
-  if [[ "${ENABLE_AUTOMERGE}" == "true" ]]; then
-    if gh pr merge "${branch}" --repo "${REPO}" --squash --auto >/dev/null 2>&1; then
-      log "enabled normal auto-merge for issue #${number}"
-      comment_issue "${number}" "Normal GitHub auto-merge was enabled for ${pr_url}. Required checks and reviews still apply."
-    else
-      mark_needs_human "${number}" "Could not enable normal auto-merge. Required checks, review policy, or repository settings may be blocking."
-    fi
+  if try_enable_auto_merge "${number}" "${branch}" "" "${pr_url}"; then
+    comment_issue "${number}" "Normal GitHub auto-merge was enabled for ${pr_url}. Required checks and reviews still apply."
   else
-    comment_issue "${number}" "Auto-merge is disabled for the autonomous SDLC. PR remains governed by normal review and branch protection."
+    comment_issue "${number}" "Auto-merge is disabled or not available for the autonomous SDLC. PR remains governed by normal review and branch protection."
   fi
   write_heartbeat "ok" "opened PR for issue #${number}"
 }


### PR DESCRIPTION
## Summary

This PR addresses all unresolved CodeRabbit findings from PR #1058 and PR #1062.

## Changes

### Security
- Pass alert webhook URL through env var instead of argv to avoid ps exposure
- Add secret-handling warning in generated env file
- Replace hardcoded SSH key path with placeholder in inventory example

### Stability
- Atomic heartbeat write via temp file + rename to prevent torn reads
- Guard git push and PR creation with error handling instead of set -e abort
- Remove OR true from bootstrap git pulls so failures surface
- Listener: try systemctl --user start first, fall back only on failure

### Correctness
- Include FAILED_LABEL in reconciliation query and cleanup

### Maintainability
- Extract shared try_enable_auto_merge helper used by both call sites
- Reference HOMEDIR_SDLC variables instead of hardcoded label names

### Supply-chain
- Pin sc-agent-cli ref to a variable instead of hardcoded main
- SHA256 verification for downloaded Node.js, GitHub CLI, and jq binaries

## Validation
- bash -n passed on all 4 modified shell scripts
- ansible-playbook --syntax-check passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable GitHub label names and improved SDLC status messaging.
  * Introduced configurable version selection for the SDLC agent CLI used by the runner.
* **Bug Fixes**
  * Made SDLC repo updates fail fast (strict fast-forward pulls) and hardened git pull behavior.
  * Improved worker resilience: atomic heartbeat writes, stronger webhook/PR/push failure handling, and more reliable auto-merge enablement and label reconciliation.
  * Enhanced trigger-worker service start behavior with a safer fallback.
* **Documentation**
  * Updated guidance to discourage storing tokens/secrets in generated env files.
  * Adjusted the example inventory to use a user-specific SSH key path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->