### PR TITLE
fix(admin): avoid Qute interpreting JS template literal in fetch URL

### DIFF
--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -531,7 +531,7 @@ Nuevo Evento · Homedir
 
         try {
           const eventId = importForm.dataset.eventId;
-          const response = await fetch(`/private/admin/events/${eventId}/import-agenda`, {
+          const response = await fetch('/private/admin/events/' + eventId + '/import-agenda', {
             method: 'POST',
             body: formData
           });


### PR DESCRIPTION
## Summary
Replace JavaScript template literal with string concatenation to prevent Qute from processing `${eventId}` at template render time.

## Root Cause (FINALLY!)

PRs #1258, #1259, and #1260 all focused on fixing the `data-event-id` attribute, but **the actual bug was in the JavaScript `fetch()` call**.

When Qute renders the template, it processes **ALL** `${}` syntax as Qute expressions, even inside JavaScript code:

```javascript
// JavaScript code in template
fetch(`/private/admin/events/${eventId}/import-agenda`, ...)
```

Qute sees `${eventId}` and replaces it with the **template parameter** `eventId` (line 106 in AdminEventResource.java), which somehow gets escaped to `$devopsdays-santiago-2026`.

## The Fix

**Before (template literal - Qute processes it):**
```javascript
fetch(`/private/admin/events/${eventId}/import-agenda`, ...)
```

**After (string concatenation - JavaScript evaluates it):**
```javascript
fetch('/private/admin/events/' + eventId + '/import-agenda', ...)
```

Now `eventId` is evaluated by **JavaScript at runtime**, not by Qute at template render time.

## Why Previous Fixes Didn't Work

- #1258: Added `data-event-id` attribute ✅ (was correct)
- #1259: Changed `{event.id}` → `{event.getId()}` in attribute (didn't help)
- #1260: Used `{event.id.raw}` in attribute (didn't help)

All three fixed the wrong thing. The `data-event-id` attribute was fine from #1258 onwards. The bug was always in the `fetch()` call using a template literal.

## Test Plan
- [ ] Deploy to production
- [ ] Open DevTools console
- [ ] Import agenda
- [ ] Verify URL is `/events/devopsdays-santiago-2026/import-agenda` (no `$`)
- [ ] Verify import succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the event agenda import request handling without changing its user-facing behavior.
  * Agenda imports continue to submit data, display success or error messages, and refresh the page after successful completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->