### PR TITLE
chore(sdlc): implement issue #1123

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=for-the-badge&logo=apache&logoColor=white)](LICENSE)
+[![Contributors](https://img.shields.io/github/contributors/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/graphs/contributors)
 [![PR Validation](https://img.shields.io/github/actions/workflow/status/os-santiago/homedir/pr-check.yml?style=for-the-badge&label=PR%20Validation&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/actions/workflows/pr-check.yml)
 [![Version](https://img.shields.io/github/v/release/os-santiago/homedir?label=Version&style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/releases)
 [![Maven Version](https://img.shields.io/badge/version-3.403.1-blue?style=for-the-badge&logo=apache-maven&logoColor=white)](https://github.com/os-santiago/homedir/releases)


### PR DESCRIPTION
## Summary

Autonomous SCC implementation for issue #1123: [e2e-2/5] Add contributors badge to README

## Validation

Worker validation command not configured; GitHub checks are required before approval.

## Issue Coverage

- [x] Map concrete code changes to issue #1123: [e2e-2/5] Add contributors badge to README
  - **Evidence**: Added contributors badge to README.md header badges section (line 5 in diff)
  - **Change**: Added `[![Contributors](https://img.shields.io/github/contributors/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/graphs/contributors)` badge to README.md header

- [x] Map each acceptance criterion, or explain why none applies.
  - **Acceptance Criterion**: "Add contributors badge to README header"
  - **Evidence**: Badge added to README.md header badges section (line 5 in diff), displaying GitHub contributors count with GitHub logo, linking to contributors graph

- [x] List any known uncovered requirement, or state that none is known with evidence.
  - **Status**: No uncovered requirements. The single acceptance criterion "Add contributors badge to README header" is fully implemented and verified in the diff.

## Governance

- Branch protection, required checks, required reviews, and repository rules still apply.
- No admin bypass was used.

Refs #1123