### PR TITLE
chore(sdlc): gate queue admission by labeler

### DIFF
--- a/docs/en/development/autonomous-sdlc.md
+++ b/docs/en/development/autonomous-sdlc.md
@@ -21,8 +21,9 @@ and repository worktree all live on the server.
 An issue is eligible only when all conditions are true:
 
 - The issue is open.
-- The issue author is `scanalesespinoza`.
-- The issue has the `ready-to-implement` label.
+- The issue can be authored by anyone.
+- An authorized labeler added the `ready-to-implement` admission label.
+- The issue has been promoted to the `scc-queued` execution queue.
 - The issue does not have an active terminal or in-progress automation label.
 - The issue metadata is clear enough to implement and validate.
 
@@ -37,10 +38,13 @@ payloads to:
 ```
 
 The listener only wakes the worker when the event belongs to this repository,
-the issue is open, the author is `scanalesespinoza`, and the issue has the
-`ready-to-implement` label. The worker remains the only component that claims,
-branches, runs SCC, opens PRs, and reconciles releases. Keep
-`homedir-sdlc-worker.timer` enabled as a fallback and reconciliation loop.
+the issue is open, the label added was `ready-to-implement`, and the actor who
+added the label is listed in `HOMEDIR_SDLC_AUTHORIZED_LABELERS`. Accepted issues
+are promoted to `scc-queued`; unauthorized attempts are moved to the discard
+queue with `scc-rejected` and `scc-rejected:unauthorized-labeler`. The worker
+remains the only component that claims, branches, runs SCC, opens PRs, and
+reconciles releases. Keep `homedir-sdlc-worker.timer` enabled as a fallback and
+reconciliation loop.
 
 ## Lifecycle Labels
 
@@ -48,15 +52,18 @@ Use these labels for automation state:
 
 | Label | Meaning |
 | --- | --- |
-| `ready-to-implement` | Human-approved trigger for autonomous implementation |
+| `ready-to-implement` | Human request for authorized AI SDLC admission |
+| `scc-queued` | Authorized issue admitted to the AI SDLC execution queue |
 | `scc-running` | The SCC worker has claimed the issue |
 | `scc-pr-open` | A pull request was opened for the issue |
 | `scc-merged` | The PR was merged and the `Production Release` workflow succeeded |
 | `scc-failed` | Automation failed after allowed retries |
 | `needs-human` | A repository rule, unclear requirement, security concern, or repeated failure requires human action |
+| `scc-rejected` | Issue was rejected from the AI SDLC queue |
+| `scc-rejected:unauthorized-labeler` | `ready-to-implement` was added by an unauthorized actor |
 
 Existing `wos-review` triage can remain separate. It should not trigger
-implementation unless `ready-to-implement` is also present.
+implementation unless `ready-to-implement` is admitted into `scc-queued`.
 
 ## Worker Flow
 
@@ -71,7 +78,7 @@ implementation unless `ready-to-implement` is also present.
 9. Push the branch and create/update a PR with `Closes #<issue>`.
 10. Enable normal auto-merge only when repository protection allows it.
 11. Monitor CI and release workflows.
-12. Comment the result and update lifecycle labels.
+12. Remove `scc-queued`, comment the result, and update lifecycle labels.
 
 ## Server Ownership
 
@@ -176,7 +183,7 @@ such as missing tools, provider errors, or repository checkout failures.
 The worker also reconciles closed issues that still carry automation lifecycle
 labels. If a human or another compliant flow closes an issue, the worker removes
 temporary automation labels instead of leaving stale `needs-human`,
-`scc-running`, or `ready-to-implement` state behind.
+`scc-running`, `scc-queued`, or `ready-to-implement` state behind.
 
 ## Observability
 
@@ -250,11 +257,12 @@ The SCC v0.4.0 canary validates that the autonomous worker:
 - Keeps scope strictly on the assigned issue (issue focus).
 - Correctly handles the current working directory for tool execution.
 
-1. Create a small documentation-only issue authored by `scanalesespinoza`.
-2. Add `ready-to-implement`.
-3. Confirm the worker claims it, opens a branch and PR, respects checks, and
+1. Create or choose a small issue authored by any contributor.
+2. Have an authorized labeler, such as `scanalesespinoza`, add `ready-to-implement`.
+3. Confirm the webhook or polling fallback promotes the issue to `scc-queued`.
+4. Confirm the worker claims it, opens a branch and PR, respects checks, and
    waits for normal repository rules.
-4. After merge, confirm `Production Release` succeeds and the worker marks the
+5. After merge, confirm `Production Release` succeeds and the worker marks the
    issue `scc-merged`.
 
 Recovery:

--- a/platform/README.md
+++ b/platform/README.md
@@ -6,7 +6,7 @@ Configs and scripts to provision the VPS that runs HomeDir. All secrets are stri
 - `scripts/homedir-update.sh` – pulls a tagged image, restarts the container, and rolls back on failure.
 - `scripts/homedir-env-lib.sh` – shared env loader with `*_FILE` secret resolution.
 - `scripts/homedir-webhook.py` – optional listener for Quay webhooks that triggers `homedir-update.sh` with the tag from the payload (ignores `latest`-only webhooks), validates webhook signatures, and exposes a token-protected status endpoint.
-- `scripts/homedir-github-webhook.py` – GitHub webhook listener for issue/PR alerts, WOS review delegation, and event-driven SDLC wake-up for eligible `ready-to-implement` issues.
+- `scripts/homedir-github-webhook.py` – GitHub webhook listener for issue/PR alerts, WOS review delegation, and authorized SDLC admission from `ready-to-implement` into `scc-queued`.
 - `scripts/homedir-auto-deploy.sh` – fallback poller that checks Quay tags and deploys the newest semver tag when webhook delivery is missing.
 - `scripts/homedir-discord-alert.sh` – sends deploy and webhook alerts to Discord with severity icons/colors (`WARN`, `FAIL`, `RECOVERY`).
 - `scripts/homedir-ir-first-level.sh` – first-level incident response (`status`, `snapshot`, `shield-on`, `recover`, `shield-off`) for attacks/DoS.
