### PR TITLE
docs(sdlc): document post-merge cleanup verification for AI SDLC

### DIFF
--- a/docs/en/development/autonomous-sdlc.md
+++ b/docs/en/development/autonomous-sdlc.md
@@ -276,6 +276,15 @@ wsl ssh -i /home/scanales/.ssh/id_ed25519 root@72.60.141.165 \
   'curl -fsS http://127.0.0.1:8080/q/health && podman ps --filter name=homedir'
 ```
 
+Post-merge cleanup verification:
+
+After an AI SDLC tracked PR is merged, the worker will remove transient labels (such as `ai-sdlc-track`, `scc-waiting-checks`, `scc-under-review`, and `scc-failing-checks`) and apply the expected terminal `scc-merged` label.
+This repeated reconciliation process is idempotent. Operators can verify the final state and labels of a merged PR by running:
+
+```bash
+gh pr view <number> --json state,labels
+```
+
 Canary test:
 
 The SCC v0.4.0 canary validates that the autonomous worker:


### PR DESCRIPTION
## Summary
Adds a small runbook note documenting the AI SDLC post-merge cleanup behavior for tracked PRs.

## Why
After PRs are merged, the worker removes transient labels and leaves the terminal `scc-merged` label. This makes the expected state discoverable in the operational runbook so recovery and validation are easy.

## Issue Coverage
- [x] Document how to verify post-merge cleanup for an AI SDLC tracked PR.
- [x] Mention expected terminal label/state after merge (`scc-merged`).
- [x] Mention that repeated reconciliation should be idempotent.
- [x] Keep the change small and safe for an end-to-end AI SDLC canary.

Resolves #1084