### PR TITLE
fix(sdlc): clean tracked PR labels after merge

### DIFF
--- a/platform/scripts/homedir-sdlc-worker.sh
+++ b/platform/scripts/homedir-sdlc-worker.sh
@@ -699,13 +699,32 @@ track_pr_event() {
 finalize_closed_tracked_pr() {
   local state_file="$1"
   local pr_json="$2"
-  local number pr_state pr_url merged_at merge_sha summary
+  local number pr_state pr_url merged_at merge_sha summary current_summary labels_json
 
   number="$(jq -r '.number // .pr_number' <<<"${pr_json}")"
   pr_state="$(jq -r '.state // ""' <<<"${pr_json}")"
   pr_url="$(jq -r '.url // ""' <<<"${pr_json}")"
   merged_at="$(jq -r '.mergedAt // ""' <<<"${pr_json}")"
   merge_sha="$(jq -r '.mergeCommit.oid // ""' <<<"${pr_json}")"
+  labels_json="$(jq -c '[.labels[].name]' <<<"${pr_json}")"
+
+  if [[ "${pr_state}" == "MERGED" ]]; then
+    summary="tracked PR merged"
+  else
+    summary="tracked PR closed without merge"
+  fi
+
+  current_summary="$(jq -r '.last_pr_state // ""' "${state_file}")"
+  if [[ "${current_summary}" == "${summary}" ]] \
+    && ! issue_has_label "${labels_json}" "${PR_TRACK_LABEL}" \
+    && ! issue_has_label "${labels_json}" "${PR_ASSIST_LABEL}" \
+    && ! issue_has_label "${labels_json}" "${WAITING_CHECKS_LABEL}" \
+    && ! issue_has_label "${labels_json}" "${FAILING_CHECKS_LABEL}" \
+    && ! issue_has_label "${labels_json}" "${UNDER_REVIEW_LABEL}" \
+    && ! issue_has_label "${labels_json}" "${COVERAGE_GAP_LABEL}" \
+    && ! issue_has_label "${labels_json}" "${APPROVED_LABEL}"; then
+    return 0
+  fi
 
   remove_label "${number}" "${PR_TRACK_LABEL}"
   remove_label "${number}" "${PR_ASSIST_LABEL}"
@@ -717,10 +736,8 @@ finalize_closed_tracked_pr() {
 
   if [[ "${pr_state}" == "MERGED" ]]; then
     add_label "${number}" "${MERGED_LABEL}"
-    summary="tracked PR merged"
     log "cleaned tracked PR #${number} after merge"
   else
-    summary="tracked PR closed without merge"
     log "cleaned tracked PR #${number} after close without merge"
   fi
 

--- a/platform/scripts/homedir-sdlc-worker.sh
+++ b/platform/scripts/homedir-sdlc-worker.sh
@@ -696,6 +696,51 @@ track_pr_event() {
   write_pr_state_from_payload "${payload_file}" "${reason}" "${force_ready}" || return 0
 }
 
+finalize_closed_tracked_pr() {
+  local state_file="$1"
+  local pr_json="$2"
+  local number pr_state pr_url merged_at merge_sha summary
+
+  number="$(jq -r '.number // .pr_number' <<<"${pr_json}")"
+  pr_state="$(jq -r '.state // ""' <<<"${pr_json}")"
+  pr_url="$(jq -r '.url // ""' <<<"${pr_json}")"
+  merged_at="$(jq -r '.mergedAt // ""' <<<"${pr_json}")"
+  merge_sha="$(jq -r '.mergeCommit.oid // ""' <<<"${pr_json}")"
+
+  remove_label "${number}" "${PR_TRACK_LABEL}"
+  remove_label "${number}" "${PR_ASSIST_LABEL}"
+  remove_label "${number}" "${WAITING_CHECKS_LABEL}"
+  remove_label "${number}" "${FAILING_CHECKS_LABEL}"
+  remove_label "${number}" "${UNDER_REVIEW_LABEL}"
+  remove_label "${number}" "${COVERAGE_GAP_LABEL}"
+  remove_label "${number}" "${APPROVED_LABEL}"
+
+  if [[ "${pr_state}" == "MERGED" ]]; then
+    add_label "${number}" "${MERGED_LABEL}"
+    summary="tracked PR merged"
+    log "cleaned tracked PR #${number} after merge"
+  else
+    summary="tracked PR closed without merge"
+    log "cleaned tracked PR #${number} after close without merge"
+  fi
+
+  jq \
+    --arg state "${pr_state}" \
+    --arg pr_url "${pr_url}" \
+    --arg merged_at "${merged_at}" \
+    --arg merge_sha "${merge_sha}" \
+    --arg summary "${summary}" \
+    --arg updated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '.state = $state
+      | .url = (if $pr_url == "" then .url else $pr_url end)
+      | .merged_at = (if $merged_at == "" then null else $merged_at end)
+      | .merge_sha = (if $merge_sha == "" then null else $merge_sha end)
+      | .last_pr_state = $summary
+      | .updated_at = $updated_at' \
+    "${state_file}" > "${state_file}.tmp"
+  mv -f "${state_file}.tmp" "${state_file}"
+}
+
 review_tracked_pr_state() {
   local state_file="$1"
   local force="${2:-false}"
@@ -711,7 +756,7 @@ review_tracked_pr_state() {
 
   pr_json="$(gh pr view "${number}" \
     --repo "${REPO}" \
-    --json number,title,body,state,isDraft,url,headRefName,headRefOid,reviewDecision,latestReviews,statusCheckRollup,labels \
+    --json number,title,body,state,isDraft,url,headRefName,headRefOid,reviewDecision,latestReviews,statusCheckRollup,labels,mergedAt,mergeCommit \
     2>/dev/null || true)"
   if [[ -z "${pr_json}" ]]; then
     return 0
@@ -719,6 +764,7 @@ review_tracked_pr_state() {
 
   pr_state="$(jq -r '.state // ""' <<<"${pr_json}")"
   if [[ "${pr_state}" != "OPEN" ]]; then
+    finalize_closed_tracked_pr "${state_file}" "${pr_json}"
     return 0
   fi
 
@@ -1395,6 +1441,7 @@ run_event_command() {
       ;;
     pr-closed)
       reconcile_merged_prs
+      reconcile_tracked_prs
       reconcile_legacy_closed_issues
       ;;
     *)

--- a/tests/test_sdlc_worker_prompt.py
+++ b/tests/test_sdlc_worker_prompt.py
@@ -68,6 +68,7 @@ def test_sdlc_worker_supports_event_driven_commands() -> None:
     assert "track_pr_event()" in worker
     assert "reconcile_tracked_prs()" in worker
     assert "run_event_command()" in worker
+    assert "finalize_closed_tracked_pr()" in worker
     for command in [
         "issue-opened",
         "issue-commented",
@@ -85,3 +86,14 @@ def test_initial_prompt_expands_issue_context() -> None:
     assert 'prompt="$(cat <<"EOF"' not in worker
     assert 'cat <<EOF\nContinue the autonomous SDLC remediation' in worker
     assert 'cat <<\'EOF\'\nContinue the autonomous SDLC remediation' not in worker
+
+
+def test_closed_tracked_prs_are_cleaned_after_merge_or_close() -> None:
+    worker = Path("platform/scripts/homedir-sdlc-worker.sh").read_text()
+
+    assert 'if [[ "${pr_state}" != "OPEN" ]]; then\n    finalize_closed_tracked_pr "${state_file}" "${pr_json}"' in worker
+    assert 'remove_label "${number}" "${PR_TRACK_LABEL}"' in worker
+    assert 'remove_label "${number}" "${WAITING_CHECKS_LABEL}"' in worker
+    assert 'remove_label "${number}" "${UNDER_REVIEW_LABEL}"' in worker
+    assert 'add_label "${number}" "${MERGED_LABEL}"' in worker
+    assert "reconcile_tracked_prs\n      reconcile_legacy_closed_issues" in worker

--- a/tests/test_sdlc_worker_prompt.py
+++ b/tests/test_sdlc_worker_prompt.py
@@ -96,4 +96,6 @@ def test_closed_tracked_prs_are_cleaned_after_merge_or_close() -> None:
     assert 'remove_label "${number}" "${WAITING_CHECKS_LABEL}"' in worker
     assert 'remove_label "${number}" "${UNDER_REVIEW_LABEL}"' in worker
     assert 'add_label "${number}" "${MERGED_LABEL}"' in worker
+    assert 'current_summary="$(jq -r \'.last_pr_state // ""\' "${state_file}")"' in worker
+    assert '&& ! issue_has_label "${labels_json}" "${PR_TRACK_LABEL}"' in worker
     assert "reconcile_tracked_prs\n      reconcile_legacy_closed_issues" in worker


### PR DESCRIPTION
## Summary
- clean temporary AI SDLC tracking labels when a tracked PR is closed or merged
- mark merged tracked PRs with the terminal \scc-merged\ label
- run tracked PR reconciliation on \pr-closed\ events
- persist terminal tracked PR state in the local state file

## Validation
- \ash -n platform/scripts/homedir-sdlc-worker.sh\`n- \python -m pytest tests/test_sdlc_worker_prompt.py\`n- Hotfix deployed on VPS and manual reconcile cleaned #1079 and #1080 from \i-sdlc-track\/\scc-waiting-checks\ to only \scc-merged\`n
## Notes
- Leaves unrelated local changes untouched: \PublicProfileResource.java\ and \AdminEventCfpResource/detail.html\.