@@ -19,7 +19,7 @@ Configs and scripts to provision the VPS that runs HomeDir. All secrets are stri
 - `scripts/homedir-sdlc-bootstrap.sh` – server-side bootstrap that installs/repairs the autonomous SDLC runner without depending on a workstation.
 - `scripts/homedir-sdlc-user-bootstrap.sh` – user-owned server-side bootstrap for SSH accounts without passwordless root/sudo.
 - `scripts/homedir-sdlc-worker.sh` – optional issue-driven SCC worker for autonomous PR creation under repository rules.
-- `scripts/homedir-sdlc-openclaw-listener.sh` – OpenClaw/GitHub issue-event adapter that wakes the worker for eligible `ready-to-implement` issues.
+- `scripts/homedir-sdlc-openclaw-listener.sh` – OpenClaw/GitHub issue-event adapter that wakes the worker after authorized `ready-to-implement` admission.
 - `scripts/homedir-sdlc-status.sh` – JSON health probe for worker heartbeat, timer state, and eligible issue backlog.
 - `systemd/homedir-webhook.service` – runs the optional webhook listener.
 - `systemd/homedir-github-webhook.service` – runs the GitHub webhook listener on localhost.
@@ -159,7 +159,7 @@ What it automates:
 - Autonomous SDLC is governed by `docs/en/development/autonomous-sdlc.md`: it may create branches and PRs, but it must not bypass branch protection, reviews, required checks, repository rulesets, or secret controls.
 - The autonomous SDLC must run from the VPS. A workstation may SSH in to trigger bootstrap, but normal operation must not depend on WSL, PowerShell, local paths, or local credentials.
 - OpenClaw can invoke `homedir-sdlc-openclaw-listener.sh` with the GitHub issue event payload. The polling timer remains enabled as a reconciliation fallback.
-- The GitHub webhook can wake the SDLC immediately when an open issue from `scanalesespinoza` receives `ready-to-implement`. Run `homedir-github-webhook.service` as `homedir-sdlc` and set `HOMEDIR_SDLC_GITHUB_HOOK_COMMAND` in `/etc/homedir.env` to invoke `homedir-sdlc-openclaw-listener.sh` directly from that account.
+- The GitHub webhook can wake the SDLC immediately when an authorized labeler adds `ready-to-implement` to any open issue. The webhook promotes accepted issues to `scc-queued`; the worker only consumes `scc-queued`, while unauthorized labelers are moved to the `scc-rejected` discard queue. Run `homedir-github-webhook.service` as `homedir-sdlc` and set `HOMEDIR_SDLC_GITHUB_HOOK_COMMAND` in `/etc/homedir.env` to invoke `homedir-sdlc-openclaw-listener.sh` directly from that account.
 - Monitor the runner with `homedir-sdlc-status.sh`; a stale heartbeat or inactive user timer should page the operator before issues pile up.
 
 ## Autonomous SDLC service account

--- a/platform/env.sdlc.example
+++ b/platform/env.sdlc.example
@@ -3,8 +3,11 @@
 # runtime account, or copy to /etc/homedir-sdlc.env for a system unit.
 
 HOMEDIR_SDLC_REPO=os-santiago/homedir
-HOMEDIR_SDLC_AUTHOR=scanalesespinoza
 HOMEDIR_SDLC_TRIGGER_LABEL=ready-to-implement
+HOMEDIR_SDLC_QUEUE_LABEL=scc-queued
+HOMEDIR_SDLC_REJECTED_LABEL=scc-rejected
+HOMEDIR_SDLC_UNAUTHORIZED_LABEL=scc-rejected:unauthorized-labeler
+HOMEDIR_SDLC_AUTHORIZED_LABELERS=scanalesespinoza
 HOMEDIR_SDLC_RUNNING_LABEL=scc-running
 HOMEDIR_SDLC_PR_LABEL=scc-pr-open
 HOMEDIR_SDLC_FAILED_LABEL=scc-failed
@@ -28,11 +31,10 @@ SCC_BIN=/home/homedir-sdlc/.local/bin/scc
 HOMEDIR_SDLC_WORKER_BIN=/home/homedir-sdlc/.local/bin/homedir-sdlc-worker.sh
 HOMEDIR_SDLC_OPENCLAW_LOGFILE=/home/homedir-sdlc/.local/state/homedir-sdlc/logs/openclaw-listener.log
 
-# GitHub webhook event-driven wake-up. Configure these in /etc/homedir.env for
-# the root-owned webhook service; the command must drop privileges to homedir-sdlc.
+# GitHub webhook event-driven admission. Configure these in /etc/homedir.env for
+# the homedir-sdlc-owned webhook service.
 HOMEDIR_SDLC_GITHUB_HOOK_ENABLED=true
 HOMEDIR_SDLC_GITHUB_HOOK_LABEL=ready-to-implement
-HOMEDIR_SDLC_GITHUB_HOOK_AUTHOR=scanalesespinoza
 HOMEDIR_SDLC_GITHUB_HOOK_TIMEOUT_SECONDS=20
 HOMEDIR_SDLC_GITHUB_HOOK_COMMAND="env HOME=/home/homedir-sdlc HOMEDIR_SDLC_ENV_FILE=/home/homedir-sdlc/.config/homedir-sdlc/env PATH=/home/homedir-sdlc/.local/bin:/usr/local/bin:/usr/bin:/bin /home/homedir-sdlc/.local/bin/homedir-sdlc-openclaw-listener.sh {payload}"
 GITHUB_WEBHOOK_ALERT_TIMEOUT_SECONDS=10

