### PR TITLE
chore(sdlc): implement issue #1127

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Version](https://img.shields.io/github/v/release/os-santiago/homedir?label=Version&style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/releases)
 [![Maven Version](https://img.shields.io/badge/version-3.403.1-blue?style=for-the-badge&logo=apache-maven&logoColor=white)](https://github.com/os-santiago/homedir/releases)
 [![Discord](https://img.shields.io/badge/Discord-Join%20the%20chat-5865F2?logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/3eawzc9ybc)
+[![Repo Size](https://img.shields.io/github/repo-size/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir)
 [![Project Status: Active](https://img.shields.io/badge/status-active-brightgreen?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir)
 
 <p align="center">


### PR DESCRIPTION
## Summary

Autonomous SCC implementation for issue #1127: [e2e-4/5] Add repo size badge to README

## Validation

Worker validation command not configured; GitHub checks are required before approval.

## Issue Coverage

- [x] **Map concrete code changes to issue #1127: [e2e-4/5] Add repo size badge to README**  
  **Evidence**: Added repo size badge to README.md header badge row (line 8 in README.md):  
  ```markdown
  [![Repo Size](https://img.shields.io/github/repo-size/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir)
  ```

- [x] **Map each acceptance criterion, or explain why none applies**  
  **Evidence**: Issue #1127 has a single acceptance criterion: "Add repo size badge to README header" — **IMPLEMENTED** as shown above. The badge uses GitHub's repo-size badge from shields.io with the for-the-badge style matching other badges in the header.

- [x] **List any known uncovered requirement, or state that none is known with evidence**  
  **Evidence**: No uncovered requirements. The single acceptance criterion from issue #1127 is fully implemented and visible in the README.md header badge row.

## Governance

- Branch protection, required checks, required reviews, and repository rules still apply.
- No admin bypass was used.

Refs #1127