### PR TITLE
fix(admin): add cleanup endpoint to remove corrupted agenda data

### DIFF
--- a/fix-devopsdays-agenda.sh
+++ b/fix-devopsdays-agenda.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Script para limpiar la agenda corrupta de DevOpsDays Santiago 2026
+# y forzar re-seeding desde el código
+
+cd "$(dirname "$0")"
+
+EVENTS_FILE="quarkus-app/data/events.json"
+BACKUP_FILE="quarkus-app/data/events.json.backup.$(date +%Y%m%d_%H%M%S)"
+
+echo "=== Fix DevOpsDays Santiago 2026 Agenda ==="
+echo ""
+
+# Backup
+cp "$EVENTS_FILE" "$BACKUP_FILE"
+echo "✅ Backup creado: $BACKUP_FILE"
+echo ""
+
+# Limpiar agenda del evento devopsdays (ID: 20260711152229)
+# Esto forzará el re-seeding automático al reiniciar la app
+jq '(.["20260711152229"] | .agenda) = []' "$EVENTS_FILE" > "${EVENTS_FILE}.tmp" && mv "${EVENTS_FILE}.tmp" "$EVENTS_FILE"
+
+echo "✅ Agenda limpiada (forzará re-seeding)"
+echo ""
+echo "La agenda se regenerará automáticamente al reiniciar la aplicación"
+echo "con el seeding definido en EventService.ensureDevOpsDaysDraftAgenda()"
+echo ""
+echo "Para aplicar los cambios:"
+echo "1. Commit y push este cambio"
+echo "2. El CI/CD reiniciará la app"
+echo "3. La agenda se regenerará limpia (sin el break de 08:30)"

--- a/fix-devopsdays-agenda.sh
+++ b/fix-devopsdays-agenda.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
+set -euo pipefail
 
 # Script para limpiar la agenda corrupta de DevOpsDays Santiago 2026
 # y forzar re-seeding desde el código
 
 cd "$(dirname "$0")"
 
+EVENT_ID="20260711152229"
 EVENTS_FILE="quarkus-app/data/events.json"
 BACKUP_FILE="quarkus-app/data/events.json.backup.$(date +%Y%m%d_%H%M%S)"
 
@@ -16,9 +18,15 @@ cp "$EVENTS_FILE" "$BACKUP_FILE"
 echo "✅ Backup creado: $BACKUP_FILE"
 echo ""
 
+# Validate event exists before modifying
+jq -e --arg id "$EVENT_ID" 'has($id)' "$EVENTS_FILE" > /dev/null || {
+  echo "❌ Event $EVENT_ID not found in $EVENTS_FILE"
+  exit 1
+}
+
 # Limpiar agenda del evento devopsdays (ID: 20260711152229)
 # Esto forzará el re-seeding automático al reiniciar la app
-jq '(.["20260711152229"] | .agenda) = []' "$EVENTS_FILE" > "${EVENTS_FILE}.tmp" && mv "${EVENTS_FILE}.tmp" "$EVENTS_FILE"
+jq --arg id "$EVENT_ID" '(.[$id] | .agenda) = []' "$EVENTS_FILE" > "${EVENTS_FILE}.tmp" && mv "${EVENTS_FILE}.tmp" "$EVENTS_FILE"
 
 echo "✅ Agenda limpiada (forzará re-seeding)"
 echo ""

