### PR TITLE
chore(sdlc): implement issue #1132

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Homedir
 > **DevRel, OpenSource, InnerSource Community Platform**
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=for-the-badge&logo=apache&logoColor=white)](LICENSE)
 [![Contributors](https://img.shields.io/github/contributors/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/graphs/contributors)
 [![PR Validation](https://img.shields.io/github/actions/workflow/status/os-santiago/homedir/pr-check.yml?style=for-the-badge&label=PR%20Validation&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/actions/workflows/pr-check.yml)


### PR DESCRIPTION
## Summary

Autonomous SCC implementation for issue #1132: [auto-split 1/4] README enhancements - multi-criteria test

## Changes Made

- **Removed incorrect MIT license badge** from README header (the project uses Apache-2.0 license, not MIT)
- **Retained correct Apache-2.0 license badge** in README header (project uses Apache-2.0 license per LICENSE file)

## Validation

All GitHub checks pass (CI, SBOM, Security scans, CodeQL, tests, style checks).

## Issue Coverage

- [x] **Add license badge to README header** - **COMPLETED**: The README header already contained the correct Apache-2.0 license badge (matching the LICENSE file which is Apache-2.0). The incorrect MIT license badge was removed. The correct Apache-2.0 badge is present in the README header.

- [x] **Map each acceptance criterion** - **COMPLETED**: The single acceptance criterion "Add license badge to README header" is satisfied - the Apache-2.0 license badge is present in the README header.

- [x] **List any known uncovered requirement** - **NONE**: All acceptance criteria from issue #1132 are satisfied. The README header contains the correct Apache-2.0 license badge matching the project's LICENSE file.

## Governance

- Branch protection, required checks, required reviews, and repository rules still apply.
- No admin bypass was used.

Refs #1132