### PR TITLE
fix: resolve memory leak and notification spam (Issue #1149)

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/notifications/NotificationService.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/notifications/NotificationService.java
@@ -62,6 +62,7 @@ public class NotificationService {
       log(n, "duplicate");
       return NotificationResult.DROPPED_DUPLICATE;
     }
+    cleanupDedupe(now);
 
     Deque<Notification> list = store.getUserList(n.userId);
     if (list.size() >= NotificationConfig.userCap
@@ -207,6 +208,11 @@ public class NotificationService {
   public void reset() {
     store.clear();
     dedupe.clear();
+  }
+
+  private void cleanupDedupe(long now) {
+    long window = NotificationConfig.dedupeWindow.toMillis();
+    dedupe.entrySet().removeIf(e -> now - e.getValue() > window);
   }
 
   private void log(Notification n, String reason) {

--- a/quarkus-app/src/main/java/com/scanales/homedir/notifications/TalkStateEvaluator.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/notifications/TalkStateEvaluator.java
@@ -50,13 +50,11 @@ public class TalkStateEvaluator {
             ? ZoneId.of(info.event().getTimezone())
             : ZoneId.of("America/Santiago");
     ZonedDateTime now = clock.now(zone);
-    ZonedDateTime start = now.with(talk.getStartTime());
-    long diff = ChronoUnit.MINUTES.between(now, start);
-    if (diff > 12 * 60) {
-      start = start.minusDays(1);
-    } else if (diff < -12 * 60) {
-      start = start.plusDays(1);
-    }
+    
+    if (info.event() == null || info.event().getDate() == null) return;
+    java.time.LocalDate talkDate = info.event().getDate().plusDays(talk.getDay() - 1);
+    ZonedDateTime start = ZonedDateTime.of(talkDate, talk.getStartTime(), zone);
+    
     ZonedDateTime end = start.plusMinutes(talk.getDurationMinutes());
     if (now.isBefore(start) && start.minus(NotificationConfig.upcomingWindow).isBefore(now)) {
       enqueue(user, talkId, info, NotificationType.UPCOMING, "Charla pronto");

--- a/quarkus-app/src/main/java/com/scanales/homedir/notifications/TalkStateEvaluator.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/notifications/TalkStateEvaluator.java
@@ -10,7 +10,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Set;
 import org.jboss.logging.Logger;
 
@@ -50,11 +49,11 @@ public class TalkStateEvaluator {
             ? ZoneId.of(info.event().getTimezone())
             : ZoneId.of("America/Santiago");
     ZonedDateTime now = clock.now(zone);
-    
+
     if (info.event() == null || info.event().getDate() == null) return;
     java.time.LocalDate talkDate = info.event().getDate().plusDays(talk.getDay() - 1);
     ZonedDateTime start = ZonedDateTime.of(talkDate, talk.getStartTime(), zone);
-    
+
     ZonedDateTime end = start.plusMinutes(talk.getDurationMinutes());
     if (now.isBefore(start) && start.minus(NotificationConfig.upcomingWindow).isBefore(now)) {
       enqueue(user, talkId, info, NotificationType.UPCOMING, "Charla pronto");

--- a/quarkus-app/src/test/java/com/scanales/homedir/notifications/TalkStateEvaluatorTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/notifications/TalkStateEvaluatorTest.java
@@ -37,7 +37,7 @@ class TalkStateEvaluatorTest {
     Event e = new Event("e1", "E", "d");
     e.setDate(java.time.LocalDate.now(java.time.ZoneId.of("UTC")));
     e.setTimezone("UTC");
-    LocalTime now = LocalTime.now();
+    LocalTime now = LocalTime.now(java.time.ZoneId.of("UTC"));
     Talk t1 = new Talk("t1", "t1");
     t1.setStartTime(now.plusMinutes(10));
     t1.setDurationMinutes(30);

--- a/quarkus-app/src/test/java/com/scanales/homedir/notifications/TalkStateEvaluatorTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/notifications/TalkStateEvaluatorTest.java
@@ -35,6 +35,7 @@ class TalkStateEvaluatorTest {
     NotificationConfig.upcomingWindow = java.time.Duration.ofMinutes(15);
     NotificationConfig.endingSoonWindow = java.time.Duration.ofMinutes(10);
     Event e = new Event("e1", "E", "d");
+    e.setDate(java.time.LocalDate.now(java.time.ZoneId.of("UTC")));
     e.setTimezone("UTC");
     LocalTime now = LocalTime.now();
     Talk t1 = new Talk("t1", "t1");


### PR DESCRIPTION
Closes #1149

**Root Cause:**
- `TalkStateEvaluator` calculated past talks using the current date, causing the system to believe they were "just finishing" every day, thereby emitting thousands of `FINISHED` notifications constantly.
- `NotificationService` missed a `cleanupDedupe(now)` call, causing the `dedupe` ConcurrentHashMap to grow indefinitely with these rapid bursts, leading to an eventual OutOfMemoryError and service unavailability.

**Changes:**
- Extracted the real `talkDate` in `TalkStateEvaluator` from the event's date instead of forcing `now()` time.
- Appended `cleanupDedupe(now)` to `NotificationService.enqueue` to cap the map size.
- Modified `TalkStateEvaluatorTest` to inject a valid fixed date to fulfill the fix's requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification deduplication cleanup to prevent stale entries from accumulating.
  * Corrected talk status timing by using the event date and talk day when evaluating scheduled talks.
  * Added handling for talks with missing event dates.

* **Style**
  * Updated button styling across public, community, event, notification, and administrative pages for consistent appearance.
  * Added small, link, and filter button variants.
  * Preserved reduced-motion and print styling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->