### PR TITLE
feat(admin): agenda import endpoint with file upload UI

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventResource.java
@@ -621,6 +621,194 @@ public class AdminEventResource {
     }
   }
 
+  @POST
+  @Path("{id}/import-agenda")
+  @Authenticated
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response importAgenda(
+      @PathParam("id") String eventId, @FormParam("file") FileUpload file) {
+    if (!canManageAdminBackoffice()) {
+      return Response.status(Response.Status.FORBIDDEN)
+          .entity(java.util.Map.of("success", false, "error", "Unauthorized"))
+          .build();
+    }
+
+    if (file == null) {
+      LOG.warn("No file received for agenda import");
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity(java.util.Map.of("success", false, "error", "Archivo requerido"))
+          .build();
+    }
+
+    LOG.infov("Importing agenda for event {0} from file {1}", eventId, file.fileName());
+
+    Event event = eventService.getEvent(eventId);
+    if (event == null) {
+      return Response.status(Response.Status.NOT_FOUND)
+          .entity(java.util.Map.of("success", false, "error", "Evento no encontrado"))
+          .build();
+    }
+
+    try {
+      java.nio.file.Path path = file.uploadedFile();
+      AgendaImportDTO agendaData;
+      try (var is = java.nio.file.Files.newInputStream(path)) {
+        agendaData = objectMapper.readValue(is, AgendaImportDTO.class);
+      }
+
+      int scenariosAdded = 0;
+      int talksAdded = 0;
+      int breaksAdded = 0;
+
+      // Import scenarios
+      if (agendaData.scenarios() != null) {
+        var existingScenarios = event.getScenarios();
+        if (existingScenarios == null) {
+          existingScenarios = new java.util.ArrayList<>();
+          event.setScenarios(existingScenarios);
+        }
+        for (var scenarioDTO : agendaData.scenarios()) {
+          // Check if scenario already exists
+          boolean exists =
+              existingScenarios.stream()
+                  .anyMatch(s -> s.getId().equals(scenarioDTO.id()));
+          if (!exists) {
+            var scenario = new Scenario();
+            scenario.setId(scenarioDTO.id());
+            scenario.setName(scenarioDTO.name());
+            scenario.setFeatures(scenarioDTO.features());
+            scenario.setLocation(scenarioDTO.location());
+            existingScenarios.add(scenario);
+            scenariosAdded++;
+          }
+        }
+      }
+
+      // Import talks and breaks
+      var existingAgenda = event.getAgenda();
+      if (existingAgenda == null) {
+        existingAgenda = new java.util.ArrayList<>();
+        event.setAgenda(existingAgenda);
+      }
+
+      // Import talks
+      if (agendaData.talks() != null) {
+        for (var talkDTO : agendaData.talks()) {
+          // Check if talk already exists
+          boolean exists =
+              existingAgenda.stream()
+                  .anyMatch(t -> t.getId().equals(talkDTO.id()));
+          if (!exists) {
+            var talk = new Talk();
+            talk.setId(talkDTO.id());
+            talk.setName(talkDTO.name());
+            talk.setDescription(
+                talkDTO.description() != null ? talkDTO.description() : "");
+            talk.setLocation(talkDTO.scenarioId());
+            talk.setDurationMinutes(talkDTO.durationMinutes());
+            talk.setDay(talkDTO.day());
+
+            // Parse start time (format: "HH:MM AM/PM" or "HH:MM")
+            try {
+              String timeStr = talkDTO.startTime().trim();
+              java.time.LocalTime startTime;
+              if (timeStr.contains("AM") || timeStr.contains("PM")) {
+                // 12-hour format
+                startTime =
+                    java.time.LocalTime.parse(
+                        timeStr, java.time.format.DateTimeFormatter.ofPattern("hh:mm a"));
+              } else {
+                // 24-hour format
+                startTime = java.time.LocalTime.parse(timeStr);
+              }
+              talk.setStartTime(startTime);
+            } catch (Exception e) {
+              LOG.warnf("Failed to parse time %s for talk %s, using midnight", talkDTO.startTime(), talkDTO.id());
+              talk.setStartTime(java.time.LocalTime.MIDNIGHT);
+            }
+
+            // Create speaker
+            var speaker = new Speaker(talkDTO.speakerId(), talkDTO.speakerName());
+            talk.setSpeakers(java.util.List.of(speaker));
+
+            existingAgenda.add(talk);
+            talksAdded++;
+          }
+        }
+      }
+
+      // Import breaks
+      if (agendaData.breaks() != null) {
+        for (var breakDTO : agendaData.breaks()) {
+          // Check if break already exists
+          boolean exists =
+              existingAgenda.stream()
+                  .anyMatch(t -> t.getId().equals(breakDTO.id()));
+          if (!exists) {
+            var talk = new Talk();
+            talk.setId(breakDTO.id());
+            talk.setName(breakDTO.name());
+            talk.setDescription("Break");
+            talk.setLocation(breakDTO.scenarioId());
+            talk.setDurationMinutes(breakDTO.durationMinutes());
+            talk.setDay(breakDTO.day());
+
+            // Parse start time
+            try {
+              String timeStr = breakDTO.startTime().trim();
+              java.time.LocalTime startTime;
+              if (timeStr.contains("AM") || timeStr.contains("PM")) {
+                startTime =
+                    java.time.LocalTime.parse(
+                        timeStr, java.time.format.DateTimeFormatter.ofPattern("hh:mm a"));
+              } else {
+                startTime = java.time.LocalTime.parse(timeStr);
+              }
+              talk.setStartTime(startTime);
+            } catch (Exception e) {
+              LOG.warnf("Failed to parse time %s for break %s, using midnight", breakDTO.startTime(), breakDTO.id());
+              talk.setStartTime(java.time.LocalTime.MIDNIGHT);
+            }
+
+            // Mark as break
+            talk.setSpeakers(java.util.List.of());
+
+            existingAgenda.add(talk);
+            breaksAdded++;
+          }
+        }
+      }
+
+      // Save event
+      eventService.saveEvent(event);
+
+      LOG.infov(
+          "Agenda import completed for event {0}: {1} scenarios, {2} talks, {3} breaks",
+          eventId, scenariosAdded, talksAdded, breaksAdded);
+
+      return Response.ok()
+          .entity(
+              java.util.Map.of(
+                  "success", true,
+                  "scenariosAdded", scenariosAdded,
+                  "talksAdded", talksAdded,
+                  "breaksAdded", breaksAdded,
+                  "message",
+                      String.format(
+                          "Importación exitosa: %d escenarios, %d charlas, %d breaks",
+                          scenariosAdded, talksAdded, breaksAdded)))
+          .build();
+
+    } catch (Exception e) {
+      LOG.error("Failed to import agenda", e);
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity(
+              java.util.Map.of("success", false, "error", "JSON inválido: " + e.getMessage()))
+          .build();
+    }
+  }
+
   private java.util.List<EventType> eventTypes() {
     return java.util.List.of(EventType.values());
   }

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventResource.java
@@ -42,7 +42,8 @@ public class AdminEventResource {
         Event event,
         java.util.List<Speaker> speakers,
         java.util.List<EventType> types,
-        String message);
+        String message,
+        String eventId);
   }
 
   @Inject SecurityIdentity identity;
