### PR TITLE
feat(profile): speaker custom photo toggle and reset options #1068

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/ProfileResource.java
@@ -467,8 +467,14 @@ public class ProfileResource {
         .data(
             "speakerPhoto",
             speakerService.getSpeaker(email) != null
+                    && speakerService.getSpeaker(email).getPhotoUrl() != null
                 ? speakerService.getSpeaker(email).getPhotoUrl()
-                : null)
+                : getClaim("picture"))
+        .data(
+            "hasCustomPhoto",
+            speakerService.getSpeaker(email) != null
+                && speakerService.getSpeaker(email).getPhotoUrl() != null
+                && speakerService.getSpeaker(email).getPhotoUrl().startsWith("/speaker/"))
         .data("selectionReadiness", selectionReadiness)
         .data("selectionLocked", selectionLocked)
         .data("volunteerOverview", volunteerOverview)
@@ -729,6 +735,34 @@ public class ProfileResource {
     } catch (java.io.IOException e) {
       return redirectWithStatus(target, "photoError", "save_error");
     }
+  }
+
+  @POST
+  @Path("speaker/photo/reset")
+  @Authenticated
+  public Response resetSpeakerPhoto() {
+    String email = getEmail();
+    String target = "/private/profile#speaker-panel";
+    var profile = userProfiles.upsert(email, getClaim("name"), email);
+    if (!profile.hasActiveSpeakerProfile()) {
+      return redirectWithStatus(target, "speakerError", "inactive");
+    }
+    String safeSpeakerId = email.replaceAll("[^a-zA-Z0-9_.-]", "_");
+    java.nio.file.Path uploadsRoot =
+        java.nio.file.Paths.get(dataDirPath).resolve("uploads").resolve("speakers").normalize();
+    String[] extensions = {".png", ".jpg", ".jpeg"};
+    for (String ext : extensions) {
+      try {
+        java.nio.file.Files.deleteIfExists(uploadsRoot.resolve("avatar_" + safeSpeakerId + ext));
+      } catch (java.io.IOException ignored) {
+      }
+    }
+    com.scanales.homedir.model.Speaker sp = speakerService.getSpeaker(email);
+    if (sp != null) {
+      sp.setPhotoUrl(getClaim("picture"));
+      speakerService.saveSpeaker(sp);
+    }
+    return redirectWithStatus(target, "photoSaved", "1");
   }
 
   @POST

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -507,18 +507,29 @@
             <!-- Photo Upload Area -->
             <div class="hd-integration-card" style="margin-bottom: 1.5rem; padding: 1rem; background: rgba(0,0,0,0.02); border-radius: 6px; border: 1px solid rgba(0,0,0,0.08);">
                 <h3>Foto de Perfil del Ponente</h3>
-                <div style="display: flex; align-items: center; gap: 1rem; margin-top: 0.8rem; flex-wrap: wrap;">
-                    <div style="width: 80px; height: 80px; border-radius: 50%; overflow: hidden; background: #eee; display: flex; align-items: center; justify-content: center; border: 2px solid var(--accent-color, #1e88e5);">
-                        {#if speakerPhoto}
-                            <img src="{speakerPhoto}" alt="Avatar" style="width: 100%; height: 100%; object-fit: cover;">
-                        {#else}
-                            <span style="font-size: 2rem; color: #aaa;">👤</span>
-                        {/if}
+                <div style="display: flex; align-items: flex-start; gap: 1.5rem; margin-top: 0.8rem; flex-wrap: wrap;">
+                    <div style="display: flex; flex-direction: column; align-items: center; gap: 0.5rem;">
+                        <div style="width: 80px; height: 80px; border-radius: 50%; overflow: hidden; background: #eee; display: flex; align-items: center; justify-content: center; border: 2px solid var(--accent-color, #1e88e5);">
+                            {#if speakerPhoto}
+                                <img src="{speakerPhoto}" alt="Avatar" style="width: 100%; height: 100%; object-fit: cover;">
+                            {#else}
+                                <span style="font-size: 2rem; color: #aaa;">👤</span>
+                            {/if}
+                        </div>
+                        <label style="font-size: 0.85rem; display: flex; align-items: center; gap: 0.4rem; cursor: pointer; color: white;">
+                            <input type="checkbox" id="useCustomPhotoCheck" {#if hasCustomPhoto}checked{/if}>
+                            Usar una foto distinta
+                        </label>
                     </div>
-                    <form action="/private/profile/speaker/photo" method="POST" enctype="multipart/form-data" style="display: flex; flex-direction: column; gap: 0.4rem;">
+                    
+                    <form id="customPhotoUploadForm" action="/private/profile/speaker/photo" method="POST" enctype="multipart/form-data" style="display: {#if hasCustomPhoto}flex{#else}none{/if}; flex-direction: column; gap: 0.4rem; margin-top: 0.5rem;">
                         {#include fragments/csrf-token.html /}
                         <input type="file" name="file" accept="image/png, image/jpeg, image/jpg" required style="font-size: 0.85rem;">
                         <button type="submit" class="hd-btn hd-btn-secondary" style="font-size: 0.8rem; padding: 0.25rem 0.5rem; align-self: flex-start;">Subir Foto</button>
+                    </form>
+                    
+                    <form id="resetPhotoForm" action="/private/profile/speaker/photo/reset" method="POST" style="display:none;">
+                        {#include fragments/csrf-token.html /}
                     </form>
                 </div>
                 {#if photoSaved}
@@ -528,6 +539,30 @@
                     <div class="hd-alert hd-alert-warning" style="margin-top: 0.5rem; padding: 0.4rem 0.8rem; font-size: 0.85rem;">Error al subir foto: {photoError}</div>
                 {/if}
             </div>
+
+            <script>
+                document.addEventListener("DOMContentLoaded", function() {
+                    const checkbox = document.getElementById('useCustomPhotoCheck');
+                    if (checkbox) {
+                        checkbox.addEventListener('change', function() {
+                            const hasCustom = {hasCustomPhoto};
+                            if (this.checked) {
+                                document.getElementById('customPhotoUploadForm').style.display = 'flex';
+                            } else {
+                                document.getElementById('customPhotoUploadForm').style.display = 'none';
+                                if (hasCustom) {
+                                    if (confirm("¿Estás seguro de que deseas volver a usar la foto predeterminada de tu cuenta de Google? Se eliminará la foto que subiste.")) {
+                                        document.getElementById('resetPhotoForm').submit();
+                                    } else {
+                                        this.checked = true;
+                                        document.getElementById('customPhotoUploadForm').style.display = 'flex';
+                                    }
+                                }
+                            }
+                        });
+                    }
+                });
+            </script>
 
             <form action="/private/profile/speaker" method="POST" class="hd-panel-actions" style="display: grid; gap: 0.8rem;">
                     {#include fragments/csrf-token.html /}


### PR DESCRIPTION
Agrega un checkbox 'Usar una foto distinta' en la sección de foto del ponente en su perfil privado. Al marcarlo se despliega el formulario de subida; al desmarcarlo (si tiene una foto subida), se solicita confirmación para borrarla del servidor y restablecer su foto de perfil a la de su cuenta de Google predeterminada mediante el nuevo endpoint /private/profile/speaker/photo/reset.