### PR TITLE
fix(ci): correct secret/variable names for VPS deployment

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -28,11 +28,11 @@ jobs:
     permissions:
       contents: read
     env:
-      DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST }}
-      DEPLOY_USER: ${{ vars.DEPLOY_SSH_USER }}
-      DEPLOY_PORT: ${{ vars.DEPLOY_SSH_PORT || '22' }}
+      DEPLOY_HOST: ${{ vars.VPS_HOST }}
+      DEPLOY_USER: ${{ vars.VPS_USER }}
+      DEPLOY_PORT: ${{ vars.VPS_PORT || '22' }}
       WORKER_USER: ${{ vars.WORKER_SSH_USER || 'homedir-sdlc' }}
-      DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+      DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_KEY }}
       DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
 
     steps:


### PR DESCRIPTION
Fixes variable/secret name mismatch in deploy-worker.yml:
- DEPLOY_SSH_HOST -> VPS_HOST
- DEPLOY_SSH_USER -> VPS_USER
- DEPLOY_SSH_PORT -> VPS_PORT
- secrets.DEPLOY_SSH_PRIVATE_KEY -> secrets.VPS_SSH_KEY