### PR TITLE
hotfix(admin): use data attribute for event ID (fix $ escaping)

### DIFF
--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -211,7 +211,7 @@ Nuevo Evento · Homedir
     <p class="form-hint" style="margin-bottom: 1rem;">
       Importa escenarios, charlas y breaks desde un archivo JSON. Los elementos duplicados (mismo ID) serán ignorados.
     </p>
-    <form id="import-agenda-form" enctype="multipart/form-data" style="margin-bottom: 1rem;">
+    <form id="import-agenda-form" data-event-id="{event.id}" enctype="multipart/form-data" style="margin-bottom: 1rem;">
       {#include fragments/csrf-token.html /}
       <div style="display: flex; gap: 1rem; align-items: end;">
         <div class="form-group" style="flex: 1;">
@@ -530,7 +530,7 @@ Nuevo Evento · Homedir
         showImportResult('info', 'Procesando archivo...');
 
         try {
-          const eventId = '{event.id}';
+          const eventId = importForm.dataset.eventId;
           const response = await fetch(`/private/admin/events/${eventId}/import-agenda`, {
             method: 'POST',
             body: formData


### PR DESCRIPTION
Fix definitivo para el $ en la URL del endpoint de import.

**Problema:**
Qute escapa variables dentro de <script> con prefijo $

**Solución:**
- HTML: data-event-id="{event.id}" (Qute interpola correctamente)
- JS: leer desde dataset.eventId (sin interpolación)

**Testing:**
URL correcta sin $: /private/admin/events/devopsdays-santiago-2026/import-agenda

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>