### PR TITLE
fix(sdlc): improve coverage validation to recognize evidence-rich items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ data/
 
 # Personal work-in-progress notes
 .slim/
+
+# Temporary query/response files from agent sessions
+query_thread.json
+resolve_*.json

--- a/platform/scripts/homedir-sdlc-worker.sh
+++ b/platform/scripts/homedir-sdlc-worker.sh
@@ -944,7 +944,7 @@ else:
         r"line \d+",
         r"`[^`]+\.(ts|js|java|py|sh|yml|yaml|json|md|txt|example)`",  # File paths
         r"\u2192\s*\*\*",  # \u2192 **SATISFIED** pattern
-        r"None known\.",  # Explicit statement of no gaps
+        r"(?:known gaps?|uncovered)\s*:\s*none known\.",  # Explicit statement of no gaps, scoped to label
     ]
 
     for block in coverage_blocks:


### PR DESCRIPTION
## Summary
- Improve coverage validation logic to recognize evidence-rich items with sub-bullets
- Prevent redundant remediation cycles when PR body already contains detailed coverage

## Issue Coverage
- [x] Extract full coverage blocks including sub-bullets instead of just first line
- [x] Add evidence pattern matching (SATISFIED, Evidence:, file paths, line numbers, → **)
- [x] Accept generic headers if they contain specific evidence markers in sub-bullets
- [x] All existing tests pass

## Validation
```bash
bash -n platform/scripts/homedir-sdlc-worker.sh
python -m pytest tests/test_sdlc_worker_prompt.py
```
9 passed

## Why
Issue #1087 PR #1088 triggered 2 remediation cycles even though coverage was complete with detailed evidence.

SCC generates format like:
```markdown
- [x] Map concrete code changes to issue #1087: ...
  - Evidence: `platform/env.sdlc.example` line 37
- [x] Map each acceptance criterion, or explain why none applies.
  - Criterion 1: ... → **SATISFIED** (line 37: `# SCC agent...`)
  - Criterion 2: ... → **SATISFIED** (single line comment)
```

Previous logic only checked the first line of each checkbox, marked items as "generic boilerplate" because headers matched patterns like `r"^map concrete code changes to issue #[0-9]+:"`.

New logic:
1. Extracts full blocks including sub-bullets
2. Recognizes evidence indicators: `Evidence:`, `SATISFIED`, file paths, line numbers, `→ **`
3. Accepts items with generic headers IF they contain specific evidence markers

Result: No false-positive coverage gaps, remediation only runs when actually needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how issue coverage details are interpreted, so checklist entries with supporting sub-bullets are handled more accurately.
  * Reduced false reports of missing coverage by better distinguishing generic boilerplate from entries that include meaningful evidence.
  * Coverage gaps are now surfaced more reliably when items are unchecked, incomplete, or lack supporting details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->