### PR TITLE
fix(cfp): filter public accepted submissions by visibleStatus instead of status #1068

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/EventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/EventResource.java
@@ -188,10 +188,15 @@ public class EventResource {
     List<CfpSubmission> acceptedSubmissions = List.of();
     if (event != null && cfpSubmissionService != null) {
       acceptedSubmissions =
-          cfpSubmissionService.listByEventAll(
-              id,
-              Optional.of(CfpSubmissionStatus.ACCEPTED),
-              CfpSubmissionService.SortOrder.CREATED_DESC);
+          cfpSubmissionService
+              .listByEventAll(
+                  id,
+                  Optional.of(CfpSubmissionStatus.ACCEPTED),
+                  CfpSubmissionService.SortOrder.CREATED_DESC)
+              .stream()
+              .filter(
+                  item -> cfpSubmissionService.visibleStatus(item) == CfpSubmissionStatus.ACCEPTED)
+              .toList();
     }
     return withLayoutData(
         Templates.cfpSelected(event, acceptedSubmissions), "eventos", localeCookie, headers);
@@ -216,10 +221,15 @@ public class EventResource {
     List<CfpSubmission> selectedSubmissions = List.of();
     if (event != null && cfpSubmissionService != null) {
       selectedSubmissions =
-          cfpSubmissionService.listByEventAll(
-              id,
-              Optional.of(CfpSubmissionStatus.ACCEPTED),
-              CfpSubmissionService.SortOrder.UPDATED_DESC);
+          cfpSubmissionService
+              .listByEventAll(
+                  id,
+                  Optional.of(CfpSubmissionStatus.ACCEPTED),
+                  CfpSubmissionService.SortOrder.UPDATED_DESC)
+              .stream()
+              .filter(
+                  item -> cfpSubmissionService.visibleStatus(item) == CfpSubmissionStatus.ACCEPTED)
+              .toList();
     }
     return withLayoutData(
         Templates.cfpSelected(event, selectedSubmissions), "eventos", localeCookie, headers);


### PR DESCRIPTION
Filtra las propuestas en las vistas públicas de ponentes y aceptados usando visibleStatus en lugar de status directo, asegurando que las propuestas aceptadas pero no publicadas sigan permaneciendo ocultas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speaker and selected submission listings for event CFPs so only fully visible accepted submissions are shown.
  * Reduced cases where entries could appear in these lists before they were meant to be visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->