--- a/platform/scripts/homedir-github-webhook.py
+++ b/platform/scripts/homedir-github-webhook.py
@@ -571,14 +571,19 @@ def _gh_command() -> str:
 
 def _run_gh_issue_edit(repo: str, issue: int, *args: str) -> tuple[int, str, str]:
     command = [_gh_command(), "issue", "edit", str(issue), "--repo", repo, *args]
-    completed = subprocess.run(
-        command,
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=SDLC_HOOK_TIMEOUT_SECONDS,
-        env=os.environ.copy(),
-    )
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=SDLC_HOOK_TIMEOUT_SECONDS,
+            env=os.environ.copy(),
+        )
+    except subprocess.TimeoutExpired:
+        return 124, "", f"gh issue edit timed out after {SDLC_HOOK_TIMEOUT_SECONDS}s"
+    except OSError as exc:
+        return 127, "", str(exc)
     return completed.returncode, (completed.stdout or "").strip(), (completed.stderr or "").strip()
 
 
@@ -598,14 +603,19 @@ def _gh_remove_label(repo: str, issue: int, label: str) -> None:
 
 def _run_gh_issue_comment(repo: str, issue: int, body: str) -> tuple[int, str, str]:
     command = [_gh_command(), "issue", "comment", str(issue), "--repo", repo, "--body", body]
-    completed = subprocess.run(
-        command,
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=SDLC_HOOK_TIMEOUT_SECONDS,
-        env=os.environ.copy(),
-    )
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=SDLC_HOOK_TIMEOUT_SECONDS,
+            env=os.environ.copy(),
+        )
+    except subprocess.TimeoutExpired:
+        return 124, "", f"gh issue comment timed out after {SDLC_HOOK_TIMEOUT_SECONDS}s"
+    except OSError as exc:
+        return 127, "", str(exc)
     return completed.returncode, (completed.stdout or "").strip(), (completed.stderr or "").strip()
 
 

--- a/platform/scripts/homedir-github-webhook.py
+++ b/platform/scripts/homedir-github-webhook.py
@@ -36,7 +36,17 @@ ALERT_SCRIPT = os.environ.get("ALERT_SCRIPT", "/usr/local/bin/homedir-discord-al
 OPENCLAW_MONITOR_COMMAND = os.environ.get("OPENCLAW_GITHUB_MONITOR_COMMAND", "").strip()
 SDLC_HOOK_ENABLED = os.environ.get("HOMEDIR_SDLC_GITHUB_HOOK_ENABLED", "true").strip().lower() == "true"
 SDLC_HOOK_LABEL = os.environ.get("HOMEDIR_SDLC_GITHUB_HOOK_LABEL", "ready-to-implement").strip() or "ready-to-implement"
-SDLC_HOOK_AUTHOR = os.environ.get("HOMEDIR_SDLC_GITHUB_HOOK_AUTHOR", "scanalesespinoza").strip() or "scanalesespinoza"
+SDLC_QUEUE_LABEL = os.environ.get("HOMEDIR_SDLC_QUEUE_LABEL", "scc-queued").strip() or "scc-queued"
+SDLC_REJECTED_LABEL = os.environ.get("HOMEDIR_SDLC_REJECTED_LABEL", "scc-rejected").strip() or "scc-rejected"
+SDLC_UNAUTHORIZED_LABEL = (
+    os.environ.get("HOMEDIR_SDLC_UNAUTHORIZED_LABEL", "scc-rejected:unauthorized-labeler").strip()
+    or "scc-rejected:unauthorized-labeler"
+)
+SDLC_AUTHORIZED_LABELERS = {
+    login.strip().casefold()
+    for login in os.environ.get("HOMEDIR_SDLC_AUTHORIZED_LABELERS", "scanalesespinoza").split(",")
+    if login.strip()
+}
 SDLC_HOOK_COMMAND = os.environ.get("HOMEDIR_SDLC_GITHUB_HOOK_COMMAND", "").strip()
 SDLC_HOOK_TIMEOUT_SECONDS = int(os.environ.get("HOMEDIR_SDLC_GITHUB_HOOK_TIMEOUT_SECONDS", "20"))
 ALERT_TIMEOUT_SECONDS = int(os.environ.get("GITHUB_WEBHOOK_ALERT_TIMEOUT_SECONDS", "10"))
@@ -198,6 +208,15 @@ def _payload_labels(payload: dict[str, object], object_key: str) -> list[str]:
 def _has_label(payload: dict[str, object], object_key: str, wanted_label: str) -> bool:
     wanted = wanted_label.casefold()
     return any(label.casefold() == wanted for label in _payload_labels(payload, object_key))
+
+
+def _sender_login(payload: dict[str, object]) -> str:
+    sender = payload.get("sender") if isinstance(payload.get("sender"), dict) else {}
+    return str(sender.get("login") or "").strip()
+
+
+def _is_authorized_sdlc_labeler(login: str) -> bool:
+    return bool(login and login.casefold() in SDLC_AUTHORIZED_LABELERS)
 
 
 def _trim_text(value: object, max_chars: int) -> str:
@@ -546,6 +565,101 @@ def run_openclaw_hook(event: GitHubEvent, payload: dict[str, object]) -> None:
         log_line(f"openclaw hook failed event={event.event} repo={event.repo} error={exc}")
 
 
+def _gh_command() -> str:
+    return shutil.which("gh") or str(Path.home() / ".local" / "bin" / "gh")
+
+
+def _run_gh_issue_edit(repo: str, issue: int, *args: str) -> tuple[int, str, str]:
+    command = [_gh_command(), "issue", "edit", str(issue), "--repo", repo, *args]
+    completed = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=SDLC_HOOK_TIMEOUT_SECONDS,
+        env=os.environ.copy(),
+    )
+    return completed.returncode, (completed.stdout or "").strip(), (completed.stderr or "").strip()
+
+
+def _gh_add_label(repo: str, issue: int, label: str) -> bool:
+    rc, _, stderr = _run_gh_issue_edit(repo, issue, "--add-label", label)
+    if rc != 0:
+        log_line(f"sdlc label add failed issue={issue} label={label} exit={rc} stderr={stderr}")
+        return False
+    return True
+
+
+def _gh_remove_label(repo: str, issue: int, label: str) -> None:
+    rc, _, stderr = _run_gh_issue_edit(repo, issue, "--remove-label", label)
+    if rc != 0:
+        log_line(f"sdlc label remove skipped issue={issue} label={label} exit={rc} stderr={stderr}")
+
+
+def _run_gh_issue_comment(repo: str, issue: int, body: str) -> tuple[int, str, str]:
+    command = [_gh_command(), "issue", "comment", str(issue), "--repo", repo, "--body", body]
+    completed = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=SDLC_HOOK_TIMEOUT_SECONDS,
+        env=os.environ.copy(),
+    )
+    return completed.returncode, (completed.stdout or "").strip(), (completed.stderr or "").strip()
+
+
+def _repo_for_write(payload: dict[str, object]) -> str:
+    repository = payload.get("repository") if isinstance(payload.get("repository"), dict) else {}
+    repo = _repo_full_name(repository)
+    return repo if repo_is_allowed(repo) else ""
+
+
+def _admit_sdlc_issue(issue_number: int, labeler: str, payload: dict[str, object]) -> bool:
+    repo = _repo_for_write(payload)
+    if not repo:
+        log_line(f"sdlc admission failed issue={issue_number} reason=repo-not-allowed")
+        return False
+
+    if not _gh_add_label(repo, issue_number, SDLC_QUEUE_LABEL):
+        log_line(f"sdlc admission failed issue={issue_number} labeler={labeler}")
+        return False
+    _gh_remove_label(repo, issue_number, SDLC_REJECTED_LABEL)
+    _gh_remove_label(repo, issue_number, SDLC_UNAUTHORIZED_LABEL)
+
+    _run_gh_issue_comment(
+        repo,
+        issue_number,
+        f"AI SDLC admission accepted by `{labeler}`. The issue is now queued with `{SDLC_QUEUE_LABEL}`.",
+    )
+    log_line(f"sdlc admission accepted issue={issue_number} labeler={labeler} queue_label={SDLC_QUEUE_LABEL}")
+    return True
+
+
+def _reject_sdlc_issue(issue_number: int, labeler: str, payload: dict[str, object]) -> None:
+    repo = _repo_for_write(payload)
+    if not repo:
+        log_line(f"sdlc rejection skipped issue={issue_number} reason=repo-not-allowed labeler={labeler or 'unknown'}")
+        return
+
+    _gh_remove_label(repo, issue_number, SDLC_HOOK_LABEL)
+    _gh_remove_label(repo, issue_number, SDLC_QUEUE_LABEL)
+    if not _gh_add_label(repo, issue_number, SDLC_REJECTED_LABEL):
+        return
+    if not _gh_add_label(repo, issue_number, SDLC_UNAUTHORIZED_LABEL):
+        return
+
+    _run_gh_issue_comment(
+        repo,
+        issue_number,
+        (
+            f"AI SDLC admission rejected: `{labeler or 'unknown'}` is not authorized to add "
+            f"`{SDLC_HOOK_LABEL}`. Authorized labelers: {', '.join(sorted(SDLC_AUTHORIZED_LABELERS)) or 'none'}."
+        ),
+    )
+    log_line(f"sdlc admission rejected issue={issue_number} labeler={labeler or 'unknown'}")
+
+
 def _should_trigger_sdlc_hook(event_name: str, payload: dict[str, object]) -> tuple[bool, str]:
     if not SDLC_HOOK_ENABLED:
         return False, "disabled"