@@ -84,7 +85,7 @@ public class AdminEventResource {
       return Response.status(Response.Status.FORBIDDEN).build();
     }
     return Response.ok(
-            Templates.edit(new Event(), speakerService.listSpeakers(), eventTypes(), message))
+            Templates.edit(new Event(), speakerService.listSpeakers(), eventTypes(), message, null))
         .build();
   }
 
@@ -100,7 +101,9 @@ public class AdminEventResource {
     if (event == null) {
       return Response.status(Response.Status.NOT_FOUND).build();
     }
-    return Response.ok(Templates.edit(event, speakerService.listSpeakers(), eventTypes(), message))
+    return Response.ok(
+            Templates.edit(
+                event, speakerService.listSpeakers(), eventTypes(), message, event.getId()))
         .build();
   }
 
@@ -671,8 +674,7 @@ public class AdminEventResource {
         for (var scenarioDTO : agendaData.scenarios()) {
           // Check if scenario already exists
           boolean exists =
-              existingScenarios.stream()
-                  .anyMatch(s -> s.getId().equals(scenarioDTO.id()));
+              existingScenarios.stream().anyMatch(s -> s.getId().equals(scenarioDTO.id()));
           if (!exists) {
             var scenario = new Scenario();
             scenario.setId(scenarioDTO.id());
@@ -696,15 +698,12 @@ public class AdminEventResource {
       if (agendaData.talks() != null) {
         for (var talkDTO : agendaData.talks()) {
           // Check if talk already exists
-          boolean exists =
-              existingAgenda.stream()
-                  .anyMatch(t -> t.getId().equals(talkDTO.id()));
+          boolean exists = existingAgenda.stream().anyMatch(t -> t.getId().equals(talkDTO.id()));
           if (!exists) {
             var talk = new Talk();
             talk.setId(talkDTO.id());
             talk.setName(talkDTO.name());
-            talk.setDescription(
-                talkDTO.description() != null ? talkDTO.description() : "");
+            talk.setDescription(talkDTO.description() != null ? talkDTO.description() : "");
             talk.setLocation(talkDTO.scenarioId());
             talk.setDurationMinutes(talkDTO.durationMinutes());
             talk.setDay(talkDTO.day());
@@ -724,7 +723,9 @@ public class AdminEventResource {
               }
               talk.setStartTime(startTime);
             } catch (Exception e) {
-              LOG.warnf("Failed to parse time %s for talk %s, using midnight", talkDTO.startTime(), talkDTO.id());
+              LOG.warnf(
+                  "Failed to parse time %s for talk %s, using midnight",
+                  talkDTO.startTime(), talkDTO.id());
               talk.setStartTime(java.time.LocalTime.MIDNIGHT);
             }
 
@@ -742,9 +743,7 @@ public class AdminEventResource {
       if (agendaData.breaks() != null) {
         for (var breakDTO : agendaData.breaks()) {
           // Check if break already exists
-          boolean exists =
-              existingAgenda.stream()
-                  .anyMatch(t -> t.getId().equals(breakDTO.id()));
+          boolean exists = existingAgenda.stream().anyMatch(t -> t.getId().equals(breakDTO.id()));
           if (!exists) {
             var talk = new Talk();
             talk.setId(breakDTO.id());
@@ -767,7 +766,9 @@ public class AdminEventResource {
               }
               talk.setStartTime(startTime);
             } catch (Exception e) {
-              LOG.warnf("Failed to parse time %s for break %s, using midnight", breakDTO.startTime(), breakDTO.id());
+              LOG.warnf(
+                  "Failed to parse time %s for break %s, using midnight",
+                  breakDTO.startTime(), breakDTO.id());
               talk.setStartTime(java.time.LocalTime.MIDNIGHT);
             }
 
@@ -803,8 +804,7 @@ public class AdminEventResource {
     } catch (Exception e) {
       LOG.error("Failed to import agenda", e);
       return Response.status(Response.Status.BAD_REQUEST)
-          .entity(
-              java.util.Map.of("success", false, "error", "JSON inválido: " + e.getMessage()))
+          .entity(java.util.Map.of("success", false, "error", "JSON inválido: " + e.getMessage()))
           .build();
     }
   }

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/AgendaImportDTO.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/AgendaImportDTO.java
@@ -1,0 +1,28 @@
+package com.scanales.homedir.private_;
+
+import java.util.List;
+
+/**
+ * DTO for agenda import containing scenarios, talks, and breaks.
+ */
+public record AgendaImportDTO(
+    List<ScenarioDTO> scenarios,
+    List<TalkDTO> talks,
+    List<BreakDTO> breaks) {
+
+  public record ScenarioDTO(String id, String name, String features, String location) {}
+
+  public record TalkDTO(
+      String id,
+      String name,
+      String speakerId,
+      String speakerName,
+      String scenarioId,
+      String startTime,
+      int day,
+      int durationMinutes,
+      String description) {}
+
+  public record BreakDTO(
+      String id, String name, int durationMinutes, String scenarioId, String startTime, int day) {}
+}

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/AgendaImportDTO.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/AgendaImportDTO.java
@@ -2,13 +2,9 @@ package com.scanales.homedir.private_;
 
 import java.util.List;
 
-/**
- * DTO for agenda import containing scenarios, talks, and breaks.
- */
+/** DTO for agenda import containing scenarios, talks, and breaks. */
 public record AgendaImportDTO(
-    List<ScenarioDTO> scenarios,
-    List<TalkDTO> talks,
-    List<BreakDTO> breaks) {
+    List<ScenarioDTO> scenarios, List<TalkDTO> talks, List<BreakDTO> breaks) {
 
   public record ScenarioDTO(String id, String name, String features, String location) {}
 

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -205,6 +205,27 @@ Nuevo Evento · Homedir
   </div>
 
   {#if event.id}
+  <!-- Import Agenda Section -->
+  <div id="import-agenda" class="card">
+    <h2 class="card-title">Importar Agenda</h2>
+    <p class="form-hint" style="margin-bottom: 1rem;">
+      Importa escenarios, charlas y breaks desde un archivo JSON. Los elementos duplicados (mismo ID) serán ignorados.
+    </p>
+    <form id="import-agenda-form" enctype="multipart/form-data" style="margin-bottom: 1rem;">
+      {#include fragments/csrf-token.html /}
+      <div style="display: flex; gap: 1rem; align-items: end;">
+        <div class="form-group" style="flex: 1;">
+          <label class="form-label" for="agenda-file-input">Archivo JSON</label>
+          <input type="file" id="agenda-file-input" name="file" accept="application/json,.json" class="form-input" required>
+        </div>
+        <button type="submit" class="btn btn--primary" id="import-agenda-btn">
+          Importar Agenda
+        </button>
+      </div>
+    </form>
+    <div id="import-result" style="display: none; padding: 1rem; border-radius: var(--radius-sm); margin-top: 1rem;"></div>
+  </div>
+
   <div id="scenarios" class="card">
     <h2 class="card-title">Escenarios</h2>
     {#for sc in event.scenarios}
@@ -487,6 +508,69 @@ Nuevo Evento · Homedir
       input.addEventListener('change', syncColorPreview);
       syncColorPreview();
     });
+
+    // Import agenda form handler
+    const importForm = document.getElementById('import-agenda-form');
+    const importResult = document.getElementById('import-result');
+    const importBtn = document.getElementById('import-agenda-btn');
+
+    if (importForm && importResult && importBtn) {
+      importForm.addEventListener('submit', async function (e) {
+        e.preventDefault();
+
+        const fileInput = document.getElementById('agenda-file-input');
+        if (!fileInput.files.length) {
+          showImportResult('error', 'Por favor selecciona un archivo');
+          return;
+        }
+
+        const formData = new FormData(importForm);
+        importBtn.disabled = true;
+        importBtn.textContent = 'Importando...';
+        showImportResult('info', 'Procesando archivo...');
+
+        try {
+          const eventId = '{event.id}';
+          const response = await fetch(`/private/admin/events/${eventId}/import-agenda`, {
+            method: 'POST',
+            body: formData
+          });
+
+          const result = await response.json();
+
+          if (result.success) {
+            showImportResult('success', result.message || 'Importación exitosa');
+            // Reload page after 2 seconds to show imported items
+            setTimeout(() => window.location.reload(), 2000);
+          } else {
+            showImportResult('error', result.error || 'Error en la importación');
+          }
+        } catch (error) {
+          showImportResult('error', 'Error de red: ' + error.message);
+        } finally {
+          importBtn.disabled = false;
+          importBtn.textContent = 'Importar Agenda';
+        }
+      });
+
+      function showImportResult(type, message) {
+        importResult.style.display = 'block';
+        if (type === 'success') {
+          importResult.style.background = 'rgba(46, 213, 115, 0.1)';
+          importResult.style.border = '1px solid rgba(46, 213, 115, 0.3)';
+          importResult.style.color = '#2ed573';
+        } else if (type === 'error') {
+          importResult.style.background = 'rgba(255, 71, 87, 0.1)';
+          importResult.style.border = '1px solid rgba(255, 71, 87, 0.3)';
+          importResult.style.color = '#ff4757';
+        } else {
+          importResult.style.background = 'rgba(255, 165, 0, 0.1)';
+          importResult.style.border = '1px solid rgba(255, 165, 0, 0.3)';
+          importResult.style.color = '#ffa500';
+        }
+        importResult.textContent = message;
+      }
+    }
   })();
 </script>
 {/body}

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -530,7 +530,7 @@ Nuevo Evento · Homedir
         showImportResult('info', 'Procesando archivo...');
 
         try {
-          const eventId = '{event.id}';
+          const eventId = '{eventId}';
           const response = await fetch(`/private/admin/events/${eventId}/import-agenda`, {
             method: 'POST',
             body: formData

--- a/restore-devopsdays-agenda.json
+++ b/restore-devopsdays-agenda.json
@@ -1,0 +1,320 @@
+{
+  "scenarios": [
+    {
+      "id": "main-stage",
+      "name": "Auditorio Principal",
+      "features": "700+ personas",
+      "location": "Centro de Extension UC - Alameda, Santiago, Chile"
+    },
+    {
+      "id": "devopsdays-santiago-2026-sala-20260726015926",
+      "name": "Sala A",
+      "features": "100 personas",
+      "location": "Centro de Extension UC - Alameda, Santiago, Chile"
+    },
+    {
+      "id": "devopsdays-santiago-2026-sala-20260726015940",
+      "name": "Sala B",
+      "features": "100 personas",
+      "location": "Centro de Extension UC - Alameda, Santiago, Chile"
+    },
+    {
+      "id": "devopsdays-santiago-2026-sala-20260726020549",
+      "name": "Plaza Principal",
+      "features": "Área de Patrocinadores, Comunidades y Recreación",
+      "location": "Centro de Extension UC - Alameda, Santiago, Chile"
+    }
+  ],
+  "talks": [
+    {
+      "id": "20260726030415-talk-20260726031310",
+      "name": "DevOps ha muerto, larga vida al DevOps: de servir aplicaciones a servir modelos",
+      "speakerId": "matias-sonnleitner",
+      "speakerName": "Matias Sonnleitner",
+      "scenarioId": "main-stage",
+      "startTime": "09:00",
+      "day": 1,
+      "durationMinutes": 30
+    },
+    {
+      "id": "20260726031955-talk-20260726032027",
+      "name": "Platinum - Trabajando con IA: Cómo cambiarán los equipos tecnológicos en los próximos 5 años",
+      "speakerId": "panel",
+      "speakerName": "Panel",
+      "scenarioId": "main-stage",
+      "startTime": "09:30",
+      "day": 1,
+      "durationMinutes": 30
+    },
+    {
+      "id": "20260726032807-talk-20260726032835",
+      "name": "Por confirmar",
+      "speakerId": "platinum-mondini",
+      "speakerName": "Platinum: Mondini IT",
+      "scenarioId": "main-stage",
+      "startTime": "10:30",
+      "day": 1,
+      "durationMinutes": 30
+    },
+    {
+      "id": "20260726032520-talk-20260726033021",
+      "name": "Conoce a nuestro Patrocinadores Día 1",
+      "speakerId": "actividad",
+      "speakerName": "Actividad",
+      "scenarioId": "main-stage",
+      "startTime": "11:30",
+      "day": 1,
+      "durationMinutes": 30
+    },
+    {
+      "id": "20260726031955-talk-20260726033453",
+      "name": "Organizadores - Más allá de la IA: la evolución de las comunidades DevOps en LATAM en un mundo de IA",
+      "speakerId": "panel-organizadores",
+      "speakerName": "Panel",
+      "scenarioId": "main-stage",
+      "startTime": "12:00",
+      "day": 1,
+      "durationMinutes": 60
+    },
+    {
+      "id": "devopsdays-santiag-cfp-f452cd67-716f-4d05-b18c",
+      "name": "El pod que tumbó la cadena: descubriendo fallas en cascada con Chaos Engineering en Kubernetes",
+      "speakerId": "alvaro-navarro",
+      "speakerName": "Álvaro Nicolas Navarro Castro",
+      "scenarioId": "devopsdays-santiago-2026-sala-20260726015926",
+      "startTime": "12:00",
+      "day": 1,
+      "durationMinutes": 30
+    },
+    {
+      "id": "devopsdays-santiag-cfp-3be12da8-cf69-45ad-9754",
+      "name": "Tu LLM es un Nodo Bizantino: Patrones de Consenso para DevOps con IA",
+      "speakerId": "felipe-carvajal",
+      "speakerName": "Felipe Carvajal Brown",
+      "scenarioId": "devopsdays-santiago-2026-sala-20260726015940",
+      "startTime": "12:00",
+      "day": 1,
+      "durationMinutes": 30
+    },
+    {
+      "id": "20260726024614-talk-20260726024844",
+      "name": "Infraestructura Cognitiva: De Alertas a Investigación Autónoma con AWS y Agentes de IA",
+      "speakerId": "gabriel-grobier",
+      "speakerName": "Gabriel Grobier Romo",
+      "scenarioId": "devopsdays-santiago-2026-sala-20260726015926",
+      "startTime": "12:30",
+      "day": 1,
+      "durationMinutes": 30
+    },
+    {
+      "id": "devopsdays-santiag-cfp-8f3bfc19-f034-4257-997c",
+      "name": "Hardening Cloud-Native CI/CD: Applying OWASPs Top 10 CI/CD Risks in Kubernetes",
+      "speakerId": "xavier-llauca",
+      "speakerName": "Xavier Llauca",
+      "scenarioId": "devopsdays-santiago-2026-sala-20260726015940",
+      "startTime": "12:30",
+      "day": 1,
+      "durationMinutes": 30
+    },
+    {
+      "id": "20260726030330-talk-20260726160854",
+      "name": "Supercharging DevOps with Google Antigravity and Claude AI",
+      "speakerId": "camilla-martins",
+      "speakerName": "Camilla Martins",
+      "scenarioId": "devopsdays-santiago-2026-sala-20260726015926",
+      "startTime": "14:30",
+      "day": 1,
+      "durationMinutes": 30
+    },
+    {
+      "id": "20260726022751-talk-20260726023507",
+      "name": "Semantic Routing: El Corazón Inteligente de los Agentes",
+      "speakerId": "carlos-estay",
+      "speakerName": "Carlos Estay González",
+      "scenarioId": "devopsdays-santiago-2026-sala-20260726015940",
+      "startTime": "14:30",
+      "day": 1,
+      "durationMinutes": 60
+    },
+    {
+      "id": "20260726033816-talk-20260726033840",
+      "name": "De ClickOps a GitOps: Cómo operar IA Privada en Producción con SUSE AI Factory y SUSE Rancher",
+      "speakerId": "cesar-lorca",
+      "speakerName": "César Lorca Bacian",
+      "scenarioId": "main-stage",
+      "startTime": "14:30",
+      "day": 1,
+      "durationMinutes": 30
+    },
+    {
+      "id": "german.blanch@gmail.com-talk-20260726021220",
+      "name": "Cuando la fábrica del software se vuelve el objetivo",
+      "speakerId": "german-blanch",
+      "speakerName": "Germán Blanch",
+      "scenarioId": "main-stage",
+      "startTime": "15:00",
+      "day": 1,
+      "durationMinutes": 30
+    },
+    {
+      "id": "devopsdays-santiag-cfp-58cbdabc-87a6-4c82-8435",
+      "name": "Un caso real con Wide Events: Cómo mejoramos nuestra observabilidad y detectamos problemas en tiempo real",
+      "speakerId": "alonso-utreras",
+      "speakerName": "Alonso Utreras",
+      "scenarioId": "devopsdays-santiago-2026-sala-20260726015926",
+      "startTime": "15:00",
+      "day": 1,
+      "durationMinutes": 30
+    },
+    {
+      "id": "20260726033151-talk-20260726033213",
+      "name": "Por confirmar",
+      "speakerId": "platinum-dynatrace",
+      "speakerName": "Platinum: Dynatrace",
+      "scenarioId": "main-stage",
+      "startTime": "15:30",
+      "day": 1,
+      "durationMinutes": 30
+    },
+    {
+      "id": "20260726032520-talk-20260726034331",
+      "name": "Cierre Día 1 + Anuncios + Llamado a Networking",
+      "speakerId": "actividad",
+      "speakerName": "Actividad",
+      "scenarioId": "main-stage",
+      "startTime": "16:00",
+      "day": 1,
+      "durationMinutes": 30
+    },
+    {
+      "id": "20260726032520-talk-20260726164513",
+      "name": "Apertura oficial Día 2",
+      "speakerId": "actividad",
+      "speakerName": "Actividad",
+      "scenarioId": "main-stage",
+      "startTime": "08:45",
+      "day": 2,
+      "durationMinutes": 15
+    },
+    {
+      "id": "20260726030340-talk-20260726165154",
+      "name": "Evolucion de DevOps a DevSecOps, IA como empuje de coversion laboral",
+      "speakerId": "andres-barrientos",
+      "speakerName": "Andres Barrientos",
+      "scenarioId": "main-stage",
+      "startTime": "09:00",
+      "day": 2,
+      "durationMinutes": 30
+    },
+    {
+      "id": "20260726170516-talk-20260726170540",
+      "name": "Por confirmar",
+      "speakerId": "platinum-tgcorp",
+      "speakerName": "Platinum: TG Corp",
+      "scenarioId": "main-stage",
+      "startTime": "09:30",
+      "day": 2,
+      "durationMinutes": 60
+    },
+    {
+      "id": "20260726025213-talk-20260726025454",
+      "name": "El idioma también es infraestructura: Preparar a Latinoamérica para la próxima ola tecnológica",
+      "speakerId": "johan-prieto",
+      "speakerName": "Johan Prieto",
+      "scenarioId": "main-stage",
+      "startTime": "10:30",
+      "day": 2,
+      "durationMinutes": 30
+    },
+    {
+      "id": "20260726032520-talk-20260726164599",
+      "name": "Conoce a nuestro Patrocinadores Día 2",
+      "speakerId": "actividad",
+      "speakerName": "Actividad",
+      "scenarioId": "main-stage",
+      "startTime": "11:00",
+      "day": 2,
+      "durationMinutes": 30
+    },
+    {
+      "id": "20260726170900-talk-20260726170922",
+      "name": "Platinum: Jarvis bot Always on-Call",
+      "speakerId": "melisa-arenas",
+      "speakerName": "Melisa Arenas",
+      "scenarioId": "main-stage",
+      "startTime": "11:30",
+      "day": 2,
+      "durationMinutes": 30
+    },
+    {
+      "id": "20260726030305-talk-20260726163628",
+      "name": "AgentOps: el futuro que ya llegó",
+      "speakerId": "axel-labruna",
+      "speakerName": "Axel Labruna",
+      "scenarioId": "main-stage",
+      "startTime": "12:00",
+      "day": 2,
+      "durationMinutes": 30
+    },
+    {
+      "id": "devopsdays-santiag-cfp-7489da18-fc74-480d-935b",
+      "name": "Los agentes necesitan plata: x402 como infraestructura para la web3",
+      "speakerId": "boris-quiroz",
+      "speakerName": "Boris Quiroz",
+      "scenarioId": "main-stage",
+      "startTime": "12:30",
+      "day": 2,
+      "durationMinutes": 30
+    }
+  ],
+  "breaks": [
+    {
+      "id": "devopsdays-santiago-2026-break-20260726020102",
+      "name": "Registro y Café + Networking",
+      "durationMinutes": 45,
+      "scenarioId": "devopsdays-santiago-2026-sala-20260726020549",
+      "startTime": "08:00",
+      "day": 1
+    },
+    {
+      "id": "dod-2026-day1-coffee-break",
+      "name": "Coffee Break, Patrocinadores, y Comunidades",
+      "durationMinutes": 30,
+      "scenarioId": "main-stage",
+      "startTime": "10:00",
+      "day": 1
+    },
+    {
+      "id": "dod-2026-day1-lunch-break",
+      "name": "Almuerzo + Networking",
+      "durationMinutes": 90,
+      "scenarioId": "devopsdays-santiago-2026-sala-20260726020549",
+      "startTime": "13:00",
+      "day": 1
+    },
+    {
+      "id": "devopsdays-santiago-2026-break-20260726020403",
+      "name": "Registro y Café + Networking",
+      "durationMinutes": 45,
+      "scenarioId": "devopsdays-santiago-2026-sala-20260726020549",
+      "startTime": "08:00",
+      "day": 2
+    },
+    {
+      "id": "dod-2026-day2-coffee-break",
+      "name": "Coffee Break, Patrocinadores, y Comunidades",
+      "durationMinutes": 30,
+      "scenarioId": "devopsdays-santiago-2026-sala-20260726020549",
+      "startTime": "10:30",
+      "day": 2
+    },
+    {
+      "id": "dod-2026-day2-lunch-break",
+      "name": "Almuerzo + Networking",
+      "durationMinutes": 90,
+      "scenarioId": "devopsdays-santiago-2026-sala-20260726020549",
+      "startTime": "13:00",
+      "day": 2
+    }
+  ]
+}


### PR DESCRIPTION
Endpoint de importación masiva de agendas desde JSON.

Restaura agenda DevOpsDays 2026: 4 escenarios + 25 charlas + 6 breaks en segundos.

Testing: Usar restore-devopsdays-agenda.json en /private/admin/events/devopsdays-santiago-2026/edit

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an agenda import tool to the event administration page.
  * Administrators can upload a JSON agenda file to add or update venues, talks, and breaks.
  * Import results report the number of items added, with clear success and error messages.
  * Added a complete agenda data file for restoring an event schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->