### PR TITLE
fix(sdlc): report actual dynamic timeout in SCC error logs (#1139)

### DIFF
--- a/platform/scripts/homedir-sdlc-worker.sh
+++ b/platform/scripts/homedir-sdlc-worker.sh
@@ -235,6 +235,9 @@ run_scc_prompt() {
     log "Issue complexity: ${issue_complexity}, timeout: ${dynamic_timeout}s"
   fi
 
+  # Export timeout for error reporting (used by run_scc_handle_exit_code)
+  export SCC_ACTUAL_TIMEOUT="${dynamic_timeout}"
+
   (
     cd "${WORKDIR}"
     scc_args=(chat)
@@ -264,8 +267,9 @@ run_scc_prompt() {
 run_scc_handle_exit_code() {
   local rc=$1
   local context=$2
+  local actual_timeout="${SCC_ACTUAL_TIMEOUT:-${SCC_TIMEOUT_SECONDS}}"
   if [[ "${rc}" -eq 124 ]]; then
-    log "SCC ${context} timed out after ${SCC_TIMEOUT_SECONDS}s"
+    log "SCC ${context} timed out after ${actual_timeout}s (exit code 124)"
   else
     log "SCC ${context} exited non-zero (${rc})"
   fi


### PR DESCRIPTION
## Summary
Fixes misleading timeout diagnostics in worker logs by reporting the actual dynamic timeout used.

## Problem Statement
Worker logs showed inconsistent timeout values:
- Log entry 1: "timeout: 300s" (correct dynamic timeout)
- Log entry 2: "timed out after 1800s" (incorrect - used SCC_TIMEOUT_SECONDS)

This made debugging timeout issues confusing.

## Solution
- Export `SCC_ACTUAL_TIMEOUT` environment variable in `run_scc_prompt()`
- Use `actual_timeout` variable in `run_scc_handle_exit_code()`
- Falls back to `SCC_TIMEOUT_SECONDS` if not set

## Changes
**File**: `platform/scripts/homedir-sdlc-worker.sh`
- Line 238: Added `export SCC_ACTUAL_TIMEOUT="${dynamic_timeout}"`
- Line 270: Changed to use `actual_timeout="${SCC_ACTUAL_TIMEOUT:-${SCC_TIMEOUT_SECONDS}}"`
- Line 272: Updated log message to show actual timeout value

## Testing
- [x] Syntax validation: `bash -n` passes
- [x] Validated in production (VPS) during previous session

## Impact
**Before**:
```
[worker] Issue complexity: simple, timeout: 300s
[worker] SCC implementation timed out after 1800s
```

**After**:
```
[worker] Issue complexity: simple, timeout: 300s
[worker] SCC implementation timed out after 300s (exit code 124)
```

Fixes #1139

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)