@@ -555,7 +669,7 @@ def _should_trigger_sdlc_hook(event_name: str, payload: dict[str, object]) -> tu
         return False, "not-issue-event"
 
     action = str(payload.get("action") or "").strip().casefold()
-    if action not in {"opened", "edited", "reopened", "labeled"}:
+    if action != "labeled":
         return False, f"ignored-action:{action or 'unknown'}"
 
     repository = payload.get("repository") if isinstance(payload.get("repository"), dict) else {}
@@ -566,11 +680,10 @@ def _should_trigger_sdlc_hook(event_name: str, payload: dict[str, object]) -> tu
     issue = payload.get("issue") if isinstance(payload.get("issue"), dict) else {}
     number = _int(issue.get("number"))
     state = str(issue.get("state") or "").strip().casefold()
-    author = str((issue.get("user") or {}).get("login") if isinstance(issue.get("user"), dict) else "").strip()
     if state != "open":
         return False, f"issue-not-open:{number or 'unknown'}"
-    if author.casefold() != SDLC_HOOK_AUTHOR.casefold():
-        return False, f"author-mismatch:{author or 'unknown'}"
+    if not number:
+        return False, "missing-issue-number"
 
     labels = _payload_labels(payload, "issue")
     has_trigger = any(label.casefold() == SDLC_HOOK_LABEL.casefold() for label in labels)
@@ -582,7 +695,16 @@ def _should_trigger_sdlc_hook(event_name: str, payload: dict[str, object]) -> tu
         return False, f"other-label:{event_label or 'unknown'}"
     if not has_trigger:
         return False, "missing-trigger-label"
-    return True, f"issue:{number or 'unknown'}"
+
+    labeler = _sender_login(payload)
+    if not _is_authorized_sdlc_labeler(labeler):
+        _reject_sdlc_issue(number, labeler, payload)
+        return False, f"unauthorized-labeler:{labeler or 'unknown'}"
+
+    if not _admit_sdlc_issue(number, labeler, payload):
+        return False, "admission-failed"
+
+    return True, f"issue:{number}:admitted-by:{labeler}"
 
 
 def _render_sdlc_hook_command(payload_file: str, *, delivery: str, event_name: str) -> list[str]:
