### PR TITLE
feat(cfp): modernizacion del flujo de CFP, autogestion de speaker e individual/bulk publishing #1068

### DIFF
--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -290,13 +290,13 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.44.0</version>
+                <version>2.43.0</version>
                 <configuration>
-                    <java>
+                     <java>
                         <googleJavaFormat>
-                            <version>1.17.0</version>
+                            <version>1.24.0</version>
                         </googleJavaFormat>
-                    </java>
+                     </java>
                 </configuration>
             </plugin>
             <plugin>

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -290,11 +290,11 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.43.0</version>
+                <version>2.44.0</version>
                 <configuration>
                     <java>
                         <googleJavaFormat>
-                            <version>1.24.0</version>
+                            <version>1.17.0</version>
                         </googleJavaFormat>
                     </java>
                 </configuration>

--- a/quarkus-app/src/main/java/com/scanales/homedir/cfp/CfpSubmission.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/cfp/CfpSubmission.java
@@ -31,4 +31,6 @@ public record CfpSubmission(
     List<CfpPanelist> panelists,
     @JsonProperty("assigned_block") String assignedBlock,
     @JsonProperty("assigned_scenario") String assignedScenario,
-    @JsonProperty("presentation_asset") CfpPresentationAsset presentationAsset) {}
+    @JsonProperty("presentation_asset") CfpPresentationAsset presentationAsset,
+    @JsonProperty("published") Boolean published,
+    @JsonProperty("presentation_published") Boolean presentationPublished) {}

--- a/quarkus-app/src/main/java/com/scanales/homedir/cfp/CfpSubmissionService.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/cfp/CfpSubmissionService.java
@@ -175,7 +175,9 @@ public class CfpSubmissionService {
               List.of(),
               null,
               null,
-              null);
+              null,
+              false,
+              false);
       submissions.put(submission.id(), submission);
       persistSync();
       return submission;
@@ -544,7 +546,9 @@ public class CfpSubmissionService {
               current.panelists() == null ? List.of() : current.panelists(),
               current.assignedBlock(),
               current.assignedScenario(),
-              current.presentationAsset());
+              current.presentationAsset(),
+              current.published(),
+              current.presentationPublished());
       submissions.put(updated.id(), updated);
       persistSync();
       return updated;
@@ -632,7 +636,9 @@ public class CfpSubmissionService {
               current.panelists() == null ? List.of() : current.panelists(),
               current.assignedBlock(),
               current.assignedScenario(),
-              current.presentationAsset());
+              current.presentationAsset(),
+              current.published(),
+              current.presentationPublished());
       submissions.put(updated.id(), updated);
       persistSync();
       return updated;
@@ -686,7 +692,9 @@ public class CfpSubmissionService {
               normalized,
               current.assignedBlock(),
               current.assignedScenario(),
-              current.presentationAsset());
+              current.presentationAsset(),
+              current.published(),
+              current.presentationPublished());
       submissions.put(updated.id(), updated);
       persistSync();
       return updated;
@@ -759,7 +767,9 @@ public class CfpSubmissionService {
               current.panelists() == null ? List.of() : current.panelists(),
               current.assignedBlock(),
               current.assignedScenario(),
-              sanitized);
+              sanitized,
+              current.published(),
+              current.presentationPublished());
       submissions.put(updated.id(), updated);
       persistSync();
       return updated;
@@ -818,7 +828,9 @@ public class CfpSubmissionService {
               current.panelists() == null ? List.of() : current.panelists(),
               normalizedBlock,
               normalizedScenario,
-              current.presentationAsset());
+              current.presentationAsset(),
+              current.published(),
+              current.presentationPublished());
       submissions.put(updated.id(), updated);
       persistSync();
       return updated;
@@ -876,8 +888,100 @@ public class CfpSubmissionService {
               refreshed,
               current.assignedBlock(),
               current.assignedScenario(),
-              current.presentationAsset());
+              current.presentationAsset(),
+              current.published(),
+              current.presentationPublished());
       submissions.put(updated.id(), updated);
