### PR TITLE
chore(sdlc): implement issue #1147

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=for-the-badge&logo=apache&logoColor=white)](LICENSE)
 [![Contributors](https://img.shields.io/github/contributors/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/graphs/contributors)
+[![GitHub Stars](https://img.shields.io/github/stars/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/stargazers)
 [![PR Validation](https://img.shields.io/github/actions/workflow/status/os-santiago/homedir/pr-check.yml?style=for-the-badge&label=PR%20Validation&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/actions/workflows/pr-check.yml)
 [![Language](https://img.shields.io/github/languages/top/os-santiago/homedir?style=for-the-badge&logo=java&logoColor=white&color=ED8B00)](https://github.com/os-santiago/homedir)
 [![Last Commit](https://img.shields.io/github/last-commit/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/commits/main)


### PR DESCRIPTION
## Summary

Autonomous SCC implementation for issue #1147: [e2e-test-1] Add GitHub stars badge to README

## Validation

Worker validation command not configured; GitHub checks are required before approval.

## Issue Coverage

- [x] Map concrete code changes to issue #1147: [e2e-test-1] Add GitHub stars badge to README
- [x] Map each acceptance criterion, or explain why none applies.
- [x] List any known uncovered requirement, or state that none is known with evidence.

**Evidence:**
- GitHub stars badge added to README.md header badge section (line 6): `[![GitHub Stars](https://img.shields.io/github/stars/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/stargazers)`
- Acceptance criterion "Add GitHub stars badge to README header badge section" is satisfied by the badge added at line 6 of README.md
- No uncovered requirements known - the single acceptance criterion is fully satisfied

## Governance

- Branch protection, required checks, required reviews, and repository rules still apply.
- No admin bypass was used.

Refs #1147