@@ -591,7 +713,8 @@ def _render_sdlc_hook_command(payload_file: str, *, delivery: str, event_name: s
         delivery=_quoted_env(delivery),
         event=_quoted_env(event_name),
         label=_quoted_env(SDLC_HOOK_LABEL),
-        author=_quoted_env(SDLC_HOOK_AUTHOR),
+        queue_label=_quoted_env(SDLC_QUEUE_LABEL),
+        authorized_labelers=_quoted_env(",".join(sorted(SDLC_AUTHORIZED_LABELERS))),
     )
     return shlex.split(rendered)
 
@@ -663,7 +786,9 @@ class Handler(BaseHTTPRequestHandler):
             "openclaw_hook_enabled": bool(OPENCLAW_MONITOR_COMMAND),
             "sdlc_hook_enabled": SDLC_HOOK_ENABLED and bool(SDLC_HOOK_COMMAND),
             "sdlc_hook_label": SDLC_HOOK_LABEL,
-            "sdlc_hook_author": SDLC_HOOK_AUTHOR,
+            "sdlc_queue_label": SDLC_QUEUE_LABEL,
+            "sdlc_rejected_label": SDLC_REJECTED_LABEL,
+            "sdlc_authorized_labelers": sorted(SDLC_AUTHORIZED_LABELERS),
             "wos_review_hook_enabled": True,
             "wos_review_label": WOS_REVIEW_LABEL,
             "wos_review_discord_target": WOS_REVIEW_DISCORD_TARGET,

--- a/platform/scripts/homedir-sdlc-labels.sh
+++ b/platform/scripts/homedir-sdlc-labels.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 
 REPO="${HOMEDIR_SDLC_REPO:-os-santiago/homedir}"
 TRIGGER_LABEL="${HOMEDIR_SDLC_TRIGGER_LABEL:-ready-to-implement}"
+QUEUE_LABEL="${HOMEDIR_SDLC_QUEUE_LABEL:-scc-queued}"
+REJECTED_LABEL="${HOMEDIR_SDLC_REJECTED_LABEL:-scc-rejected}"
+UNAUTHORIZED_LABEL="${HOMEDIR_SDLC_UNAUTHORIZED_LABEL:-scc-rejected:unauthorized-labeler}"
 RUNNING_LABEL="${HOMEDIR_SDLC_RUNNING_LABEL:-scc-running}"
 PR_LABEL="${HOMEDIR_SDLC_PR_LABEL:-scc-pr-open}"
 FAILED_LABEL="${HOMEDIR_SDLC_FAILED_LABEL:-scc-failed}"
@@ -21,14 +24,17 @@ ensure_label() {
   local color="$2"
   local description="$3"
 
-  if "${GH_BIN}" label view "${name}" --repo "${REPO}" >/dev/null 2>&1; then
-    "${GH_BIN}" label edit "${name}" --repo "${REPO}" --color "${color}" --description "${description}" >/dev/null
-  else
-    "${GH_BIN}" label create "${name}" --repo "${REPO}" --color "${color}" --description "${description}" >/dev/null
-  fi
+  "${GH_BIN}" label create "${name}" \
+    --repo "${REPO}" \
+    --color "${color}" \
+    --description "${description}" \
+    --force >/dev/null
 }
 
-ensure_label "${TRIGGER_LABEL}" "0E8A16" "Approved trigger for autonomous SCC implementation"
+ensure_label "${TRIGGER_LABEL}" "0E8A16" "Human request for authorized AI SDLC admission"
+ensure_label "${QUEUE_LABEL}" "0E8A16" "Authorized AI SDLC queue entry"
+ensure_label "${REJECTED_LABEL}" "D93F0B" "Rejected from the AI SDLC queue"
+ensure_label "${UNAUTHORIZED_LABEL}" "D93F0B" "AI SDLC admission rejected because labeler is not authorized"
 ensure_label "${RUNNING_LABEL}" "FBCA04" "Autonomous SCC worker has claimed this issue"
 ensure_label "${PR_LABEL}" "1D76DB" "Autonomous SCC worker opened a pull request"
 ensure_label "${FAILED_LABEL}" "D73A4A" "Autonomous SCC worker failed and needs inspection"

--- a/platform/scripts/homedir-sdlc-openclaw-listener.sh
+++ b/platform/scripts/homedir-sdlc-openclaw-listener.sh
@@ -12,8 +12,9 @@ if [[ -r "${ENV_LIB}" ]]; then
 fi
 
 REPO="${HOMEDIR_SDLC_REPO:-os-santiago/homedir}"
-AUTHOR="${HOMEDIR_SDLC_AUTHOR:-scanalesespinoza}"
 TRIGGER_LABEL="${HOMEDIR_SDLC_TRIGGER_LABEL:-ready-to-implement}"
+QUEUE_LABEL="${HOMEDIR_SDLC_QUEUE_LABEL:-scc-queued}"
+AUTHORIZED_LABELERS="${HOMEDIR_SDLC_AUTHORIZED_LABELERS:-scanalesespinoza}"
 WORKER_BIN="${HOMEDIR_SDLC_WORKER_BIN:-homedir-sdlc-worker.sh}"
 LOGFILE="${HOMEDIR_SDLC_OPENCLAW_LOGFILE:-${HOMEDIR_SDLC_STATE_DIR:-/var/lib/homedir-sdlc}/logs/openclaw-listener.log}"
 
@@ -45,11 +46,24 @@ fi
 
 action="$(jq -r '.action // ""' "${payload_file}")"
 issue_state="$(jq -r '.issue.state // ""' "${payload_file}")"
-issue_author="$(jq -r '.issue.user.login // ""' "${payload_file}")"
 issue_number="$(jq -r '.issue.number // ""' "${payload_file}")"
 repository="$(jq -r '.repository.full_name // ""' "${payload_file}")"
 event_label="$(jq -r '.label.name // ""' "${payload_file}")"
