### PR TITLE
fix(admin): use raw filter to prevent Qute escaping event ID

### DIFF
--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -211,7 +211,7 @@ Nuevo Evento · Homedir
     <p class="form-hint" style="margin-bottom: 1rem;">
       Importa escenarios, charlas y breaks desde un archivo JSON. Los elementos duplicados (mismo ID) serán ignorados.
     </p>
-    <form id="import-agenda-form" data-event-id="{event.getId()}" enctype="multipart/form-data" style="margin-bottom: 1rem;">
+    <form id="import-agenda-form" data-event-id="{event.id.raw}" enctype="multipart/form-data" style="margin-bottom: 1rem;">
       {#include fragments/csrf-token.html /}
       <div style="display: flex; gap: 1rem; align-items: end;">
         <div class="form-group" style="flex: 1;">


### PR DESCRIPTION
## Summary
- Use `{event.id.raw}` instead of `{event.getId()}` to disable Qute HTML escaping
- Fixes persistent 404 error where event ID was being escaped to `$devopsdays-santiago-2026`

## Root Cause Analysis
PR #1258 and #1259 attempted to fix the escaping by:
1. Using data attributes (correct approach)
2. Using `{event.getId()}` instead of `{event.id}` (didn't help)

The real issue: Qute was applying HTML escaping **regardless** of the syntax used because the template receives two parameters:
- `Event event` (the object)
- `String eventId` (already processed String)

When Qute resolves `{event.getId()}`, it may be using the pre-escaped `eventId` parameter.

## Solution
The `.raw` filter tells Qute to **disable HTML escaping** for this specific value, allowing the actual event ID to pass through unchanged.

## References
- Qute raw filter docs: https://quarkus.io/guides/qute-reference#raw_filter
- Previous attempts: #1258, #1259

🤖 Generated with [Claude Code](https://claude.com/claude-code)