### PR TITLE
chore(sdlc): implement issue #1121

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Version](https://img.shields.io/github/v/release/os-santiago/homedir?label=Version&style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/releases)
 [![Maven Version](https://img.shields.io/badge/version-3.403.1-blue?style=for-the-badge&logo=apache-maven&logoColor=white)](https://github.com/os-santiago/homedir/releases)
 [![Discord](https://img.shields.io/badge/Discord-Join%20the%20chat-5865F2?logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/3eawzc9ybc)
+[![Project Status: Active](https://img.shields.io/badge/status-active-brightgreen?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir)
 
 <p align="center">
   <a href="https://coderabbit.ai" target="_blank">


### PR DESCRIPTION
## Summary

Autonomous SCC implementation for issue #1121: [e2e-1/5] Add project status badge to README

## Validation

Worker validation command not configured; GitHub checks are required before approval.

## Issue Coverage

- [x] **Map concrete code changes to issue #1121: [e2e-1/5] Add project status badge to README**
  - **Evidence**: Added project status badge to README.md header (line 10 in diff): `[![Project Status: Active](https://img.shields.io/badge/status-active-brightgreen?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir)`
  - **File changed**: `README.md` (+1 line added to badge section)

- [x] **Map each acceptance criterion from issue #1121**
  - **Issue Acceptance Criterion**: `- [ ] Add project status badge to README header` ✅ **COVERED**
  - **Evidence**: Badge added to README header badge section alongside existing badges (Version, Maven Version, Discord) — see diff: `README.md` +1 line

- [x] **List any known uncovered requirement, or state that none is known with evidence**
  - **Status**: No uncovered requirements known.
  - **Evidence**: Issue #1121 has a single acceptance criterion "Add project status badge to README header" which is fully implemented in the PR diff (README.md +1 line).

## Governance

- Branch protection, required checks, required reviews, and repository rules still apply.
- No admin bypass was used.

Refs #1121