### PR TITLE
chore(sdlc): implement issue #1216

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Homedir
 > **DevRel, OpenSource, InnerSource Community Platform**
 
+
+![Maven Central](https://img.shields.io/maven-central/v/com.scanales/homedir?style=for-the-badge)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=for-the-badge&logo=apache&logoColor=white)](LICENSE)
 [![Contributors](https://img.shields.io/github/contributors/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/graphs/contributors)
 [![GitHub Stars](https://img.shields.io/github/stars/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/stargazers)


### PR DESCRIPTION
## Summary

Autonomous SCC implementation for issue #1216: [e2e-test-4] Add version badge to README

## Validation

Worker validation command not configured; GitHub checks are required before approval.

## Issue Coverage

- [x] Map concrete code changes to issue #1216: [e2e-test-4] Add version badge to README
- [x] Map each acceptance criterion, or explain why none applies.
- [x] List any known uncovered requirement, or state that none is known with evidence.

**Evidence:**
- Added Maven Central version badge to README.md: `![Maven Central](https://img.shields.io/maven-central/v/com.scanales/homedir?style=for-the-badge)`
- This badge displays the current Maven Central version of the homedir artifact (com.scanales/homedir)
- Acceptance criterion "Add version badge to README.md" is satisfied by the Maven Central version badge

## Governance

- Branch protection, required checks, required reviews, and repository rules still apply.
- No admin bypass was used.

Refs #1216