### PR TITLE
fix(admin): use getId() method to prevent Qute escaping dash in event ID

### DIFF
--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -211,7 +211,7 @@ Nuevo Evento · Homedir
     <p class="form-hint" style="margin-bottom: 1rem;">
       Importa escenarios, charlas y breaks desde un archivo JSON. Los elementos duplicados (mismo ID) serán ignorados.
     </p>
-    <form id="import-agenda-form" data-event-id="{event.id}" enctype="multipart/form-data" style="margin-bottom: 1rem;">
+    <form id="import-agenda-form" data-event-id="{event.getId()}" enctype="multipart/form-data" style="margin-bottom: 1rem;">
       {#include fragments/csrf-token.html /}
       <div style="display: flex; gap: 1rem; align-items: end;">
         <div class="form-group" style="flex: 1;">


### PR DESCRIPTION
## Summary
- Fixes 404 error when importing agenda caused by Qute escaping the dash in event IDs
- Changes `{event.id}` to `{event.getId()}` in data attribute

## Root Cause
Qute template engine interprets `{event.id}` as an expression where `-` is the subtraction operator, causing it to escape `devopsdays-santiago-2026` to `$devopsdays-santiago-2026`.

## Solution
Using the explicit getter `{event.getId()}` prevents Qute from treating the dash as an operator.

## Test Plan
- [x] Verify fix compiles
- [ ] Deploy to production
- [ ] Test agenda import with devopsdays-santiago-2026 event
- [ ] Verify URL is `/events/devopsdays-santiago-2026/import-agenda` (no `$`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected agenda import requests to use the event’s identifier reliably when editing an event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->