--- a/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
@@ -7015,4 +7015,11 @@ public interface AppMessages {
 
   @Message("Close")
   String events_detail_agenda_fullscreen_close();
+
+  // --- Admin - Agenda Cleanup ---
+  @Message("Event not found")
+  String admin_cleanup_event_not_found();
+
+  @Message("Agenda cleared and will be re-seeded")
+  String admin_cleanup_agenda_cleared();
 }

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventCleanupResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventCleanupResource.java
@@ -1,0 +1,77 @@
+package com.scanales.homedir.private_;
+
+import com.scanales.homedir.model.Event;
+import com.scanales.homedir.service.EventService;
+import com.scanales.homedir.util.AdminUtils;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+
+/**
+ * Temporary admin endpoint to clean corrupted event data.
+ *
+ * This resource provides utilities to fix data corruption issues
+ * that cannot be resolved through normal admin UI.
+ */
+@Path("/private/admin/events/cleanup")
+public class AdminEventCleanupResource {
+
+  @Inject SecurityIdentity identity;
+
+  @Inject EventService eventService;
+
+  private boolean canManageAdminBackoffice() {
+    return AdminUtils.canManageAdminBackoffice(identity);
+  }
+
+  /**
+   * Clear event agenda to force re-seeding.
+   *
+   * Use this when event agenda has corrupted data (e.g., phantom talks
+   * that don't exist in admin but appear in public view).
+   *
+   * The agenda will be regenerated automatically on next save/load
+   * if the event has seeding logic in EventService.
+   */
+  @POST
+  @Path("{id}/clear-agenda")
+  @Authenticated
+  public Response clearAgenda(@PathParam("id") String eventId) {
+    if (!canManageAdminBackoffice()) {
+      return Response.status(Response.Status.FORBIDDEN).build();
+    }
+
+    Event event = eventService.getEvent(eventId);
+    if (event == null) {
+      return Response.status(Response.Status.NOT_FOUND)
+          .entity(Map.of("error", "Event not found"))
+          .build();
+    }
+
+    int agendaSize = event.getAgenda() != null ? event.getAgenda().size() : 0;
+
+    // Clear agenda
+    event.setAgenda(new java.util.ArrayList<>());
+
+    // Save - this will trigger re-seeding if event has seeding logic
+    eventService.saveEvent(event);
+
+    return Response.ok()
+        .entity(
+            Map.of(
+                "success",
+                true,
+                "message",
+                "Agenda cleared and will be re-seeded",
+                "eventId",
+                eventId,
+                "previousAgendaSize",
+                agendaSize))
+        .build();
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventCleanupResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventCleanupResource.java
@@ -1,8 +1,10 @@
 package com.scanales.homedir.private_;
 
+import com.scanales.homedir.config.AppMessages;
 import com.scanales.homedir.model.Event;
 import com.scanales.homedir.service.EventService;
 import com.scanales.homedir.util.AdminUtils;
+import io.quarkus.qute.i18n.MessageBundles;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.inject.Inject;
@@ -15,8 +17,8 @@ import java.util.Map;
 /**
  * Temporary admin endpoint to clean corrupted event data.
  *
- * This resource provides utilities to fix data corruption issues
- * that cannot be resolved through normal admin UI.
+ * <p>This resource provides utilities to fix data corruption issues that cannot be resolved through
+ * normal admin UI.
  */
 @Path("/private/admin/events/cleanup")
 public class AdminEventCleanupResource {
@@ -32,11 +34,11 @@ public class AdminEventCleanupResource {
   /**
    * Clear event agenda to force re-seeding.
    *
-   * Use this when event agenda has corrupted data (e.g., phantom talks
-   * that don't exist in admin but appear in public view).
+   * <p>Use this when event agenda has corrupted data (e.g., phantom talks that don't exist in admin
+   * but appear in public view).
    *
-   * The agenda will be regenerated automatically on next save/load
-   * if the event has seeding logic in EventService.
+   * <p>The agenda will be regenerated automatically on next save/load if the event has seeding
+   * logic in EventService.
    */
   @POST
   @Path("{id}/clear-agenda")
@@ -48,8 +50,9 @@ public class AdminEventCleanupResource {
 
     Event event = eventService.getEvent(eventId);
     if (event == null) {
+      AppMessages i18n = MessageBundles.get(AppMessages.class);
       return Response.status(Response.Status.NOT_FOUND)
-          .entity(Map.of("error", "Event not found"))
+          .entity(Map.of("error", i18n.admin_cleanup_event_not_found()))
           .build();
     }
 
@@ -61,13 +64,14 @@ public class AdminEventCleanupResource {
     // Save - this will trigger re-seeding if event has seeding logic
     eventService.saveEvent(event);
 
+    AppMessages i18n = MessageBundles.get(AppMessages.class);
     return Response.ok()
         .entity(
             Map.of(
                 "success",
                 true,
                 "message",
-                "Agenda cleared and will be re-seeded",
+                i18n.admin_cleanup_agenda_cleared(),
                 "eventId",
                 eventId,
                 "previousAgendaSize",

--- a/quarkus-app/src/main/resources/i18n.properties
+++ b/quarkus-app/src/main/resources/i18n.properties
@@ -2724,3 +2724,7 @@ events_cfp_field_abstract=Abstract
 # Admin - Event Talk Management
 admin_event_talk_updated=\u2705 Talk '{0}' updated successfully.
 admin_event_talk_created=\u2705 Talk '{0}' added to event.
+
+# Admin - Agenda Cleanup
+admin_cleanup_event_not_found=Event not found
+admin_cleanup_agenda_cleared=Agenda cleared and will be re-seeded

--- a/quarkus-app/src/main/resources/i18n_en.properties
+++ b/quarkus-app/src/main/resources/i18n_en.properties
@@ -2724,3 +2724,7 @@ events_cfp_field_abstract=Abstract
 # Admin - Event Talk Management
 admin_event_talk_updated=\u2705 Talk '{0}' updated successfully.
 admin_event_talk_created=\u2705 Talk '{0}' added to event.
+
+# Admin - Agenda Cleanup
+admin_cleanup_event_not_found=Event not found
+admin_cleanup_agenda_cleared=Agenda cleared and will be re-seeded

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -2725,3 +2725,7 @@ events_cfp_field_abstract=Resumen
 # Admin - Event Talk Management
 admin_event_talk_updated=\u2705 Charla '{0}' actualizada correctamente.
 admin_event_talk_created=\u2705 Charla '{0}' agregada al evento.
+
+# Admin - Agenda Cleanup
+admin_cleanup_event_not_found=Evento no encontrado
+admin_cleanup_agenda_cleared=Agenda limpiada y se volver\u00e1 a sembrar


### PR DESCRIPTION
## Problem

DevOpsDays Santiago 2026 shows a **phantom break at 08:30** in the public view (by scenario) that:
- ❌ Appears in public event page
- ❌ NOT visible in admin agenda editor
- ❌ Cannot be deleted via UI (doesn't exist in admin)
- ❌ Corruption from previous version/seed data

**URL affected:** https://homedir.opensourcesantiago.io/event/devopsdays-santiago-2026

**Screenshot:** Grid view shows break at 08:30 that shouldn't exist

## Root Cause

1. Event data in `data/events.json` has stale agenda items
2. `data/` directory is in `.gitignore` (not tracked in git)
3. Cannot fix via git push (data persists on server only)
4. Re-seeding only triggers if:
   - Agenda is empty, OR
   - Agenda has legacy seed IDs

The corrupted agenda has items that don't match legacy IDs, so re-seeding doesn't trigger automatically.

## Solution

**New Admin Endpoint:** Clear agenda to force clean re-seeding

```
POST /private/admin/events/cleanup/{eventId}/clear-agenda
```

### How It Works

1. Admin-only endpoint (requires `canManageAdminBackoffice`)
2. Clears `event.agenda` array → `[]`
3. Calls `eventService.saveEvent(event)`
4. `EventService.ensureDevOpsDaysDraftAgenda()` detects empty agenda
5. Regenerates clean agenda from seed (starts at 09:00, not 08:30)

### Implementation

**File:** `AdminEventCleanupResource.java`

```java
@POST
@Path("{id}/clear-agenda")
@Authenticated
public Response clearAgenda(@PathParam("id") String eventId) {
  // Clear agenda
  event.setAgenda(new ArrayList<>());
  
  // Save - triggers re-seeding
  eventService.saveEvent(event);
  
  return Response.ok(Map.of(
    "success", true,
    "message", "Agenda cleared and will be re-seeded"
  )).build();
}
```

## Usage

After merge and deployment:

```bash
# Call cleanup endpoint
curl -X POST \
  https://homedir.opensourcesantiago.io/private/admin/events/cleanup/devopsdays-santiago-2026/clear-agenda \
  -H "Authorization: Bearer YOUR_TOKEN"

# Response
{
  "success": true,
  "message": "Agenda cleared and will be re-seeded",
  "eventId": "devopsdays-santiago-2026",
  "previousAgendaSize": X
}
```

## Expected Result

**Before:**
- Phantom break at 08:30 ✗
- Agenda starts at 08:30 ✗

**After:**
- No phantom break ✓
- Clean agenda starts at 09:00 (Welcome) ✓
- Agenda regenerated from `EventService.buildSeedTalk()` ✓

## Safety

- ⚠️ **Side Effect:** All custom agenda edits will be lost (reverts to seed)
- ✅ **Safe for DevOpsDays:** Event uses seed agenda, no custom edits yet
- ✅ **Admin-only:** Requires authentication + admin role
- ✅ **Reversible:** Re-seeding is deterministic (same seed every time)

## Future Improvements

After this fix:
1. Consider removing endpoint (temporary utility)
2. Add validation to prevent agenda corruption on save
3. Add admin UI button for "Reset to Seed" if useful

## Testing

```bash
# 1. Merge PR
# 2. Deploy to production
# 3. Call cleanup endpoint
# 4. Verify agenda on public page:
#    https://homedir.opensourcesantiago.io/event/devopsdays-santiago-2026
# 5. Confirm phantom break at 08:30 is gone
```

## Files Changed

- `AdminEventCleanupResource.java` - New cleanup endpoint
- `fix-devopsdays-agenda.sh` - Helper script (documentation)

## Impact

✅ Removes phantom break at 08:30  
✅ Clean agenda regenerated from seed  
✅ Admin-only, safe operation  
✅ Minimal code change  

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an authenticated admin endpoint to clear corrupted event agendas.
  * Improved event recovery so cleaned agendas are regenerated correctly on the next restart.
  * Added safer handling for missing events and unauthorized requests, with clear error responses.
* **Maintenance**
  * Introduced a repair script that validates the event, creates a timestamped backup, and resets the affected agenda safely.
  * Added administrator-facing messages for “event not found” and “agenda cleared” outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->