### PR TITLE
chore(sdlc): implement issue #1113

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Homedir
 > **DevRel, OpenSource, InnerSource Community Platform**
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=for-the-badge&logo=apache&logoColor=white)](LICENSE)
 [![PR Validation](https://img.shields.io/github/actions/workflow/status/os-santiago/homedir/pr-check.yml?style=for-the-badge&label=PR%20Validation&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/actions/workflows/pr-check.yml)
 [![Version](https://img.shields.io/github/v/release/os-santiago/homedir?label=Version&style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/releases)


### PR DESCRIPTION
## Summary

Autonomous SCC implementation for issue #1113: [auto-split 1/3] Add documentation badges to README

## Validation

Worker validation command not configured; GitHub checks are required before approval.

## Issue Coverage

- [x] Map concrete code changes to issue #1113: [auto-split 1/3] Add documentation badges to README
  - Added MIT license badge to README.md (line 4 in diff)
- [x] Map each acceptance criterion, or explain why none applies.
  - ✅ **Acceptance Criterion: Add MIT license badge to README** - IMPLEMENTED
  - Added badge: `[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)`
- [x] List any known uncovered requirement, or state that none is known with evidence.
  - No uncovered requirements. The acceptance criterion "Add MIT license badge to README" has been fully implemented.

## Governance

- Branch protection, required checks, required reviews, and repository rules still apply.
- No admin bypass was used.

Refs #1113