### PR TITLE
feat(config): make default timezone configurable

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/model/Event.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/model/Event.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 @RegisterForReflection
 @JsonIgnoreProperties(value = "dayList", allowGetters = true)
@@ -383,12 +384,26 @@ public class Event {
     return t == null ? "" : t.toString();
   }
 
-  /** Returns the time zone of the event or America/Santiago by default. */
+  /** Returns the time zone of the event or the configured default. */
   public ZoneId getZoneId() {
     try {
-      return timezone != null && !timezone.isBlank()
-          ? ZoneId.of(timezone)
-          : ZoneId.of("America/Santiago");
+      return timezone != null && !timezone.isBlank() ? ZoneId.of(timezone) : defaultZoneId();
+    } catch (Exception e) {
+      return defaultZoneId();
+    }
+  }
+
+  /**
+   * Resolves the platform default time zone from the {@code homedir.default-timezone} config
+   * property (default: {@code America/Santiago}).
+   */
+  private static ZoneId defaultZoneId() {
+    String tz =
+        ConfigProvider.getConfig()
+            .getOptionalValue("homedir.default-timezone", String.class)
+            .orElse("America/Santiago");
+    try {
+      return ZoneId.of(tz);
     } catch (Exception e) {
       return ZoneId.of("America/Santiago");
     }

--- a/quarkus-app/src/main/java/com/scanales/homedir/notifications/TalkStateEvaluator.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/notifications/TalkStateEvaluator.java
@@ -11,6 +11,7 @@ import jakarta.inject.Inject;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Set;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 /** Periodically evaluates registered talks to emit runtime notifications. */
@@ -47,7 +48,7 @@ public class TalkStateEvaluator {
     ZoneId zone =
         info.event() != null && info.event().getTimezone() != null
             ? ZoneId.of(info.event().getTimezone())
-            : ZoneId.of("America/Santiago");
+            : defaultZoneId();
     ZonedDateTime now = clock.now(zone);
 
     if (info.event() == null || info.event().getDate() == null) return;
@@ -78,5 +79,21 @@ public class TalkStateEvaluator {
     n.title = info.talk().getName();
     n.message = message;
     notifications.enqueue(n);
+  }
+
+  /**
+   * Resolves the platform default time zone from the {@code homedir.default-timezone} config
+   * property (default: {@code America/Santiago}).
+   */
+  private static ZoneId defaultZoneId() {
+    String tz =
+        ConfigProvider.getConfig()
+            .getOptionalValue("homedir.default-timezone", String.class)
+            .orElse("America/Santiago");
+    try {
+      return ZoneId.of(tz);
+    } catch (Exception e) {
+      return ZoneId.of("America/Santiago");
+    }
   }
 }

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/ProfileResource.java
@@ -65,6 +65,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ResourceBundle;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.resteasy.reactive.multipart.FileUpload;
 
@@ -1307,7 +1308,7 @@ public class ProfileResource {
     if (eventIds.isEmpty()) {
       return null;
     }
-    LocalDate today = LocalDate.now(ZoneId.of("America/Santiago"));
+    LocalDate today = LocalDate.now(defaultZoneId());
     com.scanales.homedir.model.Event selectedEvent = null;
     String selectedEventId = null;
     long bestScore = Long.MAX_VALUE;
@@ -1367,7 +1368,7 @@ public class ProfileResource {
   }
 
   private java.util.List<VolunteerEventItem> listVolunteerOpenEvents() {
-    LocalDate today = LocalDate.now(ZoneId.of("America/Santiago"));
+    LocalDate today = LocalDate.now(defaultZoneId());
     return eventService.listEvents().stream()
         .filter(event -> event != null && event.getId() != null && !event.getId().isBlank())
         .filter(event -> event.getDate() == null || !event.getDate().isBefore(today.minusDays(1)))
@@ -1533,6 +1534,22 @@ public class ProfileResource {
     String normalized = raw.trim().toLowerCase(Locale.ROOT);
     if (!normalized.isBlank()) {
       ids.add(normalized);
+    }
+  }
+
+  /**
+   * Resolves the platform default time zone from the {@code homedir.default-timezone} config
+   * property (default: {@code America/Santiago}).
+   */
+  private static ZoneId defaultZoneId() {
+    String tz =
+        ConfigProvider.getConfig()
+            .getOptionalValue("homedir.default-timezone", String.class)
+            .orElse("America/Santiago");
+    try {
+      return ZoneId.of(tz);
+    } catch (Exception e) {
+      return ZoneId.of("America/Santiago");
     }
   }
 }

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -290,6 +290,10 @@ economy.purchase.max-per-minute=12
 # OG image
 homedir.og-image.default-url=/images/og-default.png
 
+# Default time zone used when an event has no explicit timezone set.
+# Must be a valid IANA Zone ID (e.g. America/Santiago, UTC, Europe/Madrid).
+homedir.default-timezone=${HOMEDIR_DEFAULT_TIMEZONE:America/Santiago}
+
 # Trending GitHub repositories
 trending.daily.cron=0 0 0 * * ?
 trending.weekly.cron=0 0 0 ? * MON

--- a/quarkus-app/src/test/java/com/scanales/homedir/util/AppTemplateExtensionsTalkStateTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/util/AppTemplateExtensionsTalkStateTest.java
@@ -6,6 +6,7 @@ import com.scanales.homedir.model.Event;
 import com.scanales.homedir.model.Talk;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Test;
 
 public class AppTemplateExtensionsTalkStateTest {
@@ -26,5 +27,23 @@ public class AppTemplateExtensionsTalkStateTest {
 
     String state = AppTemplateExtensions.talkState(talk, event);
     assertEquals("Finalizada", state);
+  }
+
+  @Test
+  void eventGetZoneIdFallsBackToConfigProperty() {
+    Event event = new Event();
+    // No timezone set -> should use homedir.default-timezone config (defaults to America/Santiago)
+    String configuredTz =
+        ConfigProvider.getConfig()
+            .getOptionalValue("homedir.default-timezone", String.class)
+            .orElse("America/Santiago");
+    assertEquals(ZoneId.of(configuredTz), event.getZoneId());
+  }
+
+  @Test
+  void eventGetZoneIdUsesEventTimezoneWhenSet() {
+    Event event = new Event();
+    event.setTimezone("Europe/Madrid");
+    assertEquals(ZoneId.of("Europe/Madrid"), event.getZoneId());
   }
 }


### PR DESCRIPTION
## Summary

- **Default timezone was hardcoded to `America/Santiago` in 4 locations.** This made the platform unusable for communities outside Chile without code changes.
- Added `homedir.default-timezone` config property (env: `HOMEDIR_DEFAULT_TIMEZONE`, default: `America/Santiago`).

## Changes

| File | Change |
|------|--------|
| `application.properties` | New `homedir.default-timezone` property |
| `Event.java` | `getZoneId()` reads config when event has no timezone |
| `TalkStateEvaluator.java` | Uses config for talks without event timezone |
| `ProfileResource.java` | Uses config for volunteer/CFP date calculations (2 sites) |
| `AppTemplateExtensionsTalkStateTest.java` | 2 new tests: config fallback + explicit timezone |

## Test plan

- [x] 733 tests pass (0 failures, 0 errors, 1 skipped)
- [x] Spotless check passes
- [x] New tests verify config-based fallback and explicit event timezone
- [ ] CI/CD pipeline passes

Generated with [Devin](https://devin.ai)