### PR TITLE
chore(sdlc): implement issue #1125

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=for-the-badge&logo=apache&logoColor=white)](LICENSE)
 [![Contributors](https://img.shields.io/github/contributors/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/graphs/contributors)
 [![PR Validation](https://img.shields.io/github/actions/workflow/status/os-santiago/homedir/pr-check.yml?style=for-the-badge&label=PR%20Validation&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/actions/workflows/pr-check.yml)
+[![Last Commit](https://img.shields.io/github/last-commit/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/commits/main)
 [![Version](https://img.shields.io/github/v/release/os-santiago/homedir?label=Version&style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/releases)
 [![Maven Version](https://img.shields.io/badge/version-3.403.1-blue?style=for-the-badge&logo=apache-maven&logoColor=white)](https://github.com/os-santiago/homedir/releases)
 [![Discord](https://img.shields.io/badge/Discord-Join%20the%20chat-5865F2?logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/3eawzc9ybc)


### PR DESCRIPTION
## Summary

Autonomous SCC implementation for issue #1125: [e2e-3/5] Add last commit badge to README

## Validation

Worker validation command not configured; GitHub checks are required before approval.

## Issue Coverage

- [x] Map concrete code changes to issue #1125: [e2e-3/5] Add last commit badge to README
  - **Evidence**: Added `[![Last Commit](https://img.shields.io/github/last-commit/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/commits/main)` badge to README.md header (see diff in PR)
- [x] Map each acceptance criterion, or explain why none applies.
  - **Acceptance Criterion**: "Add last commit badge to README header"
  - **Evidence**: Badge added to README header badge row, displaying last commit timestamp with GitHub logo, linking to commits page
- [x] List any known uncovered requirement, or state that none is known with evidence.
  - **Status**: No uncovered requirements. The single acceptance criterion is fully satisfied by the badge addition in README.md header.

## Governance

- Branch protection, required checks, required reviews, and repository rules still apply.
- No admin bypass was used.

Refs #1125