### PR TITLE
feat(speaker): Self-service speaker profile with talk and co-speaker management

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
@@ -6962,4 +6962,43 @@ public interface AppMessages {
 
   @Message("Statistics")
   String sdlc_dash_decisions_tab_stats();
+
+  // --- Profile - Speaker Talks ---
+  @Message("My Talks")
+  String profile_speaker_talks_title();
+
+  @Message("Duration")
+  String profile_speaker_talk_duration();
+
+  @Message("Edit")
+  String profile_speaker_talk_edit();
+
+  @Message("Save")
+  String profile_speaker_talk_save();
+
+  @Message("Cancel")
+  String profile_speaker_talk_cancel();
+
+  @Message("Add co-speaker")
+  String profile_speaker_talk_add_cospeaker();
+
+  @Message("Search speakers...")
+  String profile_speaker_talk_search_speakers();
+
+  @Message("Talk updated successfully")
+  String profile_speaker_talk_saved();
+
+  @Message("Co-speakers:")
+  String profile_speaker_talk_cospeakers_label();
+
+  // --- Speaker Detail ---
+  @Message("Speakers:")
+  String speaker_detail_talk_speakers_label();
+
+  // --- CFP form fields reused in profile ---
+  @Message("Talk title")
+  String events_cfp_field_title();
+
+  @Message("Abstract")
+  String events_cfp_field_abstract();
 }

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/ProfileResource.java
@@ -40,11 +40,13 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
@@ -60,6 +62,7 @@ import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.LinkedHashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.ResourceBundle;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -291,6 +294,7 @@ public class ProfileResource {
     var userProfile = userProfiles.upsert(email, name, email);
     var speakerProfile = userProfile.getSpeakerProfile();
     boolean speakerActive = speakerProfile != null && speakerProfile.active();
+    com.scanales.homedir.model.Speaker speaker = speakerService.getSpeaker(email);
     String avatarUrl =
         firstNonBlank(
             picture,
@@ -466,15 +470,14 @@ public class ProfileResource {
         .data("photoError", photoError)
         .data(
             "speakerPhoto",
-            speakerService.getSpeaker(email) != null
-                    && speakerService.getSpeaker(email).getPhotoUrl() != null
-                ? speakerService.getSpeaker(email).getPhotoUrl()
+            speaker != null && speaker.getPhotoUrl() != null
+                ? speaker.getPhotoUrl()
                 : getClaim("picture"))
         .data(
             "hasCustomPhoto",
-            speakerService.getSpeaker(email) != null
-                && speakerService.getSpeaker(email).getPhotoUrl() != null
-                && speakerService.getSpeaker(email).getPhotoUrl().startsWith("/speaker/"))
+            speaker != null
+                && speaker.getPhotoUrl() != null
+                && speaker.getPhotoUrl().startsWith("/speaker/"))
         .data("selectionReadiness", selectionReadiness)
         .data("selectionLocked", selectionLocked)
         .data("volunteerOverview", volunteerOverview)
@@ -483,7 +486,7 @@ public class ProfileResource {
         .data("challengeOverview", challengeOverview)
         .data("profileChallenges", profileChallenges)
         .data("challengeCopy", challengeCopy)
-        .data("speaker", speakerService.getSpeaker(email))
+        .data("speaker", speaker)
         .setAttribute("locale", java.util.Locale.forLanguageTag(finalLang));
   }
 
@@ -792,10 +795,8 @@ public class ProfileResource {
     }
 
     // Find talk
-    com.scanales.homedir.model.Talk talk = speaker.getTalks().stream()
-        .filter(t -> t.getId().equals(talkId))
-        .findFirst()
-        .orElse(null);
+    com.scanales.homedir.model.Talk talk =
+        speaker.getTalks().stream().filter(t -> t.getId().equals(talkId)).findFirst().orElse(null);
 
     if (talk == null) {
       return Response.status(Response.Status.NOT_FOUND)
@@ -818,13 +819,33 @@ public class ProfileResource {
     if (coSpeakersJson != null && !coSpeakersJson.isBlank()) {
       try {
         java.util.List<String> coSpeakerIds = parseCoSpeakers(coSpeakersJson);
-        java.util.List<com.scanales.homedir.model.Speaker> allSpeakers = new java.util.ArrayList<>();
-        allSpeakers.add(speaker); // Main speaker first
+        java.util.List<com.scanales.homedir.model.Speaker> existingSpeakers = talk.getSpeakers();
+        java.util.List<com.scanales.homedir.model.Speaker> allSpeakers =
+            new java.util.ArrayList<>();
+        java.util.Set<String> seenIds = new java.util.HashSet<>();
 
+        // Preserve original primary speaker
+        com.scanales.homedir.model.Speaker primary =
+            (existingSpeakers != null && !existingSpeakers.isEmpty())
+                ? existingSpeakers.get(0)
+                : speaker;
+        allSpeakers.add(primary);
+        seenIds.add(primary.getId());
+
+        // Add current speaker if not already the primary
+        if (!seenIds.contains(speaker.getId())) {
+          allSpeakers.add(speaker);
+          seenIds.add(speaker.getId());
+        }
+
+        // Add co-speakers from form, avoiding duplicates
         for (String csId : coSpeakerIds) {
-          com.scanales.homedir.model.Speaker cs = speakerService.getSpeaker(csId);
-          if (cs != null) {
-            allSpeakers.add(cs);
+          if (!seenIds.contains(csId)) {
+            com.scanales.homedir.model.Speaker cs = speakerService.getSpeaker(csId);
+            if (cs != null) {
+              seenIds.add(csId);
+              allSpeakers.add(cs);
+            }
           }
         }
         talk.setSpeakers(allSpeakers);
@@ -836,9 +857,8 @@ public class ProfileResource {
     // Save via SpeakerService (propagates to all speakers + events)
     speakerService.saveTalk(speaker.getId(), talk);
 
-    String target = redirect != null && !redirect.isBlank()
-        ? redirect
-        : "/private/profile#speaker-panel";
+    String target =
+        redirect != null && !redirect.isBlank() ? redirect : "/private/profile#speaker-panel";
     return redirectWithStatus(target, "talkSaved", "1");
   }
 
@@ -851,16 +871,19 @@ public class ProfileResource {
       return Response.ok(java.util.List.of()).build();
     }
 
-    java.util.List<com.scanales.homedir.model.Speaker> all = speakerService.getAllSpeakers();
-    java.util.List<java.util.Map<String, String>> results = all.stream()
-        .filter(s -> s.getName().toLowerCase().contains(query.toLowerCase()))
-        .limit(10)
-        .map(s -> java.util.Map.of(
-            "id", s.getId(),
-            "name", s.getName(),
-            "bio", s.getBio() != null ? s.getBio() : ""
-        ))
-        .toList();
+    java.util.List<com.scanales.homedir.model.Speaker> all = speakerService.listSpeakers();
+    java.util.List<java.util.Map<String, String>> results =
+        all.stream()
+            .filter(
+                s -> s.getName() != null && s.getName().toLowerCase().contains(query.toLowerCase()))
+            .limit(10)
+            .map(
+                s ->
+                    java.util.Map.of(
+                        "id", s.getId(),
+                        "name", s.getName(),
+                        "bio", s.getBio() != null ? s.getBio() : ""))
+            .toList();
 
     return Response.ok(results).build();
   }
@@ -869,8 +892,8 @@ public class ProfileResource {
     try {
       com.fasterxml.jackson.databind.ObjectMapper mapper =
           new com.fasterxml.jackson.databind.ObjectMapper();
-      return mapper.readValue(json,
-          new com.fasterxml.jackson.core.type.TypeReference<java.util.List<String>>() {});
+      return mapper.readValue(
+          json, new com.fasterxml.jackson.core.type.TypeReference<java.util.List<String>>() {});
     } catch (Exception e) {
       return java.util.List.of();
     }

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/ProfileResource.java
@@ -483,6 +483,7 @@ public class ProfileResource {
         .data("challengeOverview", challengeOverview)
         .data("profileChallenges", profileChallenges)
         .data("challengeCopy", challengeCopy)
+        .data("speaker", speakerService.getSpeaker(email))
         .setAttribute("locale", java.util.Locale.forLanguageTag(finalLang));
   }
 
@@ -763,6 +764,116 @@ public class ProfileResource {
       speakerService.saveSpeaker(sp);
     }
     return redirectWithStatus(target, "photoSaved", "1");
+  }
+
+  @POST
+  @Path("speaker/talk")
+  @Authenticated
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  public Response updateTalk(
+      @FormParam("talkId") String talkId,
+      @FormParam("title") String title,
+      @FormParam("description") String description,
+      @FormParam("durationMinutes") Integer duration,
+      @FormParam("coSpeakers") String coSpeakersJson,
+      @FormParam("redirect") String redirect) {
+
+    String email = getEmail();
+    if (email == null || email.isBlank()) {
+      return Response.status(Response.Status.UNAUTHORIZED).build();
+    }
+
+    // Get user's speaker
+    com.scanales.homedir.model.Speaker speaker = speakerService.getSpeaker(email);
+    if (speaker == null) {
+      return Response.status(Response.Status.FORBIDDEN)
+          .entity(Map.of("error", "no_speaker_profile"))
+          .build();
+    }
+
+    // Find talk
+    com.scanales.homedir.model.Talk talk = speaker.getTalks().stream()
+        .filter(t -> t.getId().equals(talkId))
+        .findFirst()
+        .orElse(null);
+
+    if (talk == null) {
+      return Response.status(Response.Status.NOT_FOUND)
+          .entity(Map.of("error", "talk_not_found"))
+          .build();
+    }
+
+    // Update talk fields
+    if (title != null && !title.isBlank()) {
+      talk.setName(title.substring(0, Math.min(title.length(), 120)));
+    }
+    if (description != null) {
+      talk.setDescription(description.substring(0, Math.min(description.length(), 2000)));
+    }
+    if (duration != null && duration > 0) {
+      talk.setDurationMinutes(duration);
+    }
+
+    // Update co-speakers if provided
+    if (coSpeakersJson != null && !coSpeakersJson.isBlank()) {
+      try {
+        java.util.List<String> coSpeakerIds = parseCoSpeakers(coSpeakersJson);
+        java.util.List<com.scanales.homedir.model.Speaker> allSpeakers = new java.util.ArrayList<>();
+        allSpeakers.add(speaker); // Main speaker first
+
+        for (String csId : coSpeakerIds) {
+          com.scanales.homedir.model.Speaker cs = speakerService.getSpeaker(csId);
+          if (cs != null) {
+            allSpeakers.add(cs);
+          }
+        }
+        talk.setSpeakers(allSpeakers);
+      } catch (Exception e) {
+        // Invalid JSON, skip co-speakers update
+      }
+    }
+
+    // Save via SpeakerService (propagates to all speakers + events)
+    speakerService.saveTalk(speaker.getId(), talk);
+
+    String target = redirect != null && !redirect.isBlank()
+        ? redirect
+        : "/private/profile#speaker-panel";
+    return redirectWithStatus(target, "talkSaved", "1");
+  }
+
+  @GET
+  @Path("speaker/search")
+  @Authenticated
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response searchSpeakers(@QueryParam("q") String query) {
+    if (query == null || query.length() < 2) {
+      return Response.ok(java.util.List.of()).build();
+    }
+
+    java.util.List<com.scanales.homedir.model.Speaker> all = speakerService.getAllSpeakers();
+    java.util.List<java.util.Map<String, String>> results = all.stream()
+        .filter(s -> s.getName().toLowerCase().contains(query.toLowerCase()))
+        .limit(10)
+        .map(s -> java.util.Map.of(
+            "id", s.getId(),
+            "name", s.getName(),
+            "bio", s.getBio() != null ? s.getBio() : ""
+        ))
+        .toList();
+
+    return Response.ok(results).build();
+  }
+
+  private java.util.List<String> parseCoSpeakers(String json) {
+    try {
+      com.fasterxml.jackson.databind.ObjectMapper mapper =
+          new com.fasterxml.jackson.databind.ObjectMapper();
+      return mapper.readValue(json,
+          new com.fasterxml.jackson.core.type.TypeReference<java.util.List<String>>() {});
+    } catch (Exception e) {
+      return java.util.List.of();
+    }
   }
 
   @POST

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/CfpSubmissionApiResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/CfpSubmissionApiResource.java
@@ -44,6 +44,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -1108,7 +1109,9 @@ public class CfpSubmissionApiResource {
 
     if (submission.panelists() != null && !submission.panelists().isEmpty()) {
       for (CfpPanelist panelist : submission.panelists()) {
-        if ("linked".equals(panelist.status()) && panelist.userId() != null) {
+        if ("linked".equals(panelist.status())
+            && panelist.userId() != null
+            && !panelist.userId().isBlank()) {
           // Create/update speaker for panelist
           String panelistSpeakerId = buildSpeakerId(panelist.id(), panelist.name());
           Speaker panelistSpeaker = speakerService.getSpeaker(panelistSpeakerId);
@@ -1122,9 +1125,7 @@ public class CfpSubmissionApiResource {
 
           // Activate speaker profile for panelist user
           userProfileService.activateSpeakerProfile(
-              panelist.userId(),
-              panelist.name(),
-              panelist.email());
+              panelist.userId(), panelist.name(), panelist.email());
         }
       }
     }

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/CfpSubmissionApiResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/CfpSubmissionApiResource.java
@@ -1101,6 +1101,36 @@ public class CfpSubmissionApiResource {
     talk.setName(submission.title());
     talk.setDescription(buildTalkDescription(submission));
     talk.setDurationMinutes(submission.durationMin() != null ? submission.durationMin() : 30);
+
+    // Process panelists as co-speakers
+    List<Speaker> allSpeakers = new ArrayList<>();
+    allSpeakers.add(speaker); // Main speaker first
+
+    if (submission.panelists() != null && !submission.panelists().isEmpty()) {
+      for (CfpPanelist panelist : submission.panelists()) {
+        if ("linked".equals(panelist.status()) && panelist.userId() != null) {
+          // Create/update speaker for panelist
+          String panelistSpeakerId = buildSpeakerId(panelist.id(), panelist.name());
+          Speaker panelistSpeaker = speakerService.getSpeaker(panelistSpeakerId);
+          if (panelistSpeaker == null) {
+            panelistSpeaker = new Speaker(panelistSpeakerId, panelist.name());
+            panelistSpeaker.setBio("CFP panelist for event " + submission.eventId());
+          }
+          panelistSpeaker.setName(panelist.name());
+          speakerService.saveSpeaker(panelistSpeaker);
+          allSpeakers.add(panelistSpeaker);
+
+          // Activate speaker profile for panelist user
+          userProfileService.activateSpeakerProfile(
+              panelist.userId(),
+              panelist.name(),
+              panelist.email());
+        }
+      }
+    }
+
+    // Set all speakers on the talk
+    talk.setSpeakers(allSpeakers);
     speakerService.saveTalk(speakerId, talk);
     cfpInsightsService.recordPromoted(submission, speakerId, talkId);
 
@@ -1563,6 +1593,10 @@ public class CfpSubmissionApiResource {
 
   private static String buildSpeakerId(CfpSubmission submission) {
     return "cfp-speaker-" + sanitizeIdToken(submission.id(), 32);
+  }
+
+  private static String buildSpeakerId(String panelistId, String panelistName) {
+    return "cfp-panelist-" + sanitizeIdToken(panelistId, 32);
   }
 
   private static String buildTalkId(CfpSubmission submission) {

--- a/quarkus-app/src/main/resources/i18n.properties
+++ b/quarkus-app/src/main/resources/i18n.properties
@@ -2712,3 +2712,5 @@ profile_speaker_talk_cancel=Cancel
 profile_speaker_talk_add_cospeaker=Add co-speaker
 profile_speaker_talk_search_speakers=Search speakers...
 profile_speaker_talk_saved=Talk updated successfully
+profile_speaker_talk_cospeakers_label=Co-speakers:
+speaker_detail_talk_speakers_label=Speakers:

--- a/quarkus-app/src/main/resources/i18n.properties
+++ b/quarkus-app/src/main/resources/i18n.properties
@@ -2702,3 +2702,13 @@ sdlc_dash_decisions_heading=Autonomous Decisions
 sdlc_dash_decisions_desc=Decisions made autonomously by the AI worker based on best practices
 sdlc_dash_decisions_tab_recent=Recent
 sdlc_dash_decisions_tab_stats=Statistics
+
+# Profile - Speaker Talks
+profile_speaker_talks_title=My Talks
+profile_speaker_talk_duration=Duration
+profile_speaker_talk_edit=Edit
+profile_speaker_talk_save=Save
+profile_speaker_talk_cancel=Cancel
+profile_speaker_talk_add_cospeaker=Add co-speaker
+profile_speaker_talk_search_speakers=Search speakers...
+profile_speaker_talk_saved=Talk updated successfully

--- a/quarkus-app/src/main/resources/i18n.properties
+++ b/quarkus-app/src/main/resources/i18n.properties
@@ -2714,3 +2714,7 @@ profile_speaker_talk_search_speakers=Search speakers...
 profile_speaker_talk_saved=Talk updated successfully
 profile_speaker_talk_cospeakers_label=Co-speakers:
 speaker_detail_talk_speakers_label=Speakers:
+
+# CFP form fields reused in profile
+events_cfp_field_title=Talk title
+events_cfp_field_abstract=Abstract

--- a/quarkus-app/src/main/resources/i18n_en.properties
+++ b/quarkus-app/src/main/resources/i18n_en.properties
@@ -2712,3 +2712,5 @@ profile_speaker_talk_cancel=Cancel
 profile_speaker_talk_add_cospeaker=Add co-speaker
 profile_speaker_talk_search_speakers=Search speakers...
 profile_speaker_talk_saved=Talk updated successfully
+profile_speaker_talk_cospeakers_label=Co-speakers:
+speaker_detail_talk_speakers_label=Speakers:

--- a/quarkus-app/src/main/resources/i18n_en.properties
+++ b/quarkus-app/src/main/resources/i18n_en.properties
@@ -2702,3 +2702,13 @@ sdlc_dash_decisions_heading=Autonomous Decisions
 sdlc_dash_decisions_desc=Decisions made autonomously by the AI worker based on best practices
 sdlc_dash_decisions_tab_recent=Recent
 sdlc_dash_decisions_tab_stats=Statistics
+
+# Profile - Speaker Talks
+profile_speaker_talks_title=My Talks
+profile_speaker_talk_duration=Duration
+profile_speaker_talk_edit=Edit
+profile_speaker_talk_save=Save
+profile_speaker_talk_cancel=Cancel
+profile_speaker_talk_add_cospeaker=Add co-speaker
+profile_speaker_talk_search_speakers=Search speakers...
+profile_speaker_talk_saved=Talk updated successfully

--- a/quarkus-app/src/main/resources/i18n_en.properties
+++ b/quarkus-app/src/main/resources/i18n_en.properties
@@ -2714,3 +2714,7 @@ profile_speaker_talk_search_speakers=Search speakers...
 profile_speaker_talk_saved=Talk updated successfully
 profile_speaker_talk_cospeakers_label=Co-speakers:
 speaker_detail_talk_speakers_label=Speakers:
+
+# CFP form fields reused in profile
+events_cfp_field_title=Talk title
+events_cfp_field_abstract=Abstract

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -2715,3 +2715,7 @@ profile_speaker_talk_search_speakers=Buscar speakers...
 profile_speaker_talk_saved=Charla actualizada exitosamente
 profile_speaker_talk_cospeakers_label=Co-speakers:
 speaker_detail_talk_speakers_label=Speakers:
+
+# CFP form fields reused in profile
+events_cfp_field_title=Título de la charla
+events_cfp_field_abstract=Resumen

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -2703,3 +2703,13 @@ sdlc_dash_decisions_heading=Decisiones Aut\u00f3nomas
 sdlc_dash_decisions_desc=Decisiones tomadas aut\u00f3nomamente por el worker de IA basadas en mejores pr\u00e1cticas
 sdlc_dash_decisions_tab_recent=Recientes
 sdlc_dash_decisions_tab_stats=Estad\u00edsticas
+
+# Profile - Speaker Talks
+profile_speaker_talks_title=Mis Charlas
+profile_speaker_talk_duration=Duración
+profile_speaker_talk_edit=Editar
+profile_speaker_talk_save=Guardar
+profile_speaker_talk_cancel=Cancelar
+profile_speaker_talk_add_cospeaker=Agregar co-speaker
+profile_speaker_talk_search_speakers=Buscar speakers...
+profile_speaker_talk_saved=Charla actualizada exitosamente

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -2713,3 +2713,5 @@ profile_speaker_talk_cancel=Cancelar
 profile_speaker_talk_add_cospeaker=Agregar co-speaker
 profile_speaker_talk_search_speakers=Buscar speakers...
 profile_speaker_talk_saved=Charla actualizada exitosamente
+profile_speaker_talk_cospeakers_label=Co-speakers:
+speaker_detail_talk_speakers_label=Speakers:

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -610,7 +610,7 @@
                         <div class="hd-talk-meta">
                             <span class="hd-talk-duration">{i18n:profile_speaker_talk_duration}: {talk.durationMinutes} min</span>
                             {#if talk.speakers.size() > 1}
-                            <span class="hd-talk-cospeakers">Co-speakers: {talk.speakerNames}</span>
+                            <span class="hd-talk-cospeakers">{i18n:profile_speaker_talk_cospeakers_label} {talk.speakerNames}</span>
                             {/if}
                         </div>
                         {#if talk.description != null && !talk.description.isBlank()}
@@ -689,6 +689,7 @@
                 function openEditModal(talkId) {
                     {#if speaker != null}
                     const talks = {speaker.talks:json};
+                    const currentSpeakerId = '{speaker.id}';
                     currentTalkData = talks.find(t => t.id === talkId);
                     if (!currentTalkData) return;
 
@@ -697,9 +698,9 @@
                     document.getElementById('editTalkDescription').value = currentTalkData.description || '';
                     document.getElementById('editTalkDuration').value = currentTalkData.durationMinutes || 30;
 
-                    // Load co-speakers
+                    // Load co-speakers excluding current speaker by ID
                     selectedCoSpeakers = (currentTalkData.speakers || [])
-                        .filter((s, i) => i > 0) // Skip main speaker
+                        .filter(s => s.id !== currentSpeakerId)
                         .map(s => ({ id: s.id, name: s.name }));
                     renderSelectedCoSpeakers();
 
@@ -724,6 +725,13 @@
                     searchTimeout = setTimeout(() => searchSpeakers(query), 300);
                 });
 
+                function escapeHtml(str) {
+                    if (!str) return '';
+                    const div = document.createElement('div');
+                    div.appendChild(document.createTextNode(str));
+                    return div.innerHTML;
+                }
+
                 async function searchSpeakers(query) {
                     try {
                         const response = await fetch(`/private/profile/speaker/search?q=$\{encodeURIComponent(query)}`);
@@ -740,9 +748,9 @@
                         return;
                     }
                     resultsDiv.innerHTML = results.map(s => `
-                        <div class="hd-search-result" data-speaker-id="${s.id}" data-speaker-name="${s.name}">
-                            <strong>${s.name}</strong>
-                            ${s.bio ? `<small>${s.bio}</small>` : ''}
+                        <div class="hd-search-result" data-speaker-id="${escapeHtml(s.id)}" data-speaker-name="${escapeHtml(s.name)}">
+                            <strong>${escapeHtml(s.name)}</strong>
+                            ${s.bio ? `<small>${escapeHtml(s.bio)}</small>` : ''}
                         </div>
                     `).join('');
                     resultsDiv.style.display = 'block';
@@ -774,8 +782,8 @@
                 function renderSelectedCoSpeakers() {
                     selectedDiv.innerHTML = selectedCoSpeakers.map(s => `
                         <div class="hd-selected-item">
-                            ${s.name}
-                            <button type="button" class="hd-remove-btn" data-remove-speaker="${s.id}">&times;</button>
+                            ${escapeHtml(s.name)}
+                            <button type="button" class="hd-remove-btn" data-remove-speaker="${escapeHtml(s.id)}">&times;</button>
                         </div>
                     `).join('');
 

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -599,6 +599,197 @@
                     <button type="submit" class="hd-btn hd-btn-primary">{i18n:profile_speaker_save}</button>
                 </div>
             </form>
+
+            {#if speakerActive && speaker != null && !speaker.talks.isEmpty()}
+            <div class="hd-talks-section">
+                <h3 class="hd-section-subtitle">{i18n:profile_speaker_talks_title}</h3>
+                <div class="hd-talks-list">
+                    {#for talk in speaker.talks}
+                    <article class="hd-talk-card">
+                        <h4 class="hd-talk-title">{talk.name}</h4>
+                        <div class="hd-talk-meta">
+                            <span class="hd-talk-duration">{i18n:profile_speaker_talk_duration}: {talk.durationMinutes} min</span>
+                            {#if talk.speakers.size() > 1}
+                            <span class="hd-talk-cospeakers">Co-speakers: {talk.speakerNames}</span>
+                            {/if}
+                        </div>
+                        {#if talk.description != null && !talk.description.isBlank()}
+                        <p class="hd-talk-description">{talk.description}</p>
+                        {/if}
+                        <div class="hd-talk-actions">
+                            <button type="button" class="hd-btn hd-btn-small" data-edit-talk="{talk.id}">{i18n:profile_speaker_talk_edit}</button>
+                        </div>
+                    </article>
+                    {/for}
+                </div>
+            </div>
+            {/if}
+
+            <!-- Talk Edit Modal -->
+            <div id="talkEditModal" class="hd-modal" style="display:none;">
+                <div class="hd-modal-content">
+                    <div class="hd-modal-header">
+                        <h3>{i18n:profile_speaker_talk_edit}</h3>
+                        <button type="button" class="hd-modal-close" data-close-modal>&times;</button>
+                    </div>
+                    <form id="talkEditForm" action="/private/profile/speaker/talk" method="POST">
+                        {#include fragments/csrf-token.html /}
+                        <input type="hidden" name="talkId" id="editTalkId">
+                        <input type="hidden" name="redirect" value="/private/profile#speaker-panel">
+                        <input type="hidden" name="coSpeakers" id="editCoSpeakers">
+
+                        <div class="form-group">
+                            <label for="editTalkTitle">{i18n:events_cfp_field_title}</label>
+                            <input type="text" id="editTalkTitle" name="title" class="form-input" maxlength="120" required>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="editTalkDescription">{i18n:events_cfp_field_abstract}</label>
+                            <textarea id="editTalkDescription" name="description" class="form-input" maxlength="2000" rows="5"></textarea>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="editTalkDuration">{i18n:profile_speaker_talk_duration} (min)</label>
+                            <input type="number" id="editTalkDuration" name="durationMinutes" class="form-input" min="5" max="180">
+                        </div>
+
+                        <div class="form-group">
+                            <label>{i18n:profile_speaker_talk_add_cospeaker}</label>
+                            <input type="text" id="coSpeakerSearch" class="form-input" placeholder="{i18n:profile_speaker_talk_search_speakers}">
+                            <div id="coSpeakerResults" class="hd-search-results" style="display:none;"></div>
+                            <div id="selectedCoSpeakers" class="hd-selected-list"></div>
+                        </div>
+
+                        <div class="hd-modal-actions">
+                            <button type="submit" class="hd-btn hd-btn-primary">{i18n:profile_speaker_talk_save}</button>
+                            <button type="button" class="hd-btn" data-close-modal>{i18n:profile_speaker_talk_cancel}</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <script>
+            (function() {
+                const modal = document.getElementById('talkEditModal');
+                const form = document.getElementById('talkEditForm');
+                const searchInput = document.getElementById('coSpeakerSearch');
+                const resultsDiv = document.getElementById('coSpeakerResults');
+                const selectedDiv = document.getElementById('selectedCoSpeakers');
+                let selectedCoSpeakers = [];
+                let currentTalkData = null;
+
+                // Edit talk buttons
+                document.querySelectorAll('[data-edit-talk]').forEach(btn => {
+                    btn.addEventListener('click', function() {
+                        const talkId = this.getAttribute('data-edit-talk');
+                        openEditModal(talkId);
+                    });
+                });
+
+                function openEditModal(talkId) {
+                    {#if speaker != null}
+                    const talks = {speaker.talks:json};
+                    currentTalkData = talks.find(t => t.id === talkId);
+                    if (!currentTalkData) return;
+
+                    document.getElementById('editTalkId').value = talkId;
+                    document.getElementById('editTalkTitle').value = currentTalkData.name || '';
+                    document.getElementById('editTalkDescription').value = currentTalkData.description || '';
+                    document.getElementById('editTalkDuration').value = currentTalkData.durationMinutes || 30;
+
+                    // Load co-speakers
+                    selectedCoSpeakers = (currentTalkData.speakers || [])
+                        .filter((s, i) => i > 0) // Skip main speaker
+                        .map(s => ({ id: s.id, name: s.name }));
+                    renderSelectedCoSpeakers();
+
+                    modal.style.display = 'flex';
+                    {/if}
+                }
+
+                // Close modal
+                document.querySelectorAll('[data-close-modal]').forEach(btn => {
+                    btn.addEventListener('click', () => modal.style.display = 'none');
+                });
+
+                // Co-speaker search
+                let searchTimeout;
+                searchInput.addEventListener('input', function() {
+                    clearTimeout(searchTimeout);
+                    const query = this.value.trim();
+                    if (query.length < 2) {
+                        resultsDiv.style.display = 'none';
+                        return;
+                    }
+                    searchTimeout = setTimeout(() => searchSpeakers(query), 300);
+                });
+
+                async function searchSpeakers(query) {
+                    try {
+                        const response = await fetch(`/private/profile/speaker/search?q=$\{encodeURIComponent(query)}`);
+                        const results = await response.json();
+                        displayResults(results);
+                    } catch (e) {
+                        console.error('Search failed:', e);
+                    }
+                }
+
+                function displayResults(results) {
+                    if (!results || results.length === 0) {
+                        resultsDiv.style.display = 'none';
+                        return;
+                    }
+                    resultsDiv.innerHTML = results.map(s => `
+                        <div class="hd-search-result" data-speaker-id="${s.id}" data-speaker-name="${s.name}">
+                            <strong>${s.name}</strong>
+                            ${s.bio ? `<small>${s.bio}</small>` : ''}
+                        </div>
+                    `).join('');
+                    resultsDiv.style.display = 'block';
+
+                    resultsDiv.querySelectorAll('.hd-search-result').forEach(el => {
+                        el.addEventListener('click', function() {
+                            addCoSpeaker({
+                                id: this.getAttribute('data-speaker-id'),
+                                name: this.getAttribute('data-speaker-name')
+                            });
+                            searchInput.value = '';
+                            resultsDiv.style.display = 'none';
+                        });
+                    });
+                }
+
+                function addCoSpeaker(speaker) {
+                    if (!selectedCoSpeakers.find(s => s.id === speaker.id)) {
+                        selectedCoSpeakers.push(speaker);
+                        renderSelectedCoSpeakers();
+                    }
+                }
+
+                function removeCoSpeaker(speakerId) {
+                    selectedCoSpeakers = selectedCoSpeakers.filter(s => s.id !== speakerId);
+                    renderSelectedCoSpeakers();
+                }
+
+                function renderSelectedCoSpeakers() {
+                    selectedDiv.innerHTML = selectedCoSpeakers.map(s => `
+                        <div class="hd-selected-item">
+                            ${s.name}
+                            <button type="button" class="hd-remove-btn" data-remove-speaker="${s.id}">&times;</button>
+                        </div>
+                    `).join('');
+
+                    document.getElementById('editCoSpeakers').value =
+                        JSON.stringify(selectedCoSpeakers.map(s => s.id));
+
+                    selectedDiv.querySelectorAll('[data-remove-speaker]').forEach(btn => {
+                        btn.addEventListener('click', function() {
+                            removeCoSpeaker(this.getAttribute('data-remove-speaker'));
+                        });
+                    });
+                }
+            })();
+            </script>
             {/if}
         </section>
 

--- a/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
@@ -93,6 +93,14 @@
       {#for t in speaker.talks}
       <li class="card talk-card">
         <h3 class="talk-title">{t.name}{#if t.speakers[0].id != speaker.id} (Co Speaker){/if}</h3>
+        {#if t.speakers.size() > 1}
+        <div class="talk-speakers">
+          <strong>Speakers:</strong>
+          {#for sp in t.speakers}
+            <a href="/speaker/{sp.id}">{sp.name}</a>{#if !sp_isLast}, {/if}
+          {/for}
+        </div>
+        {/if}
         {#if talkEvents.get(t.id) != null}
         <div class="chips">
           {#for e in talkEvents.get(t.id)}

--- a/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
@@ -95,7 +95,7 @@
         <h3 class="talk-title">{t.name}{#if t.speakers[0].id != speaker.id} (Co Speaker){/if}</h3>
         {#if t.speakers.size() > 1}
         <div class="talk-speakers">
-          <strong>Speakers:</strong>
+          <strong>{i18n:speaker_detail_talk_speakers_label}</strong>
           {#for sp in t.speakers}
             <a href="/speaker/{sp.id}">{sp.name}</a>{#if !sp_isLast}, {/if}
           {/for}


### PR DESCRIPTION
# feat(speaker): Self-service speaker profile with talk and co-speaker management

## Summary

Complete implementation of self-service speaker profile management for CFP users. Users can now view and edit their speaker info, manage talks, and add co-speakers. CFP panelists are automatically promoted as co-speakers.

## Problem Solved

**Before:**
- CFP panelists were NOT converted to co-speakers when promoted
- Users couldn't see or edit their talks
- Admin had to manually manage co-speakers for panel talks
- No integration between CFP panelists and event speakers

**After:**
- ✅ CFP promotion automatically creates co-speakers for all linked panelists  
- ✅ Users see their talks at `/private/profile#speaker-panel`
- ✅ Users can edit talk details (title, description, duration)
- ✅ Users can add/remove co-speakers via search
- ✅ Public profiles show all co-speakers with bidirectional links
- ✅ Full integration: CFP → Private Profile → Public Profile → Event Agenda

## Changes

### 1. CFP Promotion Enhancement (CfpSubmissionApiResource.java)
- Processes all linked panelists when promoting CFPs
- Creates Speaker entities for each panelist
- Activates SpeakerProfile for panelist users
- Sets Talk.speakers with main + all panelists
- Uses SpeakerService.saveTalk() for propagation

### 2. Talk Display (profile.html + ProfileResource.java)
- Added "Mis Charlas" section in speaker panel
- Shows title, duration, co-speakers, description
- Edit button per talk

### 3. Talk Editing API (ProfileResource.java)
- `POST /private/profile/speaker/talk` - Update talk
- Owner validation (user can only edit own talks)
- Supports title, description, duration, co-speakers
- Uses SpeakerService.saveTalk() to propagate

### 4. Co-Speaker Search (ProfileResource.java)
- `GET /private/profile/speaker/search?q={query}`
- Autocomplete for finding speakers
- Returns JSON array (max 10 results)

### 5. Public Profile Enhancement (detail.html)
- Shows all speakers for multi-speaker talks
- Links to each co-speaker profile
- Enables bidirectional navigation

### 6. Modal & JavaScript (profile.html)
- Talk edit modal with form
- Co-speaker autocomplete search
- Selected speakers display with remove
- JSON serialization for submit

## Validation

- ✅ Compiles successfully: `mvn compile`
- ✅ Owner-only talk editing
- ✅ Input sanitization (120/2000 char limits)
- ✅ Backwards compatible
- ✅ No database migrations needed

## Testing

See detailed verification plan in full PR description.

Key flows:
1. Promote CFP with panelists → all get speaker profiles
2. Edit talk → changes propagate to all speakers
3. Add co-speaker → appears in their profile
4. Public profiles link between co-speakers

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Speakers can manage talks from their profile via a new talk edit modal (title, description, duration).
  * Add/remove co-speakers using a searchable selector.
  * Speaker profile now shows the talks list only when the speaker is active and has talks.
  * Speaker detail pages now link to all participating speakers for multi-speaker talks.
  * Promoted submissions now include the main proposer plus associated panelist speaker profiles.
* **Bug Fixes**
  * Improved preservation of speaker and panelist information when promoting submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->