### PR TITLE
hotfix(admin): fix event ID variable in agenda import JavaScript

### DIFF
--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -530,7 +530,7 @@ Nuevo Evento · Homedir
         showImportResult('info', 'Procesando archivo...');
 
         try {
-          const eventId = '{eventId}';
+          const eventId = '{event.id}';
           const response = await fetch(`/private/admin/events/${eventId}/import-agenda`, {
             method: 'POST',
             body: formData


### PR DESCRIPTION
Hotfix: Corrige variable de Qute en JavaScript del import de agenda.

**Error en producción:**
- URL generada: /private/admin/events/$devopsdays-santiago-2026/import-agenda
- Error: 404 Not Found

**Causa:**
Variable incorrecta en template: {eventId} → Qute no la encuentra y escapa como $

**Fix:**
Cambio de {eventId} a {event.id}

**Testing:**
URL correcta: /private/admin/events/devopsdays-santiago-2026/import-agenda

**Prioridad:** CRÍTICA - Feature no funciona en producción

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected agenda import requests so they use the selected event’s ID, ensuring the import is applied to the intended event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->