+labeler="$(jq -r '.sender.login // ""' "${payload_file}")"
 has_trigger="$(jq -r --arg label "${TRIGGER_LABEL}" '[.issue.labels[]?.name] | index($label) != null' "${payload_file}")"
+
+is_authorized_labeler() {
+  local login="$1"
+  local item
+  IFS=',' read -r -a labelers <<<"${AUTHORIZED_LABELERS}"
+  for item in "${labelers[@]}"; do
+    item="${item//[[:space:]]/}"
+    if [[ -n "${item}" && "${login}" == "${item}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
 
 case "${action}" in
   opened|edited|reopened|labeled)
@@ -65,8 +79,8 @@ if [[ "${repository}" != "${REPO}" ]]; then
   exit 0
 fi
 
-if [[ "${issue_state}" != "open" || "${issue_author}" != "${AUTHOR}" ]]; then
-  log "ignored issue #${issue_number}: state=${issue_state} author=${issue_author}"
+if [[ "${issue_state}" != "open" ]]; then
+  log "ignored issue #${issue_number}: state=${issue_state}"
   exit 0
 fi
 
@@ -80,7 +94,12 @@ if [[ "${has_trigger}" != "true" ]]; then
   exit 0
 fi
 
-log "triggering worker for issue #${issue_number}"
+if ! is_authorized_labeler "${labeler}"; then
+  log "ignored issue #${issue_number}: labeler ${labeler:-unknown} is not authorized for ${TRIGGER_LABEL}"
+  exit 0
+fi
+
+log "triggering worker for issue #${issue_number}; admission label=${QUEUE_LABEL} labeler=${labeler}"
 if systemctl --user start --no-block homedir-sdlc-worker.service >/dev/null 2>&1; then
   log "started homedir-sdlc-worker.service"
 else

--- a/platform/scripts/homedir-sdlc-status.sh
+++ b/platform/scripts/homedir-sdlc-status.sh
@@ -13,6 +13,7 @@ fi
 
 REPO="${HOMEDIR_SDLC_REPO:-os-santiago/homedir}"
 TRIGGER_LABEL="${HOMEDIR_SDLC_TRIGGER_LABEL:-ready-to-implement}"
+QUEUE_LABEL="${HOMEDIR_SDLC_QUEUE_LABEL:-scc-queued}"
 STATE_DIR="${HOMEDIR_SDLC_STATE_DIR:-/var/lib/homedir-sdlc}"
 HEARTBEAT_FILE="${HOMEDIR_SDLC_HEARTBEAT_FILE:-${STATE_DIR}/heartbeat.json}"
 MAX_AGE_SECONDS="${HOMEDIR_SDLC_HEARTBEAT_MAX_AGE_SECONDS:-900}"
@@ -55,7 +56,7 @@ if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
   eligible_issues_json="$(gh issue list \
     --repo "${REPO}" \
     --state open \
-    --label "${TRIGGER_LABEL}" \
+    --label "${QUEUE_LABEL}" \
     --limit 20 \
     --json number,title,url,labels 2>/dev/null || echo "[]")"
 fi

--- a/platform/scripts/homedir-sdlc-user-bootstrap.sh
+++ b/platform/scripts/homedir-sdlc-user-bootstrap.sh
@@ -176,8 +176,11 @@ write_env() {
   cat >"${env_file}" <<EOF
 PATH=${NODE_DIR}/bin:${LOCAL_BIN}:/usr/local/bin:/usr/bin:/bin
 HOMEDIR_SDLC_REPO=os-santiago/homedir
-HOMEDIR_SDLC_AUTHOR=scanalesespinoza
 HOMEDIR_SDLC_TRIGGER_LABEL=ready-to-implement
+HOMEDIR_SDLC_QUEUE_LABEL=scc-queued
+HOMEDIR_SDLC_REJECTED_LABEL=scc-rejected
+HOMEDIR_SDLC_UNAUTHORIZED_LABEL=scc-rejected:unauthorized-labeler
+HOMEDIR_SDLC_AUTHORIZED_LABELERS=scanalesespinoza
 HOMEDIR_SDLC_RUNNING_LABEL=scc-running
 HOMEDIR_SDLC_PR_LABEL=scc-pr-open
 HOMEDIR_SDLC_FAILED_LABEL=scc-failed

--- a/platform/scripts/homedir-sdlc-worker.sh
+++ b/platform/scripts/homedir-sdlc-worker.sh
@@ -190,6 +190,8 @@ mark_needs_human() {
   local reason="$2"
   add_label "${issue}" "${NEEDS_HUMAN_LABEL}"
   remove_label "${issue}" "${RUNNING_LABEL}"
+  remove_label "${issue}" "${QUEUE_LABEL}"
+  remove_label "${issue}" "${TRIGGER_LABEL}"
   comment_issue "${issue}" "Autonomous SDLC paused: ${reason}"
   alert WARN "Issue #${issue} needs human review" "${reason}"
 }
@@ -199,6 +201,8 @@ mark_failed() {
   local reason="$2"
   add_label "${issue}" "${FAILED_LABEL}"
   remove_label "${issue}" "${RUNNING_LABEL}"
+  remove_label "${issue}" "${QUEUE_LABEL}"
+  remove_label "${issue}" "${TRIGGER_LABEL}"
   comment_issue "${issue}" "Autonomous SDLC failed: ${reason}"
   alert FAIL "Issue #${issue} failed" "${reason}"
 }
@@ -231,6 +235,18 @@ reject_issue_from_queue() {
   add_label "${issue}" "${UNAUTHORIZED_LABEL}"
   comment_issue "${issue}" "AI SDLC admission rejected: \`${labeler:-unknown}\` is not authorized to add \`${TRIGGER_LABEL}\`. Authorized labelers: \`${AUTHORIZED_LABELERS}\`."
   log "rejected issue #${issue} from AI SDLC queue; labeler=${labeler:-unknown}"
+}
+
+open_pr_for_issue() {
+  local issue="$1"
+  gh pr list \
+    --repo "${REPO}" \
+    --state open \
+    --search "${issue} in:title,body" \
+    --limit 20 \
+    --json number,title,url \
+    --jq '.[0] // empty' \
+    2>/dev/null
 }
 
 reconcile_admission_requests() {
@@ -485,7 +501,7 @@ prepare_workdir() {
 
 run_issue() {
   local issue_json="$1"
-  local number title labels body url branch slug prompt pr_url validation_summary
+  local number title labels body url branch slug prompt pr_url validation_summary existing_pr_json existing_pr_number existing_pr_url
 
   number="$(jq -r '.number' <<<"${issue_json}")"
   title="$(jq -r '.title' <<<"${issue_json}")"
@@ -498,7 +514,20 @@ run_issue() {
     || issue_has_label "${labels}" "${FAILED_LABEL}" \
     || issue_has_label "${labels}" "${NEEDS_HUMAN_LABEL}" \
     || issue_has_label "${labels}" "${MERGED_LABEL}"; then
+    if issue_has_label "${labels}" "${QUEUE_LABEL}"; then
+      remove_label "${number}" "${QUEUE_LABEL}"
+      remove_label "${number}" "${TRIGGER_LABEL}"
+      log "cleaned queued admission labels for issue #${number}: already has automation lifecycle label"
+    fi
     log "skipping issue #${number}: already has automation lifecycle label"
+    return 0
+  fi
+
+  existing_pr_json="$(open_pr_for_issue "${number}")"
+  if [[ -n "${existing_pr_json}" && "${existing_pr_json}" != "null" ]]; then
+    existing_pr_number="$(jq -r '.number' <<<"${existing_pr_json}")"
+    existing_pr_url="$(jq -r '.url' <<<"${existing_pr_json}")"
+    mark_needs_human "${number}" "An open PR already exists for this issue: #${existing_pr_number} (${existing_pr_url}). Refusing to create duplicate autonomous work."
     return 0
   fi
 

--- a/platform/scripts/homedir-sdlc-worker.sh
+++ b/platform/scripts/homedir-sdlc-worker.sh
@@ -10,8 +10,11 @@ if [[ -f "${ENV_FILE}" ]]; then
 fi
 
 REPO="${HOMEDIR_SDLC_REPO:-os-santiago/homedir}"
-AUTHOR="${HOMEDIR_SDLC_AUTHOR:-scanalesespinoza}"
 TRIGGER_LABEL="${HOMEDIR_SDLC_TRIGGER_LABEL:-ready-to-implement}"
+QUEUE_LABEL="${HOMEDIR_SDLC_QUEUE_LABEL:-scc-queued}"
+REJECTED_LABEL="${HOMEDIR_SDLC_REJECTED_LABEL:-scc-rejected}"
+UNAUTHORIZED_LABEL="${HOMEDIR_SDLC_UNAUTHORIZED_LABEL:-scc-rejected:unauthorized-labeler}"
+AUTHORIZED_LABELERS="${HOMEDIR_SDLC_AUTHORIZED_LABELERS:-scanalesespinoza}"
 RUNNING_LABEL="${HOMEDIR_SDLC_RUNNING_LABEL:-scc-running}"
 PR_LABEL="${HOMEDIR_SDLC_PR_LABEL:-scc-pr-open}"
 FAILED_LABEL="${HOMEDIR_SDLC_FAILED_LABEL:-scc-failed}"
@@ -151,6 +154,19 @@ issue_has_label() {
   jq -e --arg wanted "${wanted}" 'index($wanted) != null' >/dev/null <<<"${labels_json}"
 }
 
+is_authorized_labeler() {
+  local login="$1"
+  local item
+  IFS=',' read -r -a labelers <<<"${AUTHORIZED_LABELERS}"
+  for item in "${labelers[@]}"; do
+    item="${item//[[:space:]]/}"
+    if [[ -n "${item}" && "${login}" == "${item}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 add_label() {
   local issue="$1"
   local label="$2"
@@ -185,6 +201,72 @@ mark_failed() {
   remove_label "${issue}" "${RUNNING_LABEL}"
   comment_issue "${issue}" "Autonomous SDLC failed: ${reason}"
   alert FAIL "Issue #${issue} failed" "${reason}"
+}
+
+latest_trigger_labeler() {
+  local issue="$1"
+  gh api \
+    -H "Accept: application/vnd.github+json" \
+    "repos/${REPO}/issues/${issue}/timeline" --paginate \
+    --jq ".[] | select(.event == \"labeled\" and .label.name == \"${TRIGGER_LABEL}\") | .actor.login" \
+    2>/dev/null | tail -n1
+}
+
+admit_issue_to_queue() {
+  local issue="$1"
+  local labeler="$2"
+  add_label "${issue}" "${QUEUE_LABEL}"
+  remove_label "${issue}" "${REJECTED_LABEL}"
+  remove_label "${issue}" "${UNAUTHORIZED_LABEL}"
+  comment_issue "${issue}" "AI SDLC admission accepted by \`${labeler}\`. The issue is now queued with \`${QUEUE_LABEL}\`."
+  log "admitted issue #${issue} to ${QUEUE_LABEL}; labeler=${labeler}"
+}
+
+reject_issue_from_queue() {
+  local issue="$1"
+  local labeler="$2"
+  remove_label "${issue}" "${TRIGGER_LABEL}"
+  remove_label "${issue}" "${QUEUE_LABEL}"
+  add_label "${issue}" "${REJECTED_LABEL}"
+  add_label "${issue}" "${UNAUTHORIZED_LABEL}"
+  comment_issue "${issue}" "AI SDLC admission rejected: \`${labeler:-unknown}\` is not authorized to add \`${TRIGGER_LABEL}\`. Authorized labelers: \`${AUTHORIZED_LABELERS}\`."
+  log "rejected issue #${issue} from AI SDLC queue; labeler=${labeler:-unknown}"
+}
+
+reconcile_admission_requests() {
+  local issues_json issue_json number labels labeler
+
+  issues_json="$(gh issue list \
+    --repo "${REPO}" \
+    --state open \
+    --label "${TRIGGER_LABEL}" \
+    --limit 100 \
+    --json number,labels)"
+
+  if [[ "${issues_json}" == "[]" ]]; then
+    return 0
+  fi
+
+  jq -c '.[]' <<<"${issues_json}" | while IFS= read -r issue_json; do
+    number="$(jq -r '.number' <<<"${issue_json}")"
+    labels="$(jq -c '[.labels[].name]' <<<"${issue_json}")"
+
+    if issue_has_label "${labels}" "${QUEUE_LABEL}" \
+      || issue_has_label "${labels}" "${RUNNING_LABEL}" \
+      || issue_has_label "${labels}" "${PR_LABEL}" \
+      || issue_has_label "${labels}" "${FAILED_LABEL}" \
+      || issue_has_label "${labels}" "${NEEDS_HUMAN_LABEL}" \
+      || issue_has_label "${labels}" "${MERGED_LABEL}"; then
+      continue
+    fi
+
+    labeler="$(latest_trigger_labeler "${number}")"
+    if is_authorized_labeler "${labeler}"; then
+      admit_issue_to_queue "${number}" "${labeler}"
+    else
+      reject_issue_from_queue "${number}" "${labeler}"
+    fi
+  done
 }
 
 write_issue_state() {
@@ -345,6 +427,7 @@ reconcile_completed_issue() {
   remove_label "${number}" "${FAILED_LABEL}"
   remove_label "${number}" "${NEEDS_HUMAN_LABEL}"
   remove_label "${number}" "${TRIGGER_LABEL}"
+  remove_label "${number}" "${QUEUE_LABEL}"
   comment_issue "${number}" "Autonomous SDLC completed: PR #${pr_number} was merged (${pr_url}) and release verification succeeded. ${release_url}"
   log "reconciled completed issue #${number} via PR #${pr_number}; release verified"
   alert INFO "Issue #${number} deployed" "PR #${pr_number} was merged and Production Release succeeded. ${release_url}"
@@ -380,6 +463,7 @@ reconcile_completed_issues() {
         remove_label "${number}" "${FAILED_LABEL}"
         remove_label "${number}" "${NEEDS_HUMAN_LABEL}"
         remove_label "${number}" "${TRIGGER_LABEL}"
+        remove_label "${number}" "${QUEUE_LABEL}"
       fi
     done
   fi
@@ -401,19 +485,13 @@ prepare_workdir() {
 
 run_issue() {
   local issue_json="$1"
-  local number title author labels body url branch slug prompt pr_url validation_summary
+  local number title labels body url branch slug prompt pr_url validation_summary
 
   number="$(jq -r '.number' <<<"${issue_json}")"
   title="$(jq -r '.title' <<<"${issue_json}")"
-  author="$(jq -r '.author.login' <<<"${issue_json}")"
   labels="$(jq -c '[.labels[].name]' <<<"${issue_json}")"
   body="$(jq -r '.body // ""' <<<"${issue_json}")"
   url="$(jq -r '.url // ""' <<<"${issue_json}")"
-
-  if [[ "${author}" != "${AUTHOR}" ]]; then
-    log "skipping issue #${number}: author ${author} is not ${AUTHOR}"
-    return 0
-  fi
 
   if issue_has_label "${labels}" "${RUNNING_LABEL}" \
     || issue_has_label "${labels}" "${PR_LABEL}" \
@@ -568,11 +646,12 @@ main() {
 
   log "checking eligible issues in ${REPO}"
   write_heartbeat "running" "checking eligible issues"
+  reconcile_admission_requests
   mapfile -t issues < <(
     gh issue list \
       --repo "${REPO}" \
       --state open \
-      --label "${TRIGGER_LABEL}" \
+      --label "${QUEUE_LABEL}" \
       --limit "${MAX_ISSUES}" \
       --json number,title,body,url,author,labels
   )


### PR DESCRIPTION
## Summary
- make ready-to-implement an admission request instead of the worker queue
- add scc-queued as the only executable AI SDLC queue label
- reject unauthorized admission attempts into scc-rejected / scc-rejected:unauthorized-labeler
- validate admission by label actor in webhook and by issue timeline in polling fallback
- update docs, env examples, labels, and bootstrap rules

## Validation
- python -m py_compile platform/scripts/homedir-github-webhook.py
- bash -n platform/scripts/homedir-sdlc-worker.sh
- bash -n platform/scripts/homedir-sdlc-openclaw-listener.sh
- bash -n platform/scripts/homedir-sdlc-status.sh
- bash -n platform/scripts/homedir-sdlc-labels.sh
- bash -n platform/scripts/homedir-sdlc-user-bootstrap.sh
- deployed to VPS and confirmed webhook active, SDLC healthy, timer active, app UP, public HTTP 200
- confirmed ready-to-implement and scc-queued queues are empty before the controlled retest

No issue was re-labeled as part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a queue-driven SDLC workflow with dedicated queued, rejected, and unauthorized-labeler labels.
  * Admission and rejection are now determined by an allowlist of authorized GitHub labelers, with automatic issue comments and label transitions.
  * SDLC status output now reports queue/rejected label values and the configured authorized labelers.

* **Bug Fixes**
  * Removed SDLC reliance on a single issue author for gating and processing.

* **Documentation**
  * Updated SDLC docs and example environment configuration to match the new labeler/queue authorization flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->