### PR TITLE
fix(admin): allow updating existing talks in event agenda

### DIFF
--- a/.opencode/pr1247_threads.json
+++ b/.opencode/pr1247_threads.json
@@ -1,0 +1,1 @@
+{"query": "query { repository(owner: \"os-santiago\", name: \"homedir\") { pullRequest(number: 1247) { reviewThreads(first: 50) { nodes { id isResolved comments(first: 1) { nodes { body } } } } } } }"}

--- a/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
@@ -7001,4 +7001,11 @@ public interface AppMessages {
 
   @Message("Abstract")
   String events_cfp_field_abstract();
+
+  // --- Admin - Event Talk Management ---
+  @Message("✅ Talk '{name}' updated successfully.")
+  String admin_event_talk_updated(String name);
+
+  @Message("✅ Talk '{name}' added to event.")
+  String admin_event_talk_created(String name);
 }

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventResource.java
@@ -320,19 +320,12 @@ public class AdminEventResource {
     java.time.LocalTime start = java.time.LocalTime.parse(startTime);
     java.time.LocalTime end = start.plusMinutes(base.getDurationMinutes());
     LOG.infof(
-        "accion=charla_crear_intento usuario=%s eventoId=%s charlaTitulo=%s fechaInicio=%s fechaFin=%s dia=%d sala=%s requestId=%s",
+        "accion=charla_guardar_intento usuario=%s eventoId=%s charlaTitulo=%s fechaInicio=%s fechaFin=%s dia=%d sala=%s requestId=%s",
         user, eventId, base.getName(), start, end, day, location, reqId);
-    if (event.getAgenda().stream().anyMatch(t -> t.getId().equals(talkId))) {
-      LOG.warnf(
-          "accion=charla_crear_rechazada motivo=duplicado charlaExistenteId=%s eventoId=%s requestId=%s",
-          talkId, eventId, reqId);
-      String msg =
-          java.net.URLEncoder.encode(
-              "Esta charla ya existe para el evento", java.nio.charset.StandardCharsets.UTF_8);
-      return Response.status(Response.Status.SEE_OTHER)
-          .header("Location", "/private/admin/events/" + eventId + "/edit?msg=" + msg)
-          .build();
-    }
+
+    // Check if talk already exists in agenda (for update vs create detection)
+    boolean isUpdate = event.getAgenda().stream().anyMatch(t -> t.getId().equals(talkId));
+
     Talk talk = new Talk(talkId, base.getName());
     talk.setDescription(base.getDescription());
     talk.setDurationMinutes(base.getDurationMinutes());
@@ -357,11 +350,12 @@ public class AdminEventResource {
     try {
       eventService.saveTalk(eventId, talk);
       LOG.infof(
-          "accion=charla_crear_exito charlaId=%s eventoId=%s requestId=%s", talkId, eventId, reqId);
-      String msg =
-          java.net.URLEncoder.encode(
-              "✅ Charla '" + base.getName() + "' agregada al evento.",
-              java.nio.charset.StandardCharsets.UTF_8);
+          "accion=charla_guardar_exito operacion=%s charlaId=%s eventoId=%s requestId=%s",
+          isUpdate ? "actualizar" : "crear", talkId, eventId, reqId);
+      String successMessage = isUpdate
+          ? "✅ Charla '" + base.getName() + "' actualizada correctamente."
+          : "✅ Charla '" + base.getName() + "' agregada al evento.";
+      String msg = java.net.URLEncoder.encode(successMessage, java.nio.charset.StandardCharsets.UTF_8);
       return Response.status(Response.Status.SEE_OTHER)
           .header("Location", "/private/admin/events/" + eventId + "/edit?msg=" + msg)
           .build();

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventResource.java
@@ -2,6 +2,7 @@ package com.scanales.homedir.private_;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.scanales.homedir.config.AppMessages;
 import com.scanales.homedir.model.Event;
 import com.scanales.homedir.model.EventType;
 import com.scanales.homedir.model.Scenario;
@@ -12,6 +13,7 @@ import com.scanales.homedir.service.SpeakerService;
 import com.scanales.homedir.util.AdminUtils;
 import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.i18n.MessageBundles;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.inject.Inject;
@@ -352,10 +354,11 @@ public class AdminEventResource {
       LOG.infof(
           "accion=charla_guardar_exito operacion=%s charlaId=%s eventoId=%s requestId=%s",
           isUpdate ? "actualizar" : "crear", talkId, eventId, reqId);
+      AppMessages i18n = MessageBundles.get(AppMessages.class);
       String successMessage =
           isUpdate
-              ? "✅ Charla '" + base.getName() + "' actualizada correctamente."
-              : "✅ Charla '" + base.getName() + "' agregada al evento.";
+              ? i18n.admin_event_talk_updated(base.getName())
+              : i18n.admin_event_talk_created(base.getName());
       String msg =
           java.net.URLEncoder.encode(successMessage, java.nio.charset.StandardCharsets.UTF_8);
       return Response.status(Response.Status.SEE_OTHER)

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventResource.java
@@ -352,10 +352,12 @@ public class AdminEventResource {
       LOG.infof(
           "accion=charla_guardar_exito operacion=%s charlaId=%s eventoId=%s requestId=%s",
           isUpdate ? "actualizar" : "crear", talkId, eventId, reqId);
-      String successMessage = isUpdate
-          ? "✅ Charla '" + base.getName() + "' actualizada correctamente."
-          : "✅ Charla '" + base.getName() + "' agregada al evento.";
-      String msg = java.net.URLEncoder.encode(successMessage, java.nio.charset.StandardCharsets.UTF_8);
+      String successMessage =
+          isUpdate
+              ? "✅ Charla '" + base.getName() + "' actualizada correctamente."
+              : "✅ Charla '" + base.getName() + "' agregada al evento.";
+      String msg =
+          java.net.URLEncoder.encode(successMessage, java.nio.charset.StandardCharsets.UTF_8);
       return Response.status(Response.Status.SEE_OTHER)
           .header("Location", "/private/admin/events/" + eventId + "/edit?msg=" + msg)
           .build();

--- a/quarkus-app/src/main/resources/i18n.properties
+++ b/quarkus-app/src/main/resources/i18n.properties
@@ -2718,3 +2718,7 @@ speaker_detail_talk_speakers_label=Speakers:
 # CFP form fields reused in profile
 events_cfp_field_title=Talk title
 events_cfp_field_abstract=Abstract
+
+# Admin - Event Talk Management
+admin_event_talk_updated=\u2705 Talk '{0}' updated successfully.
+admin_event_talk_created=\u2705 Talk '{0}' added to event.

--- a/quarkus-app/src/main/resources/i18n_en.properties
+++ b/quarkus-app/src/main/resources/i18n_en.properties
@@ -2718,3 +2718,7 @@ speaker_detail_talk_speakers_label=Speakers:
 # CFP form fields reused in profile
 events_cfp_field_title=Talk title
 events_cfp_field_abstract=Abstract
+
+# Admin - Event Talk Management
+admin_event_talk_updated=\u2705 Talk '{0}' updated successfully.
+admin_event_talk_created=\u2705 Talk '{0}' added to event.

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -2719,3 +2719,7 @@ speaker_detail_talk_speakers_label=Speakers:
 # CFP form fields reused in profile
 events_cfp_field_title=Título de la charla
 events_cfp_field_abstract=Resumen
+
+# Admin - Event Talk Management
+admin_event_talk_updated=\u2705 Charla '{0}' actualizada correctamente.
+admin_event_talk_created=\u2705 Charla '{0}' agregada al evento.


### PR DESCRIPTION
## Problem

Admin cannot update existing talk schedules in event editor:
- Admin edits existing talk (change time/location)
- Clicks "Guardar" (Save)
- Error: "Esta charla ya existe para el evento"
- Changes not saved
- URL shows: `?msg=Esta+charla+ya+existe+para+el+evento` but message already displays correctly in template

## Root Cause

`saveTalk()` endpoint serves both CREATE and UPDATE operations.

Validation at line 325 rejected ALL talks with existing talkId:
```java
if (event.getAgenda().stream().anyMatch(t -> t.getId().equals(talkId))) {
  // Reject: "Esta charla ya existe"
}
```

This blocked updates since updating a talk obviously has an existing ID.

## Solution

1. **Removed incorrect duplicate validation** (lines 325-335)
2. **Added update detection**:
   ```java
   boolean isUpdate = event.getAgenda().stream()
       .anyMatch(t -> t.getId().equals(talkId));
   ```
3. **Updated success messages**:
   - Create: "✅ Charla '{title}' agregada al evento."
   - Update: "✅ Charla '{title}' actualizada correctamente."
4. **Updated logs**: `operacion=crear` vs `operacion=actualizar`

## Changes

- `AdminEventResource.java`:
  - Lines 322-328: Removed duplicate check, added isUpdate flag
  - Lines 350-360: Dynamic success message based on operation
  - Logs now show operation type for observability

## Validation

✅ **Compiles successfully**  
✅ **Overlap detection unchanged** (different talks, same time/location still validated)  
✅ **Message display works** (template already shows msg param at line 23)  
✅ **Create flow**: Adds new talk → "agregada" message  
✅ **Update flow**: Updates existing talk → "actualizada" message  

## Impact

- Admins can now update talk schedules
- Clear feedback distinguishes create vs update
- No regression in overlap validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing talks can now be updated instead of being rejected as duplicates.
  * Confirmation messages now clearly indicate whether a talk was added or updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->