### PR TITLE
fix(speaker): handle null or empty speakers list in talk cards

### DIFF
--- a/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
@@ -92,8 +92,8 @@
     <ul class="talk-list">
       {#for t in speaker.talks}
       <li class="card talk-card">
-        <h3 class="talk-title">{t.name}{#if t.speakers[0].id != speaker.id} (Co Speaker){/if}</h3>
-        {#if t.speakers.size() > 1}
+        <h3 class="talk-title">{t.name}{#if t.speakers != null && !t.speakers.isEmpty() && t.speakers[0].id != speaker.id} (Co Speaker){/if}</h3>
+        {#if t.speakers != null && t.speakers.size() > 1}
         <div class="talk-speakers">
           <strong>{i18n:speaker_detail_talk_speakers_label}</strong>
           {#for sp in t.speakers}


### PR DESCRIPTION
## Problem

Speaker detail page fails to load (stays blue screen) when talks have null or empty speakers list.

**Affected URL:** https://homedir.opensourcesantiago.io/speaker/20260726030415?event=devopsdays-santiago-2026

- HTTP 200 returned
- Page doesn't render (stays blue)
- Console shows NPE/template error

## Root Cause

Template assumes `t.speakers` is always non-null and non-empty:

**Line 95:**
```html
{#if t.speakers[0].id != speaker.id} (Co Speaker){/if}
```
→ NPE if `speakers` is null or empty

**Line 96:**
```html
{#if t.speakers.size() > 1}
```
→ NPE if `speakers` is null

## Solution

Add null/empty checks before accessing speakers array:

**Line 95:**
```html
{#if t.speakers != null && !t.speakers.isEmpty() && t.speakers[0].id != speaker.id} (Co Speaker){/if}
```

**Line 96:**
```html
{#if t.speakers != null && t.speakers.size() > 1}
```

## Changes

- `detail.html` lines 95-96: Added null/empty guards

## Impact

✅ Speaker pages load even with legacy/incomplete talk data  
✅ Co-speaker labels display correctly when data available  
✅ Graceful degradation when speakers list missing  
✅ No regression for talks with proper speakers data  

## Validation

- Existing speakers with complete data: works as before
- Speakers with null/empty speakers list: page loads, no crash
- Co-speaker labels: only show when data exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented speaker detail pages from displaying template errors when talks have no speaker data.
  * Improved co-speaker label handling so it appears only when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->