+      persistSync();
+      return updated;
+    }
+  }
+
+  public CfpSubmission updatePublished(String id, boolean published, String moderator) {
+    synchronized (submissionsLock) {
+      refreshFromDisk(false);
+      CfpSubmission current = findOrThrow(id);
+      if (current.published() != null && current.published() == published) {
+        return current;
+      }
+      Instant now = nextUpdatedAt(current);
+      CfpSubmission updated = new CfpSubmission(
+          current.id(),
+          current.eventId(),
+          current.proposerUserId(),
+          current.proposerName(),
+          current.title(),
+          current.summary(),
+          current.abstractText(),
+          current.level(),
+          current.format(),
+          current.durationMin(),
+          current.language(),
+          current.track(),
+          current.tags(),
+          current.links(),
+          current.status(),
+          current.createdAt(),
+          now,
+          current.moderatedAt(),
+          moderator,
+          current.moderationNote(),
+          current.ratingTechnicalDetail(),
+          current.ratingNarrative(),
+          current.ratingContentImpact(),
+          current.panelists(),
+          current.assignedBlock(),
+          current.assignedScenario(),
+          current.presentationAsset(),
+          published,
+          current.presentationPublished()
+      );
+      submissions.put(id, updated);
+      persistSync();
+      return updated;
+    }
+  }
+
+  public CfpSubmission updatePresentationPublished(String id, boolean published, String moderator) {
+    synchronized (submissionsLock) {
+      refreshFromDisk(false);
+      CfpSubmission current = findOrThrow(id);
+      if (current.presentationPublished() != null && current.presentationPublished() == published) {
+        return current;
+      }
+      Instant now = nextUpdatedAt(current);
+      CfpSubmission updated = new CfpSubmission(
+          current.id(),
+          current.eventId(),
+          current.proposerUserId(),
+          current.proposerName(),
+          current.title(),
+          current.summary(),
+          current.abstractText(),
+          current.level(),
+          current.format(),
+          current.durationMin(),
+          current.language(),
+          current.track(),
+          current.tags(),
+          current.links(),
+          current.status(),
+          current.createdAt(),
+          now,
+          current.moderatedAt(),
+          moderator,
+          current.moderationNote(),
+          current.ratingTechnicalDetail(),
+          current.ratingNarrative(),
+          current.ratingContentImpact(),
+          current.panelists(),
+          current.assignedBlock(),
+          current.assignedScenario(),
+          current.presentationAsset(),
+          current.published(),
+          published
+      );
+      submissions.put(id, updated);
       persistSync();
       return updated;
     }
@@ -1063,6 +1167,9 @@ public class CfpSubmissionService {
     CfpSubmissionStatus internal =
         submission.status() != null ? submission.status() : CfpSubmissionStatus.PENDING;
     if (internal == CfpSubmissionStatus.ACCEPTED || internal == CfpSubmissionStatus.REJECTED) {
+      if (Boolean.TRUE.equals(submission.published())) {
+        return internal;
+      }
       CfpEventConfigService.ResolvedEventConfig eventConfig =
           resolveEventConfig(submission.eventId());
       if (!eventConfig.resultsPublished()) {
@@ -1079,7 +1186,8 @@ public class CfpSubmissionService {
     CfpSubmissionStatus visibleStatus = visibleStatus(submission);
     CfpEventConfigService.ResolvedEventConfig eventConfig =
         resolveEventConfig(submission.eventId());
-    if (!eventConfig.resultsPublished()) {
+    boolean isPublished = Boolean.TRUE.equals(submission.published()) || eventConfig.resultsPublished();
+    if (!isPublished) {
       return null;
     }
     return switch (visibleStatus) {

--- a/quarkus-app/src/main/java/com/scanales/homedir/cfp/CfpSubmissionService.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/cfp/CfpSubmissionService.java
@@ -905,37 +905,37 @@ public class CfpSubmissionService {
         return current;
       }
       Instant now = nextUpdatedAt(current);
-      CfpSubmission updated = new CfpSubmission(
-          current.id(),
-          current.eventId(),
-          current.proposerUserId(),
-          current.proposerName(),
-          current.title(),
-          current.summary(),
-          current.abstractText(),
-          current.level(),
-          current.format(),
-          current.durationMin(),
-          current.language(),
-          current.track(),
-          current.tags(),
-          current.links(),
-          current.status(),
-          current.createdAt(),
-          now,
-          current.moderatedAt(),
-          moderator,
-          current.moderationNote(),
-          current.ratingTechnicalDetail(),
-          current.ratingNarrative(),
-          current.ratingContentImpact(),
-          current.panelists(),
-          current.assignedBlock(),
-          current.assignedScenario(),
-          current.presentationAsset(),
-          published,
-          current.presentationPublished()
-      );
+      CfpSubmission updated =
+          new CfpSubmission(
+              current.id(),
+              current.eventId(),
+              current.proposerUserId(),
+              current.proposerName(),
+              current.title(),
+              current.summary(),
+              current.abstractText(),
+              current.level(),
+              current.format(),
+              current.durationMin(),
+              current.language(),
+              current.track(),
+              current.tags(),
+              current.links(),
+              current.status(),
+              current.createdAt(),
+              now,
+              current.moderatedAt(),
+              moderator,
+              current.moderationNote(),
+              current.ratingTechnicalDetail(),
+              current.ratingNarrative(),
+              current.ratingContentImpact(),
+              current.panelists(),
+              current.assignedBlock(),
+              current.assignedScenario(),
+              current.presentationAsset(),
+              published,
+              current.presentationPublished());
       submissions.put(id, updated);
       persistSync();
       return updated;
@@ -950,37 +950,37 @@ public class CfpSubmissionService {
         return current;
       }
       Instant now = nextUpdatedAt(current);
-      CfpSubmission updated = new CfpSubmission(
-          current.id(),
-          current.eventId(),
-          current.proposerUserId(),
-          current.proposerName(),
-          current.title(),
-          current.summary(),
-          current.abstractText(),
-          current.level(),
-          current.format(),
-          current.durationMin(),
-          current.language(),
-          current.track(),
-          current.tags(),
-          current.links(),
-          current.status(),
-          current.createdAt(),
-          now,
-          current.moderatedAt(),
-          moderator,
-          current.moderationNote(),
-          current.ratingTechnicalDetail(),
-          current.ratingNarrative(),
-          current.ratingContentImpact(),
-          current.panelists(),
-          current.assignedBlock(),
-          current.assignedScenario(),
-          current.presentationAsset(),
-          current.published(),
-          published
-      );
+      CfpSubmission updated =
+          new CfpSubmission(
+              current.id(),
+              current.eventId(),
+              current.proposerUserId(),
+              current.proposerName(),
+              current.title(),
+              current.summary(),
+              current.abstractText(),
+              current.level(),
+              current.format(),
+              current.durationMin(),
+              current.language(),
+              current.track(),
+              current.tags(),
+              current.links(),
+              current.status(),
+              current.createdAt(),
+              now,
+              current.moderatedAt(),
+              moderator,
+              current.moderationNote(),
+              current.ratingTechnicalDetail(),
+              current.ratingNarrative(),
+              current.ratingContentImpact(),
+              current.panelists(),
+              current.assignedBlock(),
+              current.assignedScenario(),
+              current.presentationAsset(),
+              current.published(),
+              published);
       submissions.put(id, updated);
       persistSync();
       return updated;
@@ -1186,7 +1186,8 @@ public class CfpSubmissionService {
     CfpSubmissionStatus visibleStatus = visibleStatus(submission);
     CfpEventConfigService.ResolvedEventConfig eventConfig =
         resolveEventConfig(submission.eventId());
-    boolean isPublished = Boolean.TRUE.equals(submission.published()) || eventConfig.resultsPublished();
+    boolean isPublished =
+        Boolean.TRUE.equals(submission.published()) || eventConfig.resultsPublished();
     if (!isPublished) {
       return null;
     }
@@ -1307,15 +1308,13 @@ public class CfpSubmissionService {
       return true;
     }
     return switch (current) {
-      case PENDING ->
-          target == CfpSubmissionStatus.UNDER_REVIEW
-              || target == CfpSubmissionStatus.ACCEPTED
-              || target == CfpSubmissionStatus.REJECTED
-              || target == CfpSubmissionStatus.WITHDRAWN;
-      case UNDER_REVIEW ->
-          target == CfpSubmissionStatus.ACCEPTED
-              || target == CfpSubmissionStatus.REJECTED
-              || target == CfpSubmissionStatus.WITHDRAWN;
+      case PENDING -> target == CfpSubmissionStatus.UNDER_REVIEW
+          || target == CfpSubmissionStatus.ACCEPTED
+          || target == CfpSubmissionStatus.REJECTED
+          || target == CfpSubmissionStatus.WITHDRAWN;
+      case UNDER_REVIEW -> target == CfpSubmissionStatus.ACCEPTED
+          || target == CfpSubmissionStatus.REJECTED
+          || target == CfpSubmissionStatus.WITHDRAWN;
       case ACCEPTED -> target == CfpSubmissionStatus.UNDER_REVIEW;
       case REJECTED -> target == CfpSubmissionStatus.UNDER_REVIEW;
       case WITHDRAWN -> target == CfpSubmissionStatus.UNDER_REVIEW;

--- a/quarkus-app/src/main/java/com/scanales/homedir/cfp/CfpSubmissionService.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/cfp/CfpSubmissionService.java
@@ -1308,13 +1308,15 @@ public class CfpSubmissionService {
       return true;
     }
     return switch (current) {
-      case PENDING -> target == CfpSubmissionStatus.UNDER_REVIEW
-          || target == CfpSubmissionStatus.ACCEPTED
-          || target == CfpSubmissionStatus.REJECTED
-          || target == CfpSubmissionStatus.WITHDRAWN;
-      case UNDER_REVIEW -> target == CfpSubmissionStatus.ACCEPTED
-          || target == CfpSubmissionStatus.REJECTED
-          || target == CfpSubmissionStatus.WITHDRAWN;
+      case PENDING ->
+          target == CfpSubmissionStatus.UNDER_REVIEW
+              || target == CfpSubmissionStatus.ACCEPTED
+              || target == CfpSubmissionStatus.REJECTED
+              || target == CfpSubmissionStatus.WITHDRAWN;
+      case UNDER_REVIEW ->
+          target == CfpSubmissionStatus.ACCEPTED
+              || target == CfpSubmissionStatus.REJECTED
+              || target == CfpSubmissionStatus.WITHDRAWN;
       case ACCEPTED -> target == CfpSubmissionStatus.UNDER_REVIEW;
       case REJECTED -> target == CfpSubmissionStatus.UNDER_REVIEW;
       case WITHDRAWN -> target == CfpSubmissionStatus.UNDER_REVIEW;

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/ProfileResource.java
@@ -4,6 +4,8 @@ import com.scanales.homedir.cfp.CfpEventConfigService;
 import com.scanales.homedir.cfp.CfpSubmission;
 import com.scanales.homedir.cfp.CfpSubmissionService;
 import com.scanales.homedir.cfp.CfpSubmissionStatus;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import com.scanales.homedir.cfp.CfpTimelinePlanner;
 import com.scanales.homedir.cfp.CfpTimelineView;
 import com.scanales.homedir.challenges.ChallengeService;
@@ -238,6 +240,9 @@ public class ProfileResource {
   @Inject CfpSubmissionService cfpSubmissionService;
   @Inject CfpEventConfigService cfpEventConfigService;
   @Inject VolunteerApplicationService volunteerApplicationService;
+  @Inject com.scanales.homedir.service.SpeakerService speakerService;
+  @ConfigProperty(name = "homedir.data.dir", defaultValue = "data")
+  String dataDirPath;
   @Inject VolunteerEventConfigService volunteerEventConfigService;
   @Inject ChallengeService challengeService;
   @Inject ProfileReadinessService profileReadinessService;
@@ -253,6 +258,8 @@ public class ProfileResource {
       @jakarta.ws.rs.QueryParam("discordError") String discordError,
       @jakarta.ws.rs.QueryParam("speakerSaved") boolean speakerSaved,
       @jakarta.ws.rs.QueryParam("speakerError") String speakerError,
+      @jakarta.ws.rs.QueryParam("photoSaved") String photoSaved,
+      @jakarta.ws.rs.QueryParam("photoError") String photoError,
       @jakarta.ws.rs.QueryParam("linkGithub") boolean linkGithub,
       @jakarta.ws.rs.QueryParam("historyLimit") Integer historyLimitParam,
       @jakarta.ws.rs.CookieParam("QP_LOCALE") String localeCookie,
@@ -453,6 +460,9 @@ public class ProfileResource {
         .data("speakerActive", speakerActive)
         .data("speakerSaved", speakerSaved)
         .data("speakerError", speakerError)
+        .data("photoSaved", photoSaved)
+        .data("photoError", photoError)
+        .data("speakerPhoto", speakerService.getSpeaker(email) != null ? speakerService.getSpeaker(email).getPhotoUrl() : null)
         .data("selectionReadiness", selectionReadiness)
         .data("selectionLocked", selectionLocked)
         .data("volunteerOverview", volunteerOverview)
@@ -613,6 +623,7 @@ public class ProfileResource {
   @Authenticated
   @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   public Response updateSpeakerProfile(
+      @jakarta.ws.rs.FormParam("name") String name,
       @jakarta.ws.rs.FormParam("headline") String headline,
       @jakarta.ws.rs.FormParam("bio") String bio,
       @jakarta.ws.rs.FormParam("organization") String organization,
@@ -625,6 +636,18 @@ public class ProfileResource {
     if (!profile.hasActiveSpeakerProfile()) {
       return redirectWithStatus(target, "speakerError", "inactive");
     }
+    if (name != null && !name.isBlank()) {
+      profile.setName(name);
+      userProfiles.update(profile);
+      
+      com.scanales.homedir.model.Speaker sp = speakerService.getSpeaker(email);
+      if (sp == null) {
+        sp = new com.scanales.homedir.model.Speaker(email, name);
+      } else {
+        sp.setName(name);
+      }
+      speakerService.saveSpeaker(sp);
+    }
     java.util.List<String> topicList =
         topics == null
             ? java.util.List.of()
@@ -635,6 +658,64 @@ public class ProfileResource {
     userProfiles.updateSpeakerProfile(
         email, headline, bio, organization, website, linkedin, topicList);
     return redirectWithStatus(target, "speakerSaved", "1");
+  }
+
+  @POST
+  @Path("speaker/photo")
+  @Authenticated
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  public Response uploadSpeakerPhoto(
+      @jakarta.ws.rs.FormParam("file") FileUpload file) {
+    String email = getEmail();
+    String target = "/private/profile#speaker-panel";
+    var profile = userProfiles.upsert(email, getClaim("name"), email);
+    if (!profile.hasActiveSpeakerProfile()) {
+      return redirectWithStatus(target, "speakerError", "inactive");
+    }
+    if (file == null || file.fileName() == null || file.fileName().isBlank()) {
+      return redirectWithStatus(target, "photoError", "missing_file");
+    }
+    String contentType = file.contentType();
+    if (contentType == null || (!contentType.equals("image/png") && !contentType.equals("image/jpeg") && !contentType.equals("image/jpg"))) {
+      String lowerName = file.fileName().toLowerCase();
+      if (!lowerName.endsWith(".png") && !lowerName.endsWith(".jpg") && !lowerName.endsWith(".jpeg")) {
+        return redirectWithStatus(target, "photoError", "invalid_type");
+      }
+    }
+    long size = 0;
+    try {
+      size = java.nio.file.Files.size(file.uploadedFile());
+    } catch (java.io.IOException e) {
+      return redirectWithStatus(target, "photoError", "read_error");
+    }
+    if (size > 20 * 1024 * 1024) {
+      return redirectWithStatus(target, "photoError", "too_large");
+    }
+    String safeSpeakerId = email.replaceAll("[^a-zA-Z0-9_.-]", "_");
+    String extension = file.fileName().toLowerCase().endsWith(".png") ? ".png" : ".jpg";
+    String fileName = "avatar_" + safeSpeakerId + extension;
+    try {
+      java.nio.file.Path uploadsRoot = java.nio.file.Paths.get(dataDirPath).resolve("uploads").resolve("speakers").normalize();
+      java.nio.file.Files.createDirectories(uploadsRoot);
+      String[] extensions = {".png", ".jpg", ".jpeg"};
+      for (String ext : extensions) {
+        try {
+          java.nio.file.Files.deleteIfExists(uploadsRoot.resolve("avatar_" + safeSpeakerId + ext));
+        } catch (java.io.IOException ignored) {}
+      }
+      java.nio.file.Path targetFile = uploadsRoot.resolve(fileName);
+      java.nio.file.Files.copy(file.uploadedFile(), targetFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+      String photoUrl = "/speaker/" + email + "/photo";
+      com.scanales.homedir.model.Speaker sp = speakerService.getSpeaker(email);
+      if (sp == null) {
+        sp = new com.scanales.homedir.model.Speaker(email, profile.getName());
+      }
+      sp.setPhotoUrl(photoUrl);
+      speakerService.saveSpeaker(sp);
+      return redirectWithStatus(target, "photoSaved", "1");
+    } catch (java.io.IOException e) {
+      return redirectWithStatus(target, "photoError", "save_error");
+    }
   }
 
   @POST
@@ -1007,25 +1088,7 @@ public class ProfileResource {
   }
 
   private CfpSubmissionStatus privateStatus(CfpSubmission submission) {
-    if (submission == null || submission.status() == null) {
-      return CfpSubmissionStatus.PENDING;
-    }
-    CfpSubmissionStatus status = submission.status();
-    if (status == CfpSubmissionStatus.ACCEPTED) {
-      return CfpSubmissionStatus.ACCEPTED;
-    }
-    if (status == CfpSubmissionStatus.REJECTED) {
-      try {
-        CfpEventConfigService.ResolvedEventConfig eventConfig =
-            cfpEventConfigService.resolveForEvent(submission.eventId());
-        if (!eventConfig.resultsPublished()) {
-          return CfpSubmissionStatus.UNDER_REVIEW;
-        }
-      } catch (Exception e) {
-        return CfpSubmissionStatus.UNDER_REVIEW;
-      }
-    }
-    return status;
+    return cfpSubmissionService.visibleStatus(submission);
   }
 
   private String privateDeliveryStatus(CfpSubmission submission) {

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/ProfileResource.java
@@ -4,8 +4,6 @@ import com.scanales.homedir.cfp.CfpEventConfigService;
 import com.scanales.homedir.cfp.CfpSubmission;
 import com.scanales.homedir.cfp.CfpSubmissionService;
 import com.scanales.homedir.cfp.CfpSubmissionStatus;
-import org.jboss.resteasy.reactive.multipart.FileUpload;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import com.scanales.homedir.cfp.CfpTimelinePlanner;
 import com.scanales.homedir.cfp.CfpTimelineView;
 import com.scanales.homedir.challenges.ChallengeService;
@@ -64,6 +62,8 @@ import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.ResourceBundle;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
 
 @Path("/private/profile")
 public class ProfileResource {
@@ -241,8 +241,10 @@ public class ProfileResource {
   @Inject CfpEventConfigService cfpEventConfigService;
   @Inject VolunteerApplicationService volunteerApplicationService;
   @Inject com.scanales.homedir.service.SpeakerService speakerService;
+
   @ConfigProperty(name = "homedir.data.dir", defaultValue = "data")
   String dataDirPath;
+
   @Inject VolunteerEventConfigService volunteerEventConfigService;
   @Inject ChallengeService challengeService;
   @Inject ProfileReadinessService profileReadinessService;
@@ -462,7 +464,11 @@ public class ProfileResource {
         .data("speakerError", speakerError)
         .data("photoSaved", photoSaved)
         .data("photoError", photoError)
-        .data("speakerPhoto", speakerService.getSpeaker(email) != null ? speakerService.getSpeaker(email).getPhotoUrl() : null)
+        .data(
+            "speakerPhoto",
+            speakerService.getSpeaker(email) != null
+                ? speakerService.getSpeaker(email).getPhotoUrl()
+                : null)
         .data("selectionReadiness", selectionReadiness)
         .data("selectionLocked", selectionLocked)
         .data("volunteerOverview", volunteerOverview)
@@ -639,7 +645,7 @@ public class ProfileResource {
     if (name != null && !name.isBlank()) {
       profile.setName(name);
       userProfiles.update(profile);
-      
+
       com.scanales.homedir.model.Speaker sp = speakerService.getSpeaker(email);
       if (sp == null) {
         sp = new com.scanales.homedir.model.Speaker(email, name);
@@ -664,8 +670,7 @@ public class ProfileResource {
   @Path("speaker/photo")
   @Authenticated
   @Consumes(MediaType.MULTIPART_FORM_DATA)
-  public Response uploadSpeakerPhoto(
-      @jakarta.ws.rs.FormParam("file") FileUpload file) {
+  public Response uploadSpeakerPhoto(@jakarta.ws.rs.FormParam("file") FileUpload file) {
     String email = getEmail();
     String target = "/private/profile#speaker-panel";
     var profile = userProfiles.upsert(email, getClaim("name"), email);
@@ -676,9 +681,14 @@ public class ProfileResource {
       return redirectWithStatus(target, "photoError", "missing_file");
     }
     String contentType = file.contentType();
-    if (contentType == null || (!contentType.equals("image/png") && !contentType.equals("image/jpeg") && !contentType.equals("image/jpg"))) {
+    if (contentType == null
+        || (!contentType.equals("image/png")
+            && !contentType.equals("image/jpeg")
+            && !contentType.equals("image/jpg"))) {
       String lowerName = file.fileName().toLowerCase();
-      if (!lowerName.endsWith(".png") && !lowerName.endsWith(".jpg") && !lowerName.endsWith(".jpeg")) {
+      if (!lowerName.endsWith(".png")
+          && !lowerName.endsWith(".jpg")
+          && !lowerName.endsWith(".jpeg")) {
         return redirectWithStatus(target, "photoError", "invalid_type");
       }
     }
@@ -695,16 +705,19 @@ public class ProfileResource {
     String extension = file.fileName().toLowerCase().endsWith(".png") ? ".png" : ".jpg";
     String fileName = "avatar_" + safeSpeakerId + extension;
     try {
-      java.nio.file.Path uploadsRoot = java.nio.file.Paths.get(dataDirPath).resolve("uploads").resolve("speakers").normalize();
+      java.nio.file.Path uploadsRoot =
+          java.nio.file.Paths.get(dataDirPath).resolve("uploads").resolve("speakers").normalize();
       java.nio.file.Files.createDirectories(uploadsRoot);
       String[] extensions = {".png", ".jpg", ".jpeg"};
       for (String ext : extensions) {
         try {
           java.nio.file.Files.deleteIfExists(uploadsRoot.resolve("avatar_" + safeSpeakerId + ext));
-        } catch (java.io.IOException ignored) {}
+        } catch (java.io.IOException ignored) {
+        }
       }
       java.nio.file.Path targetFile = uploadsRoot.resolve(fileName);
-      java.nio.file.Files.copy(file.uploadedFile(), targetFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+      java.nio.file.Files.copy(
+          file.uploadedFile(), targetFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
       String photoUrl = "/speaker/" + email + "/photo";
       com.scanales.homedir.model.Speaker sp = speakerService.getSpeaker(email);
       if (sp == null) {

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/CfpSubmissionApiResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/CfpSubmissionApiResource.java
@@ -693,7 +693,8 @@ public class CfpSubmissionApiResource {
             .build();
       }
       CfpSubmission updated =
-          cfpSubmissionService.updatePublished(id, request.published(), currentUserId().orElse("admin"));
+          cfpSubmissionService.updatePublished(
+              id, request.published(), currentUserId().orElse("admin"));
       if (updated.status() == CfpSubmissionStatus.ACCEPTED && request.published()) {
         updated = safeRefreshPanelists(eventId, updated);
         applyAcceptedPublicationSideEffects(updated);
@@ -732,7 +733,8 @@ public class CfpSubmissionApiResource {
             .build();
       }
       CfpSubmission updated =
-          cfpSubmissionService.updatePresentationPublished(id, request.published(), currentUserId().orElse("admin"));
+          cfpSubmissionService.updatePresentationPublished(
+              id, request.published(), currentUserId().orElse("admin"));
       return Response.ok(new SubmissionResponse(toAdminView(updated))).build();
     } catch (CfpSubmissionService.NotFoundException e) {
       return Response.status(Response.Status.NOT_FOUND)
@@ -746,8 +748,7 @@ public class CfpSubmissionApiResource {
   @Authenticated
   @Consumes(MediaType.APPLICATION_JSON)
   public Response publishSlidesBulk(
-      @PathParam("eventId") String eventId,
-      BulkPublishRequest request) {
+      @PathParam("eventId") String eventId, BulkPublishRequest request) {
     if (!AdminUtils.isAdmin(identity)) {
       return Response.status(Response.Status.FORBIDDEN)
           .entity(Map.of("error", "admin_required"))
@@ -763,7 +764,8 @@ public class CfpSubmissionApiResource {
       for (String id : request.ids()) {
         Optional<CfpSubmission> existing = cfpSubmissionService.findById(id);
         if (existing.isPresent() && eventId.equals(existing.get().eventId())) {
-          cfpSubmissionService.updatePresentationPublished(id, request.published(), currentUserId().orElse("admin"));
+          cfpSubmissionService.updatePresentationPublished(
+              id, request.published(), currentUserId().orElse("admin"));
           count++;
         }
       }
@@ -779,8 +781,7 @@ public class CfpSubmissionApiResource {
   @Path("/{id}/presentation")
   @Authenticated
   public Response downloadPresentation(
-      @PathParam("eventId") String eventId,
-      @PathParam("id") String id) {
+      @PathParam("eventId") String eventId, @PathParam("id") String id) {
     Set<String> userIds = currentUserIds();
     if (userIds.isEmpty()) {
       return Response.status(Response.Status.UNAUTHORIZED).build();
@@ -1906,8 +1907,7 @@ public class CfpSubmissionApiResource {
   public record UpdatePublishedRequest(@JsonProperty("published") Boolean published) {}
 
   public record BulkPublishRequest(
-      @JsonProperty("ids") List<String> ids,
-      @JsonProperty("published") Boolean published) {}
+      @JsonProperty("ids") List<String> ids, @JsonProperty("published") Boolean published) {}
 
   public record SubmissionLimitConfigResponse(
       @JsonProperty("max_per_user") int maxPerUser,

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/CfpSubmissionApiResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/CfpSubmissionApiResource.java
@@ -640,7 +640,7 @@ public class CfpSubmissionApiResource {
       metrics.recordFunnelStep("cfp.submission.status");
       metrics.recordFunnelStep("cfp.submission.status." + status.get().apiValue());
       if (status.get() == CfpSubmissionStatus.ACCEPTED
-          && cfpSubmissionService.areResultsPublished(eventId)) {
+          && Boolean.TRUE.equals(updated.published())) {
         updated = safeRefreshPanelists(eventId, updated);
         applyAcceptedPublicationSideEffects(updated);
       }
@@ -665,6 +665,155 @@ public class CfpSubmissionApiResource {
           .entity(Map.of("error", "cfp_storage_unavailable", "detail", storageDetail(e)))
           .build();
     }
+  }
+
+  @PUT
+  @Path("/{id}/publish")
+  @Authenticated
+  @Consumes(MediaType.APPLICATION_JSON)
+  public Response updatePublished(
+      @PathParam("eventId") String eventId,
+      @PathParam("id") String id,
+      UpdatePublishedRequest request) {
+    if (!AdminUtils.isAdmin(identity)) {
+      return Response.status(Response.Status.FORBIDDEN)
+          .entity(Map.of("error", "admin_required"))
+          .build();
+    }
+    if (request == null || request.published() == null) {
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity(Map.of("error", "published_required"))
+          .build();
+    }
+    try {
+      Optional<CfpSubmission> existing = cfpSubmissionService.findById(id);
+      if (existing.isEmpty() || !eventId.equals(existing.get().eventId())) {
+        return Response.status(Response.Status.NOT_FOUND)
+            .entity(Map.of("error", "submission_not_found"))
+            .build();
+      }
+      CfpSubmission updated =
+          cfpSubmissionService.updatePublished(id, request.published(), currentUserId().orElse("admin"));
+      if (updated.status() == CfpSubmissionStatus.ACCEPTED && request.published()) {
+        updated = safeRefreshPanelists(eventId, updated);
+        applyAcceptedPublicationSideEffects(updated);
+      }
+      return Response.ok(new SubmissionResponse(toAdminView(updated))).build();
+    } catch (CfpSubmissionService.NotFoundException e) {
+      return Response.status(Response.Status.NOT_FOUND)
+          .entity(Map.of("error", e.getMessage()))
+          .build();
+    }
+  }
+
+  @PUT
+  @Path("/{id}/presentation/publish")
+  @Authenticated
+  @Consumes(MediaType.APPLICATION_JSON)
+  public Response updatePresentationPublished(
+      @PathParam("eventId") String eventId,
+      @PathParam("id") String id,
+      UpdatePublishedRequest request) {
+    if (!AdminUtils.isAdmin(identity)) {
+      return Response.status(Response.Status.FORBIDDEN)
+          .entity(Map.of("error", "admin_required"))
+          .build();
+    }
+    if (request == null || request.published() == null) {
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity(Map.of("error", "published_required"))
+          .build();
+    }
+    try {
+      Optional<CfpSubmission> existing = cfpSubmissionService.findById(id);
+      if (existing.isEmpty() || !eventId.equals(existing.get().eventId())) {
+        return Response.status(Response.Status.NOT_FOUND)
+            .entity(Map.of("error", "submission_not_found"))
+            .build();
+      }
+      CfpSubmission updated =
+          cfpSubmissionService.updatePresentationPublished(id, request.published(), currentUserId().orElse("admin"));
+      return Response.ok(new SubmissionResponse(toAdminView(updated))).build();
+    } catch (CfpSubmissionService.NotFoundException e) {
+      return Response.status(Response.Status.NOT_FOUND)
+          .entity(Map.of("error", e.getMessage()))
+          .build();
+    }
+  }
+
+  @PUT
+  @Path("/presentation/publish-bulk")
+  @Authenticated
+  @Consumes(MediaType.APPLICATION_JSON)
+  public Response publishSlidesBulk(
+      @PathParam("eventId") String eventId,
+      BulkPublishRequest request) {
+    if (!AdminUtils.isAdmin(identity)) {
+      return Response.status(Response.Status.FORBIDDEN)
+          .entity(Map.of("error", "admin_required"))
+          .build();
+    }
+    if (request == null || request.ids() == null || request.published() == null) {
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity(Map.of("error", "ids_and_published_required"))
+          .build();
+    }
+    try {
+      int count = 0;
+      for (String id : request.ids()) {
+        Optional<CfpSubmission> existing = cfpSubmissionService.findById(id);
+        if (existing.isPresent() && eventId.equals(existing.get().eventId())) {
+          cfpSubmissionService.updatePresentationPublished(id, request.published(), currentUserId().orElse("admin"));
+          count++;
+        }
+      }
+      return Response.ok(Map.of("status", "success", "count", count)).build();
+    } catch (Exception e) {
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity(Map.of("error", e.getMessage()))
+          .build();
+    }
+  }
+
+  @GET
+  @Path("/{id}/presentation")
+  @Authenticated
+  public Response downloadPresentation(
+      @PathParam("eventId") String eventId,
+      @PathParam("id") String id) {
+    Set<String> userIds = currentUserIds();
+    if (userIds.isEmpty()) {
+      return Response.status(Response.Status.UNAUTHORIZED).build();
+    }
+    Optional<CfpSubmission> existing = cfpSubmissionService.findById(id);
+    if (existing.isEmpty() || !eventId.equals(existing.get().eventId())) {
+      return Response.status(Response.Status.NOT_FOUND).build();
+    }
+    boolean admin = AdminUtils.isAdmin(identity);
+    boolean owner = containsUserId(userIds, existing.get().proposerUserId());
+    boolean panelist =
+        existing.get().panelists() != null
+            && existing.get().panelists().stream()
+                .anyMatch(item -> item != null && containsUserId(userIds, item.userId()));
+    if (!admin && !owner && !panelist) {
+      return Response.status(Response.Status.FORBIDDEN).build();
+    }
+    CfpPresentationAsset asset = existing.get().presentationAsset();
+    if (asset == null || asset.storagePath() == null) {
+      return Response.status(Response.Status.NOT_FOUND)
+          .entity(Map.of("error", "presentation_not_uploaded"))
+          .build();
+    }
+    java.nio.file.Path filePath = java.nio.file.Paths.get(asset.storagePath());
+    if (!java.nio.file.Files.exists(filePath)) {
+      return Response.status(Response.Status.NOT_FOUND)
+          .entity(Map.of("error", "presentation_file_missing"))
+          .build();
+    }
+    return Response.ok(filePath.toFile())
+        .header("Content-Disposition", "attachment; filename=\"" + asset.fileName() + "\"")
+        .type(asset.contentType())
+        .build();
   }
 
   @PUT
@@ -1077,7 +1226,9 @@ public class CfpSubmissionApiResource {
         resultsPublishedAt,
         resultMessage,
         viewerRole,
-        canEdit);
+        canEdit,
+        submission.published() != null && submission.published(),
+        submission.presentationPublished() != null && submission.presentationPublished());
   }
 
   private static String resolveViewerRole(CfpSubmission submission, Set<String> viewerUserIds) {
@@ -1752,6 +1903,12 @@ public class CfpSubmissionApiResource {
       int errors,
       @JsonProperty("error_details") List<String> errorDetails) {}
 
+  public record UpdatePublishedRequest(@JsonProperty("published") Boolean published) {}
+
+  public record BulkPublishRequest(
+      @JsonProperty("ids") List<String> ids,
+      @JsonProperty("published") Boolean published) {}
+
   public record SubmissionLimitConfigResponse(
       @JsonProperty("max_per_user") int maxPerUser,
       @JsonProperty("min_allowed") int minAllowed,
@@ -1802,7 +1959,9 @@ public class CfpSubmissionApiResource {
       @JsonProperty("results_published_at") Instant resultsPublishedAt,
       @JsonProperty("result_message") String resultMessage,
       @JsonProperty("viewer_role") String viewerRole,
-      @JsonProperty("can_edit") boolean canEdit) {}
+      @JsonProperty("can_edit") boolean canEdit,
+      @JsonProperty("published") Boolean published,
+      @JsonProperty("presentation_published") Boolean presentationPublished) {}
 
   public record PanelistView(
       String id,

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/EventTalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/EventTalkResource.java
@@ -8,6 +8,8 @@ import com.scanales.homedir.service.UsageMetricsService;
 import com.scanales.homedir.service.UserScheduleService;
 import com.scanales.homedir.util.AdminUtils;
 import com.scanales.homedir.util.TemplateLocaleUtil;
+import com.scanales.homedir.cfp.CfpSubmission;
+import com.scanales.homedir.cfp.CfpSubmissionService;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
@@ -27,6 +29,7 @@ public class EventTalkResource {
   private static final Logger LOG = Logger.getLogger(EventTalkResource.class);
 
   @Inject EventService eventService;
+  @Inject CfpSubmissionService cfpSubmissionService;
   @Inject SecurityIdentity identity;
   @Inject UserScheduleService userSchedule;
   @Inject UsageMetricsService metrics;
@@ -93,9 +96,18 @@ public class EventTalkResource {
           inSchedule = userSchedule.getTalksForUser(email).contains(resolvedTalkId);
         }
       }
+      boolean slidesAvailable = false;
+      String slidesUrl = null;
+      String submissionId = resolvedTalkId.startsWith("talk-") ? resolvedTalkId.substring(5) : resolvedTalkId;
+      Optional<CfpSubmission> submission = cfpSubmissionService.findById(submissionId);
+      if (submission.isPresent() && submission.get().presentationAsset() != null && Boolean.TRUE.equals(submission.get().presentationPublished())) {
+        slidesAvailable = true;
+        slidesUrl = "/talk/" + resolvedTalkId + "/slides";
+      }
+
       return Response.ok(
               TemplateLocaleUtil.apply(
-                  TalkResource.Templates.detail(talk, event, occurrences, inSchedule),
+                  TalkResource.Templates.detail(talk, event, occurrences, inSchedule, slidesAvailable, slidesUrl),
                   localeCookie))
           .build();
     } catch (Exception e) {

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/EventTalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/EventTalkResource.java
@@ -1,5 +1,7 @@
 package com.scanales.homedir.public_;
 
+import com.scanales.homedir.cfp.CfpSubmission;
+import com.scanales.homedir.cfp.CfpSubmissionService;
 import com.scanales.homedir.model.GamificationActivity;
 import com.scanales.homedir.model.Talk;
 import com.scanales.homedir.service.EventService;
@@ -8,8 +10,6 @@ import com.scanales.homedir.service.UsageMetricsService;
 import com.scanales.homedir.service.UserScheduleService;
 import com.scanales.homedir.util.AdminUtils;
 import com.scanales.homedir.util.TemplateLocaleUtil;
-import com.scanales.homedir.cfp.CfpSubmission;
-import com.scanales.homedir.cfp.CfpSubmissionService;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
@@ -98,16 +98,20 @@ public class EventTalkResource {
       }
       boolean slidesAvailable = false;
       String slidesUrl = null;
-      String submissionId = resolvedTalkId.startsWith("talk-") ? resolvedTalkId.substring(5) : resolvedTalkId;
+      String submissionId =
+          resolvedTalkId.startsWith("talk-") ? resolvedTalkId.substring(5) : resolvedTalkId;
       Optional<CfpSubmission> submission = cfpSubmissionService.findById(submissionId);
-      if (submission.isPresent() && submission.get().presentationAsset() != null && Boolean.TRUE.equals(submission.get().presentationPublished())) {
+      if (submission.isPresent()
+          && submission.get().presentationAsset() != null
+          && Boolean.TRUE.equals(submission.get().presentationPublished())) {
         slidesAvailable = true;
         slidesUrl = "/talk/" + resolvedTalkId + "/slides";
       }
 
       return Response.ok(
               TemplateLocaleUtil.apply(
-                  TalkResource.Templates.detail(talk, event, occurrences, inSchedule, slidesAvailable, slidesUrl),
+                  TalkResource.Templates.detail(
+                      talk, event, occurrences, inSchedule, slidesAvailable, slidesUrl),
                   localeCookie))
           .build();
     } catch (Exception e) {

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/SpeakerResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/SpeakerResource.java
@@ -19,8 +19,45 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import jakarta.ws.rs.core.Response;
+
 @Path("/speaker")
 public class SpeakerResource {
+
+  @ConfigProperty(name = "homedir.data.dir", defaultValue = "data")
+  String dataDirPath;
+
+  @GET
+  @Path("/{id}/photo")
+  @PermitAll
+  public Response getSpeakerPhoto(@PathParam("id") String speakerId) {
+    if (speakerId == null) {
+      return Response.status(Response.Status.NOT_FOUND).build();
+    }
+    String safeSpeakerId = speakerId.replaceAll("[^a-zA-Z0-9_.-]", "_");
+    java.nio.file.Path uploadsRoot = java.nio.file.Paths.get(dataDirPath).resolve("uploads").resolve("speakers").normalize();
+    
+    // Check for PNG
+    java.nio.file.Path pngPath = uploadsRoot.resolve("avatar_" + safeSpeakerId + ".png");
+    if (java.nio.file.Files.exists(pngPath)) {
+      return Response.ok(pngPath.toFile()).type("image/png").build();
+    }
+    
+    // Check for JPG
+    java.nio.file.Path jpgPath = uploadsRoot.resolve("avatar_" + safeSpeakerId + ".jpg");
+    if (java.nio.file.Files.exists(jpgPath)) {
+      return Response.ok(jpgPath.toFile()).type("image/jpeg").build();
+    }
+    
+    // Check for JPEG
+    java.nio.file.Path jpegPath = uploadsRoot.resolve("avatar_" + safeSpeakerId + ".jpeg");
+    if (java.nio.file.Files.exists(jpegPath)) {
+      return Response.ok(jpegPath.toFile()).type("image/jpeg").build();
+    }
+    
+    return Response.status(Response.Status.NOT_FOUND).build();
+  }
 
   @CheckedTemplate
   static class Templates {

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/SpeakerResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/SpeakerResource.java
@@ -15,12 +15,11 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import jakarta.ws.rs.core.Response;
 
 @Path("/speaker")
 public class SpeakerResource {
@@ -36,26 +35,27 @@ public class SpeakerResource {
       return Response.status(Response.Status.NOT_FOUND).build();
     }
     String safeSpeakerId = speakerId.replaceAll("[^a-zA-Z0-9_.-]", "_");
-    java.nio.file.Path uploadsRoot = java.nio.file.Paths.get(dataDirPath).resolve("uploads").resolve("speakers").normalize();
-    
+    java.nio.file.Path uploadsRoot =
+        java.nio.file.Paths.get(dataDirPath).resolve("uploads").resolve("speakers").normalize();
+
     // Check for PNG
     java.nio.file.Path pngPath = uploadsRoot.resolve("avatar_" + safeSpeakerId + ".png");
     if (java.nio.file.Files.exists(pngPath)) {
       return Response.ok(pngPath.toFile()).type("image/png").build();
     }
-    
+
     // Check for JPG
     java.nio.file.Path jpgPath = uploadsRoot.resolve("avatar_" + safeSpeakerId + ".jpg");
     if (java.nio.file.Files.exists(jpgPath)) {
       return Response.ok(jpgPath.toFile()).type("image/jpeg").build();
     }
-    
+
     // Check for JPEG
     java.nio.file.Path jpegPath = uploadsRoot.resolve("avatar_" + safeSpeakerId + ".jpeg");
     if (java.nio.file.Files.exists(jpegPath)) {
       return Response.ok(jpegPath.toFile()).type("image/jpeg").build();
     }
-    
+
     return Response.status(Response.Status.NOT_FOUND).build();
   }
 

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/TalkResource.java
@@ -1,13 +1,13 @@
 package com.scanales.homedir.public_;
 
+import com.scanales.homedir.cfp.CfpSubmission;
+import com.scanales.homedir.cfp.CfpSubmissionService;
 import com.scanales.homedir.model.GamificationActivity;
 import com.scanales.homedir.model.Talk;
 import com.scanales.homedir.service.EventService;
 import com.scanales.homedir.service.GamificationService;
 import com.scanales.homedir.service.UsageMetricsService;
 import com.scanales.homedir.service.UserScheduleService;
-import com.scanales.homedir.cfp.CfpSubmission;
-import com.scanales.homedir.cfp.CfpSubmissionService;
 import com.scanales.homedir.util.AdminUtils;
 import com.scanales.homedir.util.TemplateLocaleUtil;
 import io.quarkus.qute.CheckedTemplate;
@@ -126,16 +126,21 @@ public class TalkResource {
       }
       boolean slidesAvailable = false;
       String slidesUrl = null;
-      String submissionId = resolvedTalkId.startsWith("talk-") ? resolvedTalkId.substring(5) : resolvedTalkId;
+      String submissionId =
+          resolvedTalkId.startsWith("talk-") ? resolvedTalkId.substring(5) : resolvedTalkId;
       Optional<CfpSubmission> submission = cfpSubmissionService.findById(submissionId);
-      if (submission.isPresent() && submission.get().presentationAsset() != null && Boolean.TRUE.equals(submission.get().presentationPublished())) {
+      if (submission.isPresent()
+          && submission.get().presentationAsset() != null
+          && Boolean.TRUE.equals(submission.get().presentationPublished())) {
         slidesAvailable = true;
         slidesUrl = "/talk/" + resolvedTalkId + "/slides";
       }
 
       return Response.ok(
               TemplateLocaleUtil.apply(
-                  Templates.detail(talk, event, occurrences, inSchedule, slidesAvailable, slidesUrl), localeCookie))
+                  Templates.detail(
+                      talk, event, occurrences, inSchedule, slidesAvailable, slidesUrl),
+                  localeCookie))
           .build();
     } catch (Exception e) {
       LOG.errorf(e, "Error rendering talk %s", id);
@@ -152,7 +157,9 @@ public class TalkResource {
     }
     String submissionId = talkId.startsWith("talk-") ? talkId.substring(5) : talkId;
     Optional<CfpSubmission> submission = cfpSubmissionService.findById(submissionId);
-    if (submission.isEmpty() || submission.get().presentationAsset() == null || !Boolean.TRUE.equals(submission.get().presentationPublished())) {
+    if (submission.isEmpty()
+        || submission.get().presentationAsset() == null
+        || !Boolean.TRUE.equals(submission.get().presentationPublished())) {
       return Response.status(Response.Status.NOT_FOUND).build();
     }
     var asset = submission.get().presentationAsset();

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/TalkResource.java
@@ -6,6 +6,8 @@ import com.scanales.homedir.service.EventService;
 import com.scanales.homedir.service.GamificationService;
 import com.scanales.homedir.service.UsageMetricsService;
 import com.scanales.homedir.service.UserScheduleService;
+import com.scanales.homedir.cfp.CfpSubmission;
+import com.scanales.homedir.cfp.CfpSubmissionService;
 import com.scanales.homedir.util.AdminUtils;
 import com.scanales.homedir.util.TemplateLocaleUtil;
 import io.quarkus.qute.CheckedTemplate;
@@ -34,7 +36,9 @@ public class TalkResource {
         Talk talk,
         com.scanales.homedir.model.Event event,
         java.util.List<Talk> occurrences,
-        boolean inSchedule);
+        boolean inSchedule,
+        boolean slidesAvailable,
+        String slidesUrl);
   }
 
   @Inject EventService eventService;
@@ -42,6 +46,8 @@ public class TalkResource {
   @Inject SecurityIdentity identity;
 
   @Inject UserScheduleService userSchedule;
+
+  @Inject CfpSubmissionService cfpSubmissionService;
 
   @Inject UsageMetricsService metrics;
 
@@ -118,14 +124,46 @@ public class TalkResource {
           inSchedule = userSchedule.getTalksForUser(email).contains(resolvedTalkId);
         }
       }
+      boolean slidesAvailable = false;
+      String slidesUrl = null;
+      String submissionId = resolvedTalkId.startsWith("talk-") ? resolvedTalkId.substring(5) : resolvedTalkId;
+      Optional<CfpSubmission> submission = cfpSubmissionService.findById(submissionId);
+      if (submission.isPresent() && submission.get().presentationAsset() != null && Boolean.TRUE.equals(submission.get().presentationPublished())) {
+        slidesAvailable = true;
+        slidesUrl = "/talk/" + resolvedTalkId + "/slides";
+      }
+
       return Response.ok(
               TemplateLocaleUtil.apply(
-                  Templates.detail(talk, event, occurrences, inSchedule), localeCookie))
+                  Templates.detail(talk, event, occurrences, inSchedule, slidesAvailable, slidesUrl), localeCookie))
           .build();
     } catch (Exception e) {
       LOG.errorf(e, "Error rendering talk %s", id);
       return Response.serverError().build();
     }
+  }
+
+  @GET
+  @Path("/talk/{id}/slides")
+  @PermitAll
+  public Response downloadSlides(@PathParam("id") String talkId) {
+    if (talkId == null) {
+      return Response.status(Response.Status.NOT_FOUND).build();
+    }
+    String submissionId = talkId.startsWith("talk-") ? talkId.substring(5) : talkId;
+    Optional<CfpSubmission> submission = cfpSubmissionService.findById(submissionId);
+    if (submission.isEmpty() || submission.get().presentationAsset() == null || !Boolean.TRUE.equals(submission.get().presentationPublished())) {
+      return Response.status(Response.Status.NOT_FOUND).build();
+    }
+    var asset = submission.get().presentationAsset();
+    java.nio.file.Path filePath = java.nio.file.Paths.get(asset.storagePath());
+    if (!java.nio.file.Files.exists(filePath)) {
+      return Response.status(Response.Status.NOT_FOUND).build();
+    }
+    return Response.ok(filePath.toFile())
+        .header("Content-Disposition", "attachment; filename=\"" + asset.fileName() + "\"")
+        .type(asset.contentType())
+        .build();
   }
 
   private Optional<String> currentUserId() {

--- a/quarkus-app/src/main/java/com/scanales/homedir/util/AppTemplateExtensions.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/util/AppTemplateExtensions.java
@@ -99,6 +99,9 @@ public class AppTemplateExtensions {
     if (url == null || url.isBlank()) {
       return false;
     }
+    if (url.startsWith("/")) {
+      return true;
+    }
     try {
       URI uri = new URI(url);
       String scheme = uri.getScheme();

--- a/quarkus-app/src/main/resources/templates/AdminEventCfpResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventCfpResource/detail.html
@@ -633,7 +633,9 @@
         ? '<p class="form-hint" style="margin-top: 0.35rem;"><strong>'
             + escapeHtml(i18n.presentationTitle)
             + ':</strong> '
-            + escapeHtml(i18n.presentationCurrent + " " + item.presentation_asset.file_name)
+            + '<a href="' + baseEndpoint + '/' + encodeURIComponent(item.id) + '/presentation" class="hd-link" target="_blank">'
+            + escapeHtml(item.presentation_asset.file_name)
+            + '</a>'
             + "</p>"
         : "";
 
@@ -689,6 +691,8 @@
           + buildMetaItem(i18n.language, item.language)
           + buildMetaItem(i18n.format, item.format)
           + buildMetaItem(i18n.duration, item.duration_min ? item.duration_min + " min" : null)
+          + buildMetaItem("Resultado publicado", item.published ? "Sí" : "No")
+          + buildMetaItem("Diapositivas publicadas", item.presentation_published ? "Sí" : "No")
           + '</div></div>'
           + '<div class="card cfp-detail-section"><h3>' + escapeHtml(i18n.summary) + '</h3>'
           + '<p class="cfp-detail-summary" style="margin-top: 0.65rem;">' + escapeHtml(item.summary || i18n.notAvailable) + '</p></div>'
@@ -856,6 +860,52 @@
             showFeedback(i18n.promoteSuccess + " " + payload.speaker_id + " / " + payload.talk_id, false, btn);
           } catch (error) {
             showFeedback(error.message || i18n.promoteError, true, btn);
+          } finally {
+            btn.disabled = false;
+          }
+        });
+      }
+
+      if (status === "accepted" || status === "rejected") {
+        const pubLabel = item.published ? "Revertir publicación resultado" : "Publicar resultado";
+        const pubClass = item.published ? "btn btn-warning" : "btn btn-success";
+        attachAction(pubLabel, pubClass, async (event) => {
+          const btn = event.currentTarget;
+          btn.disabled = true;
+          try {
+            const res = await fetch(baseEndpoint + "/" + encodeURIComponent(submissionId) + "/publish", {
+              method: "PUT",
+              headers: { "Content-Type": "application/json", Accept: "application/json" },
+              body: JSON.stringify({ published: !item.published })
+            });
+            if (!res.ok) throw new Error("Error al cambiar estado de publicación");
+            showFeedback("Publicación de resultado actualizada", false, btn);
+            await loadDetail();
+          } catch (error) {
+            showFeedback(error.message, true, btn);
+          } finally {
+            btn.disabled = false;
+          }
+        });
+      }
+
+      if (item.presentation_asset && item.presentation_asset.file_name) {
+        const slidesPubLabel = item.presentation_published ? "Ocultar diapositivas en agenda" : "Publicar diapositivas en agenda";
+        const slidesPubClass = item.presentation_published ? "btn btn-warning" : "btn btn-success";
+        attachAction(slidesPubLabel, slidesPubClass, async (event) => {
+          const btn = event.currentTarget;
+          btn.disabled = true;
+          try {
+            const res = await fetch(baseEndpoint + "/" + encodeURIComponent(submissionId) + "/presentation/publish", {
+              method: "PUT",
+              headers: { "Content-Type": "application/json", Accept: "application/json" },
+              body: JSON.stringify({ published: !item.presentation_published })
+            });
+            if (!res.ok) throw new Error("Error al cambiar estado de publicación de diapositivas");
+            showFeedback("Publicación de diapositivas actualizada", false, btn);
+            await loadDetail();
+          } catch (error) {
+            showFeedback(error.message, true, btn);
           } finally {
             btn.disabled = false;
           }

--- a/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
@@ -267,6 +267,15 @@
     </div>
   </div>
 
+  <div id="cfpBulkActionsBar" class="admin-shell-actions-bar" style="margin-bottom: 0.8rem; display: none; align-items: center; gap: 0.5rem; flex-wrap: wrap; background: rgba(0,0,0,0.05); padding: 0.5rem; border-radius: 4px;">
+    <button id="cfpSelectAllBtn" type="button" class="btn btn-secondary">Seleccionar Todos</button>
+    <button id="cfpDeselectAllBtn" type="button" class="btn btn-secondary">Deseleccionar Todos</button>
+    <span class="form-hint" id="cfpBulkSelectedCount">0 seleccionados</span>
+    <span style="flex-grow: 1;"></span>
+    <button id="cfpBulkPublishSlidesBtn" type="button" class="btn btn-success">Publicar diapositivas en agenda</button>
+    <button id="cfpBulkUnpublishSlidesBtn" type="button" class="btn btn-warning">Ocultar diapositivas de agenda</button>
+  </div>
+
   <div id="cfpQueueList"></div>
   </section>
 </div>
@@ -736,6 +745,23 @@
       title.textContent = item.title || i18n.untitled;
       top.appendChild(title);
 
+      if (canManage) {
+        const cbContainer = document.createElement("div");
+        cbContainer.style.display = "flex";
+        cbContainer.style.alignItems = "center";
+        cbContainer.style.marginRight = "0.6rem";
+        const cb = document.createElement("input");
+        cb.type = "checkbox";
+        cb.className = "cfp-bulk-checkbox";
+        cb.dataset.id = item.id;
+        cb.style.width = "18px";
+        cb.style.height = "18px";
+        cb.style.cursor = "pointer";
+        cb.addEventListener("change", updateBulkBarState);
+        cbContainer.appendChild(cb);
+        top.insertBefore(cbContainer, title);
+      }
+
       const chipWrap = document.createElement("div");
       chipWrap.style.display = "flex";
       chipWrap.style.alignItems = "center";
@@ -746,6 +772,40 @@
       chip.className = "cfp-status-chip cfp-status-chip--" + currentStatus;
       chip.textContent = statusLabel[currentStatus] || currentStatus;
       chipWrap.appendChild(chip);
+
+      if (item.published) {
+        const pubChip = document.createElement("span");
+        pubChip.className = "cfp-status-chip";
+        pubChip.textContent = "Resultado Publicado";
+        pubChip.style.background = "#2e7d32";
+        pubChip.style.color = "#fff";
+        chipWrap.appendChild(pubChip);
+      } else {
+        const pubChip = document.createElement("span");
+        pubChip.className = "cfp-status-chip";
+        pubChip.textContent = "Resultado Privado";
+        pubChip.style.background = "#757575";
+        pubChip.style.color = "#fff";
+        chipWrap.appendChild(pubChip);
+      }
+
+      if (item.presentation_asset && item.presentation_asset.file_name) {
+        if (item.presentation_published) {
+          const slidesChip = document.createElement("span");
+          slidesChip.className = "cfp-status-chip";
+          slidesChip.textContent = "Diapositivas Publicadas";
+          slidesChip.style.background = "#1565c0";
+          slidesChip.style.color = "#fff";
+          chipWrap.appendChild(slidesChip);
+        } else {
+          const slidesChip = document.createElement("span");
+          slidesChip.className = "cfp-status-chip";
+          slidesChip.textContent = "Diapositivas Ocultas";
+          slidesChip.style.background = "#757575";
+          slidesChip.style.color = "#fff";
+          chipWrap.appendChild(slidesChip);
+        }
+      }
 
       if (item.public_status && item.public_status !== currentStatus) {
         const publicChip = document.createElement("span");
@@ -907,9 +967,11 @@
         items.forEach((item) => {
           listEl.appendChild(buildSubmissionCard(item));
         });
+        updateBulkBarState();
         updateListPagination();
         loadStats();
       } catch (error) {
+        updateBulkBarState();
         if (requestSequence !== listRequestSequence) {
           return;
         }
@@ -1470,6 +1532,59 @@
         addReviewerFromInput();
       });
     }
+    function updateBulkBarState() {
+      const cbs = document.querySelectorAll(".cfp-bulk-checkbox");
+      const selected = Array.from(cbs).filter(cb => cb.checked);
+      const bar = document.getElementById("cfpBulkActionsBar");
+      const countLabel = document.getElementById("cfpBulkSelectedCount");
+      if (bar && countLabel) {
+        if (selected.length > 0) {
+          bar.style.display = "flex";
+          countLabel.textContent = selected.length + " seleccionados";
+        } else {
+          bar.style.display = "none";
+          countLabel.textContent = "0 seleccionados";
+        }
+      }
+    }
+
+    async function handleBulkPublish(publish) {
+      const cbs = document.querySelectorAll(".cfp-bulk-checkbox");
+      const ids = Array.from(cbs).filter(cb => cb.checked).map(cb => cb.dataset.id);
+      if (ids.length === 0) return;
+      
+      const btn = publish ? document.getElementById("cfpBulkPublishSlidesBtn") : document.getElementById("cfpBulkUnpublishSlidesBtn");
+      if (btn) btn.disabled = true;
+      try {
+        const response = await fetch(baseEndpoint + "/presentation/publish-bulk", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json", Accept: "application/json" },
+          body: JSON.stringify({ ids: ids, published: publish })
+        });
+        if (!response.ok) throw new Error("Error en la publicación en bloque");
+        const payload = await response.json();
+        showFeedback("Diapositivas actualizadas para " + payload.count + " propuestas", false, btn);
+        await loadList();
+      } catch (error) {
+        showFeedback(error.message, true, btn);
+      } finally {
+        if (btn) btn.disabled = false;
+      }
+    }
+
+    if (canManage) {
+      document.getElementById("cfpSelectAllBtn")?.addEventListener("click", () => {
+        document.querySelectorAll(".cfp-bulk-checkbox").forEach(cb => cb.checked = true);
+        updateBulkBarState();
+      });
+      document.getElementById("cfpDeselectAllBtn")?.addEventListener("click", () => {
+        document.querySelectorAll(".cfp-bulk-checkbox").forEach(cb => cb.checked = false);
+        updateBulkBarState();
+      });
+      document.getElementById("cfpBulkPublishSlidesBtn")?.addEventListener("click", () => handleBulkPublish(true));
+      document.getElementById("cfpBulkUnpublishSlidesBtn")?.addEventListener("click", () => handleBulkPublish(false));
+    }
+
     restoreModerationStateFromUrl();
     applyControlsFromState();
     const initialPanelId = (() => {

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -504,9 +504,38 @@
             {#if !speakerActive}
             <p class="hd-page-intro">{i18n:profile_speaker_locked_hint}</p>
             {#else}
+            <!-- Photo Upload Area -->
+            <div class="hd-integration-card" style="margin-bottom: 1.5rem; padding: 1rem; background: rgba(0,0,0,0.02); border-radius: 6px; border: 1px solid rgba(0,0,0,0.08);">
+                <h3>Foto de Perfil del Ponente</h3>
+                <div style="display: flex; align-items: center; gap: 1rem; margin-top: 0.8rem; flex-wrap: wrap;">
+                    <div style="width: 80px; height: 80px; border-radius: 50%; overflow: hidden; background: #eee; display: flex; align-items: center; justify-content: center; border: 2px solid var(--accent-color, #1e88e5);">
+                        {#if speakerPhoto}
+                            <img src="{speakerPhoto}" alt="Avatar" style="width: 100%; height: 100%; object-fit: cover;">
+                        {#else}
+                            <span style="font-size: 2rem; color: #aaa;">👤</span>
+                        {/if}
+                    </div>
+                    <form action="/private/profile/speaker/photo" method="POST" enctype="multipart/form-data" style="display: flex; flex-direction: column; gap: 0.4rem;">
+                        {#include fragments/csrf-token.html /}
+                        <input type="file" name="file" accept="image/png, image/jpeg, image/jpg" required style="font-size: 0.85rem;">
+                        <button type="submit" class="hd-btn hd-btn-secondary" style="font-size: 0.8rem; padding: 0.25rem 0.5rem; align-self: flex-start;">Subir Foto</button>
+                    </form>
+                </div>
+                {#if photoSaved}
+                    <div class="hd-alert hd-alert-success" style="margin-top: 0.5rem; padding: 0.4rem 0.8rem; font-size: 0.85rem;">Foto de perfil actualizada correctamente</div>
+                {/if}
+                {#if photoError??}
+                    <div class="hd-alert hd-alert-warning" style="margin-top: 0.5rem; padding: 0.4rem 0.8rem; font-size: 0.85rem;">Error al subir foto: {photoError}</div>
+                {/if}
+            </div>
+
             <form action="/private/profile/speaker" method="POST" class="hd-panel-actions" style="display: grid; gap: 0.8rem;">
                     {#include fragments/csrf-token.html /}
                 <input type="hidden" name="redirect" value="/private/profile#speaker-panel">
+                <div class="form-group">
+                    <label class="form-label" for="speakerName">Nombre Ponente</label>
+                    <input id="speakerName" name="name" class="form-input" required maxlength="120" value="{name}">
+                </div>
                 <div class="form-group">
                     <label class="form-label" for="speakerHeadline">{i18n:profile_speaker_headline}</label>
                     <input id="speakerHeadline" name="headline" class="form-input" maxlength="120" value="{#if speakerProfile != null}{speakerProfile.headline}{/if}">

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -73,6 +73,12 @@
         {#if talk.location && event}<span class="badge">{event.getScenarioName(talk.location)}</span>{/if}
         {#if talk.startTimeStr}<span class="badge">{talk.startTimeStr}</span>{#else}<span class="badge">{i18n:talk_tbd}</span>{/if}
         {#if talk.durationMinutes > 0}<span class="badge">{i18n:talk_duration_minutes(talk.durationMinutes)}</span>{/if}
+        {#if slidesAvailable}
+        <a href="{slidesUrl}" class="hd-btn hd-btn-primary" style="font-size: 0.8rem; padding: 0.25rem 0.5rem; text-decoration: none; display: inline-flex; align-items: center; gap: 0.35rem;" target="_blank">
+          <span class="material-symbols-outlined" style="font-size: 1rem;">download</span>
+          Descargar Diapositivas
+        </a>
+        {/if}
       </div>
 
       {#if talk.description}<p class="talk-description">{talk.description}</p>{/if}

--- a/quarkus-app/src/test/java/com/scanales/homedir/service/PersistenceServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/service/PersistenceServiceTest.java
@@ -649,7 +649,9 @@ public class PersistenceServiceTest {
         java.util.List.of(),
         null,
         null,
-        null);
+        null,
+        false,
+        false);
   }
 
   private boolean waitUntil(BooleanSupplier condition, Duration timeout)


### PR DESCRIPTION
Implementacion completa de la epica #1068: - Fase 1: Publicacion individual de resultados de CFP - Fase 2: Perfil de speaker y presentaciones (subida de slides, visualizacion y descarga, publicacion individual/masiva) - Fase 3: Imagen de perfil personalizada con subida, validacion y persistencia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added speaker photo upload and photo display on the private profile page.
  * Added talk slide downloads and visible slide availability on talk pages.
  * Added admin controls to publish/unpublish CFP results and presentation slides, including bulk slide publishing.
* **Bug Fixes**
  * Improved visibility rules so unpublished results and slides are hidden until marked public.
  * Added slide and photo file handling with safer validation and 404 behavior when files are unavailable.
* **Style**
  * Updated profile and admin pages to show clearer labels and status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->