### PR TITLE
fix(security): harden uploads, speaker service, and backup restore

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/model/Event.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/model/Event.java
@@ -330,7 +330,11 @@ public class Event {
 
   public void setDateStr(String value) {
     if (value != null && !value.isBlank()) {
-      this.date = LocalDate.parse(value);
+      try {
+        this.date = LocalDate.parse(value);
+      } catch (Exception e) {
+        this.date = null;
+      }
     } else {
       this.date = null;
     }
@@ -502,8 +506,11 @@ public class Event {
 
   /** Retrieves the name of a scenario given its id, or {@code null} if not found. */
   public String getScenarioName(String scenarioId) {
+    if (scenarios == null || scenarioId == null) {
+      return null;
+    }
     return scenarios.stream()
-        .filter(s -> s.getId().equals(scenarioId))
+        .filter(s -> s != null && s.getId() != null && s.getId().equals(scenarioId))
         .map(Scenario::getName)
         .findFirst()
         .orElse(null);
@@ -511,9 +518,13 @@ public class Event {
 
   /** Returns the list of talks for the given day ordered by start time. */
   public java.util.List<Talk> getAgendaForDay(int day) {
+    if (agenda == null) return java.util.List.of();
     return agenda.stream()
-        .filter(t -> t.getDay() == day)
-        .sorted(java.util.Comparator.comparing(Talk::getStartTime))
+        .filter(t -> t != null && t.getDay() == day)
+        .sorted(
+            java.util.Comparator.comparing(
+                Talk::getStartTime,
+                java.util.Comparator.nullsLast(java.util.Comparator.naturalOrder())))
         .toList();
   }
 
@@ -522,9 +533,18 @@ public class Event {
    * time. An empty list is returned when there are no talks matching the provided parameters.
    */
   public java.util.List<Talk> getAgendaForDayAndScenario(int day, String scenarioId) {
+    if (agenda == null || scenarioId == null) return java.util.List.of();
     return agenda.stream()
-        .filter(t -> t.getDay() == day && scenarioId.equals(t.getLocation()))
-        .sorted(java.util.Comparator.comparing(Talk::getStartTime))
+        .filter(
+            t ->
+                t != null
+                    && t.getDay() == day
+                    && t.getLocation() != null
+                    && scenarioId.equals(t.getLocation()))
+        .sorted(
+            java.util.Comparator.comparing(
+                Talk::getStartTime,
+                java.util.Comparator.nullsLast(java.util.Comparator.naturalOrder())))
         .toList();
   }
 
@@ -536,8 +556,9 @@ public class Event {
    */
   public java.util.Map<java.time.LocalTime, java.util.List<Talk>> getAgendaGroupedByStartTime(
       int day) {
+    if (agenda == null) return java.util.Collections.emptyMap();
     return agenda.stream()
-        .filter(t -> t.getDay() == day)
+        .filter(t -> t != null && t.getDay() == day && t.getStartTime() != null)
         .collect(
             java.util.stream.Collectors.groupingBy(
                 Talk::getStartTime, java.util.TreeMap::new, java.util.stream.Collectors.toList()));
@@ -551,7 +572,13 @@ public class Event {
    */
   public java.util.Map<java.time.LocalTime, java.util.List<Talk>> getAgendaGroupedByTimeSlot(
       int day) {
-    java.util.List<Talk> dayTalks = agenda.stream().filter(t -> t.getDay() == day).toList();
+    if (agenda == null) {
+      return java.util.Collections.emptyMap();
+    }
+    java.util.List<Talk> dayTalks =
+        agenda.stream()
+            .filter(t -> t != null && t.getDay() == day && t.getStartTime() != null)
+            .toList();
     if (dayTalks.isEmpty()) {
       return java.util.Collections.emptyMap();
     }

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminBackupResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminBackupResource.java
@@ -59,6 +59,10 @@ public class AdminBackupResource {
   String dataDirPath;
 
   private static final Logger LOG = Logger.getLogger(AdminBackupResource.class);
+
+  /** Maximum allowed size for backup uploads (500 MB). */
+  private static final long MAX_BACKUP_FILE_SIZE_BYTES = 500L * 1024 * 1024;
+
   private static final Pattern BACKUP_VERSION =
       Pattern.compile("backup_.*_v(\\d+\\.\\d+(?:\\.\\d+)?).*\\.zip");
 
@@ -127,6 +131,15 @@ public class AdminBackupResource {
       LOG.warn("No file uploaded for restore");
       return Response.seeOther(
               UriBuilder.fromPath(redirect).queryParam("msg", "\u274c Archivo inválido.").build())
+          .build();
+    }
+    if (file.size() > MAX_BACKUP_FILE_SIZE_BYTES) {
+      LOG.warnf(
+          "Backup file too large: %d bytes (max=%d)", file.size(), MAX_BACKUP_FILE_SIZE_BYTES);
+      return Response.seeOther(
+              UriBuilder.fromPath(redirect)
+                  .queryParam("msg", "\u274c Archivo demasiado grande (m\u00e1x 500MB).")
+                  .build())
           .build();
     }
     String fileName = file.fileName();

--- a/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/private_/AdminEventResource.java
@@ -50,6 +50,9 @@ public class AdminEventResource {
 
   private static final Logger LOG = Logger.getLogger(AdminEventResource.class);
 
+  /** Maximum allowed size for imported JSON files (10 MB). */
+  private static final long MAX_IMPORT_FILE_SIZE_BYTES = 10L * 1024 * 1024;
+
   @Inject EventService eventService;
 
   @Inject SpeakerService speakerService;
@@ -322,7 +325,18 @@ public class AdminEventResource {
           .header("Location", "/private/admin/events/" + eventId + "/edit?msg=" + msg)
           .build();
     }
-    java.time.LocalTime start = java.time.LocalTime.parse(startTime);
+    java.time.LocalTime start;
+    try {
+      start = java.time.LocalTime.parse(startTime);
+    } catch (Exception e) {
+      LOG.warnf("Invalid startTime format: %s", startTime);
+      String msg =
+          java.net.URLEncoder.encode(
+              "Formato de hora inv\u00e1lido (use HH:MM)", java.nio.charset.StandardCharsets.UTF_8);
+      return Response.status(Response.Status.SEE_OTHER)
+          .header("Location", "/private/admin/events/" + eventId + "/edit?msg=" + msg)
+          .build();
+    }
     java.time.LocalTime end = start.plusMinutes(base.getDurationMinutes());
     LOG.infof(
         "accion=charla_guardar_intento usuario=%s eventoId=%s charlaTitulo=%s fechaInicio=%s fechaFin=%s dia=%d sala=%s requestId=%s",
@@ -446,7 +460,19 @@ public class AdminEventResource {
     talk.setDurationMinutes(duration);
     talk.setSpeakers(java.util.List.of());
     talk.setLocation(location);
-    talk.setStartTime(java.time.LocalTime.parse(startTime));
+    java.time.LocalTime breakStart;
+    try {
+      breakStart = java.time.LocalTime.parse(startTime);
+    } catch (Exception e) {
+      LOG.warnf("Invalid break startTime format: %s", startTime);
+      String msg =
+          java.net.URLEncoder.encode(
+              "Formato de hora inv\u00e1lido (use HH:MM)", java.nio.charset.StandardCharsets.UTF_8);
+      return Response.status(Response.Status.SEE_OTHER)
+          .header("Location", "/private/admin/events/" + eventId + "/edit?msg=" + msg)
+          .build();
+    }
+    talk.setStartTime(breakStart);
     talk.setDay(day);
     talk.setBreak(true);
     Talk overlap = eventService.findOverlap(eventId, talk);
@@ -497,6 +523,17 @@ public class AdminEventResource {
       var events = eventService.listEvents();
       return Response.status(Response.Status.BAD_REQUEST)
           .entity(Templates.list(events, "Importaci\u00f3n fallida: archivo requerido"))
+          .build();
+    }
+
+    if (file.size() > MAX_IMPORT_FILE_SIZE_BYTES) {
+      LOG.warnf(
+          "Import file too large: %d bytes (max=%d)", file.size(), MAX_IMPORT_FILE_SIZE_BYTES);
+      var events = eventService.listEvents();
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity(
+              Templates.list(
+                  events, "Importaci\u00f3n fallida: archivo demasiado grande (m\u00e1x 10MB)"))
           .build();
     }
 
@@ -641,6 +678,17 @@ public class AdminEventResource {
       LOG.warn("No file received for agenda import");
       return Response.status(Response.Status.BAD_REQUEST)
           .entity(java.util.Map.of("success", false, "error", "Archivo requerido"))
+          .build();
+    }
+
+    if (file.size() > MAX_IMPORT_FILE_SIZE_BYTES) {
+      LOG.warnf(
+          "Agenda import file too large: %d bytes (max=%d)",
+          file.size(), MAX_IMPORT_FILE_SIZE_BYTES);
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity(
+              java.util.Map.of(
+                  "success", false, "error", "Archivo demasiado grande (m\u00e1x 10MB)"))
           .build();
     }
 

--- a/quarkus-app/src/main/java/com/scanales/homedir/service/BackupArchiveService.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/service/BackupArchiveService.java
@@ -74,6 +74,9 @@ public class BackupArchiveService {
           zis.closeEntry();
           continue;
         }
+        if (rawName.contains("\0")) {
+          throw new IOException("null_byte_in_entry_name");
+        }
         if ("backup-manifest.json".equals(rawName)) {
           zis.closeEntry();
           continue;
@@ -94,8 +97,13 @@ public class BackupArchiveService {
             verifyInsideRoot(parent, root);
           }
         }
-        Files.copy(zis, target, StandardCopyOption.REPLACE_EXISTING);
+        // Reject symlinks: a symlink in the data dir could point outside root.
+        if (Files.isSymbolicLink(target)) {
+          throw new IOException("symbolic_link_not_allowed:" + rawName);
+        }
+        // Verify target is inside root BEFORE writing, not after.
         verifyInsideRoot(target, root);
+        Files.copy(zis, target, StandardCopyOption.REPLACE_EXISTING);
         restoredFiles++;
         zis.closeEntry();
       }
@@ -125,7 +133,15 @@ public class BackupArchiveService {
   }
 
   private static void verifyInsideRoot(Path target, Path root) throws IOException {
-    if (!target.toRealPath().startsWith(root)) {
+    // Use toRealPath() when the file exists (post-write check), otherwise
+    // fall back to toAbsolutePath().normalize() (pre-write check).
+    Path resolved;
+    if (Files.exists(target)) {
+      resolved = target.toRealPath();
+    } else {
+      resolved = target.toAbsolutePath().normalize();
+    }
+    if (!resolved.startsWith(root)) {
       throw new IOException("zip_outside_data_dir");
     }
   }

--- a/quarkus-app/src/main/java/com/scanales/homedir/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/service/EventService.java
@@ -85,6 +85,9 @@ public class EventService {
   }
 
   public void saveEvent(Event event) {
+    if (event == null || event.getId() == null) {
+      return;
+    }
     ensureDefaults(event);
     ensureDevOpsDaysDraftAgenda(event);
     events.put(event.getId(), event);
@@ -98,28 +101,40 @@ public class EventService {
 
   public void saveScenario(String eventId, Scenario scenario) {
     Event event = events.get(eventId);
-    if (event == null) {
+    if (event == null || scenario == null || scenario.getId() == null) {
       return;
     }
-    event.getScenarios().removeIf(s -> s.getId().equals(scenario.getId()));
+    if (event.getScenarios() == null) {
+      event.setScenarios(new ArrayList<>());
+    }
+    event
+        .getScenarios()
+        .removeIf(s -> s != null && s.getId() != null && s.getId().equals(scenario.getId()));
     event.getScenarios().add(scenario);
     persistence.saveEvents(new ConcurrentHashMap<>(events));
   }
 
   public void deleteScenario(String eventId, String scenarioId) {
     Event event = events.get(eventId);
-    if (event != null) {
-      event.getScenarios().removeIf(s -> s.getId().equals(scenarioId));
+    if (event != null && event.getScenarios() != null) {
+      event
+          .getScenarios()
+          .removeIf(s -> s != null && s.getId() != null && s.getId().equals(scenarioId));
       persistence.saveEvents(new ConcurrentHashMap<>(events));
     }
   }
 
   public void saveTalk(String eventId, Talk talk) {
     Event event = events.get(eventId);
-    if (event == null) {
+    if (event == null || talk == null || talk.getId() == null) {
       return;
     }
-    event.getAgenda().removeIf(t -> t.getId().equals(talk.getId()));
+    if (event.getAgenda() == null) {
+      event.setAgenda(new ArrayList<>());
+    }
+    event
+        .getAgenda()
+        .removeIf(t -> t != null && t.getId() != null && t.getId().equals(talk.getId()));
     event.getAgenda().add(talk);
     event
         .getAgenda()
@@ -133,8 +148,8 @@ public class EventService {
 
   public void deleteTalk(String eventId, String talkId) {
     Event event = events.get(eventId);
-    if (event != null) {
-      event.getAgenda().removeIf(t -> t.getId().equals(talkId));
+    if (event != null && event.getAgenda() != null) {
+      event.getAgenda().removeIf(t -> t != null && t.getId() != null && t.getId().equals(talkId));
       persistence.saveEvents(new ConcurrentHashMap<>(events));
     }
   }
@@ -161,7 +176,7 @@ public class EventService {
    */
   public Talk findOverlap(String eventId, Talk talk) {
     Event event = events.get(eventId);
-    if (event == null || talk.getStartTime() == null) {
+    if (event == null || talk == null || talk.getStartTime() == null || event.getAgenda() == null) {
       return null;
     }
     java.time.LocalTime start = talk.getStartTime();
@@ -169,7 +184,9 @@ public class EventService {
     return event.getAgenda().stream()
         .filter(
             t ->
-                !t.getId().equals(talk.getId())
+                t != null
+                    && t.getId() != null
+                    && !t.getId().equals(talk.getId())
                     && t.getDay() == talk.getDay()
                     && t.getLocation() != null
                     && t.getLocation().equals(talk.getLocation()))
@@ -187,17 +204,21 @@ public class EventService {
   }
 
   public Scenario findScenario(String scenarioId) {
+    if (scenarioId == null) return null;
     return events.values().stream()
+        .filter(e -> e != null && e.getScenarios() != null)
         .flatMap(e -> e.getScenarios().stream())
-        .filter(s -> s.getId().equals(scenarioId))
+        .filter(s -> s != null && s.getId() != null && s.getId().equals(scenarioId))
         .findFirst()
         .orElse(null);
   }
 
   public Talk findTalk(String talkId) {
+    if (talkId == null) return null;
     return events.values().stream()
+        .filter(e -> e != null && e.getAgenda() != null)
         .flatMap(e -> e.getAgenda().stream())
-        .filter(t -> t.getId().equals(talkId))
+        .filter(t -> t != null && t.getId() != null && t.getId().equals(talkId))
         .findFirst()
         .orElse(null);
   }
@@ -205,35 +226,50 @@ public class EventService {
   /** Returns the talk with the given id within the specified event or {@code null} if not found. */
   public Talk findTalk(String eventId, String talkId) {
     Event event = events.get(eventId);
-    if (event == null) {
+    if (event == null || event.getAgenda() == null || talkId == null) {
       return null;
     }
     return event.getAgenda().stream()
-        .filter(t -> t.getId().equals(talkId))
+        .filter(t -> t != null && t.getId() != null && t.getId().equals(talkId))
         .findFirst()
         .orElse(null);
   }
 
   /** Returns the event that contains the given scenario or {@code null} if none. */
   public Event findEventByScenario(String scenarioId) {
+    if (scenarioId == null) return null;
     return events.values().stream()
-        .filter(e -> e.getScenarios().stream().anyMatch(s -> s.getId().equals(scenarioId)))
+        .filter(e -> e != null && e.getScenarios() != null)
+        .filter(
+            e ->
+                e.getScenarios().stream()
+                    .anyMatch(s -> s != null && s.getId() != null && s.getId().equals(scenarioId)))
         .findFirst()
         .orElse(null);
   }
 
   /** Returns the event that includes the provided talk id or {@code null}. */
   public Event findEventByTalk(String talkId) {
+    if (talkId == null) return null;
     return events.values().stream()
-        .filter(e -> e.getAgenda().stream().anyMatch(t -> t.getId().equals(talkId)))
+        .filter(e -> e != null && e.getAgenda() != null)
+        .filter(
+            e ->
+                e.getAgenda().stream()
+                    .anyMatch(t -> t != null && t.getId() != null && t.getId().equals(talkId)))
         .findFirst()
         .orElse(null);
   }
 
   /** Returns all events that include the provided talk id. */
   public List<Event> findEventsByTalk(String talkId) {
+    if (talkId == null) return java.util.List.of();
     return events.values().stream()
-        .filter(e -> e.getAgenda().stream().anyMatch(t -> t.getId().equals(talkId)))
+        .filter(e -> e != null && e.getAgenda() != null)
+        .filter(
+            e ->
+                e.getAgenda().stream()
+                    .anyMatch(t -> t != null && t.getId() != null && t.getId().equals(talkId)))
         .sorted(java.util.Comparator.comparing(Event::getId))
         .toList();
   }
@@ -253,8 +289,13 @@ public class EventService {
    * is scheduled multiple times.
    */
   public List<Talk> findTalkOccurrences(String talkId) {
+    if (talkId == null) return java.util.List.of();
     return events.values().stream()
-        .flatMap(e -> e.getAgenda().stream().filter(t -> t.getId().equals(talkId)))
+        .filter(e -> e != null && e.getAgenda() != null)
+        .flatMap(
+            e ->
+                e.getAgenda().stream()
+                    .filter(t -> t != null && t.getId() != null && t.getId().equals(talkId)))
         .sorted(
             java.util.Comparator.comparingInt(Talk::getDay)
                 .thenComparing(
@@ -266,11 +307,11 @@ public class EventService {
   /** Returns all instances of a talk within the specified event ordered by day and time. */
   public List<Talk> findTalkOccurrences(String eventId, String talkId) {
     Event event = events.get(eventId);
-    if (event == null) {
+    if (event == null || event.getAgenda() == null || talkId == null) {
       return java.util.List.of();
     }
     return event.getAgenda().stream()
-        .filter(t -> t.getId().equals(talkId))
+        .filter(t -> t != null && t.getId() != null && t.getId().equals(talkId))
         .sorted(
             java.util.Comparator.comparingInt(Talk::getDay)
                 .thenComparing(

--- a/quarkus-app/src/main/java/com/scanales/homedir/service/SpeakerService.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/service/SpeakerService.java
@@ -77,11 +77,15 @@ public class SpeakerService {
 
   public void deleteSpeaker(String id) {
     Speaker sp = speakers.remove(id);
-    if (sp != null) {
+    if (sp != null && sp.getTalks() != null) {
       // remove talks from events as well
       for (Talk t : sp.getTalks()) {
+        if (t == null) continue;
         for (Event e : eventService.listEvents()) {
-          e.getAgenda().removeIf(tt -> tt.getId().equals(t.getId()));
+          if (e.getAgenda() != null) {
+            e.getAgenda()
+                .removeIf(tt -> tt != null && t.getId() != null && t.getId().equals(tt.getId()));
+          }
         }
       }
       persistEvents();
@@ -100,6 +104,9 @@ public class SpeakerService {
     if (sp == null || talk == null || talk.getId() == null) {
       return;
     }
+    if (sp.getTalks() == null) {
+      sp.setTalks(new ArrayList<>());
+    }
     // ensure the main speaker is present and listed first
     List<Speaker> allSpeakers = new ArrayList<>();
     allSpeakers.add(sp);
@@ -117,17 +124,23 @@ public class SpeakerService {
       }
     }
     talk.setSpeakers(allSpeakers);
-    sp.getTalks().removeIf(t -> t.getId().equals(talk.getId()));
+    sp.getTalks().removeIf(t -> t != null && t.getId() != null && t.getId().equals(talk.getId()));
     sp.getTalks().add(talk);
     // ensure co-speakers have the talk and remove from those no longer associated
     for (Speaker s : speakers.values()) {
       if (!newIds.contains(s.getId())) {
-        s.getTalks().removeIf(t -> t.getId().equals(talk.getId()));
+        if (s.getTalks() != null) {
+          s.getTalks()
+              .removeIf(t -> t != null && t.getId() != null && t.getId().equals(talk.getId()));
+        }
       }
     }
     for (int i = 1; i < allSpeakers.size(); i++) {
       Speaker co = allSpeakers.get(i);
-      co.getTalks().removeIf(t -> t.getId().equals(talk.getId()));
+      if (co.getTalks() == null) {
+        co.setTalks(new ArrayList<>());
+      }
+      co.getTalks().removeIf(t -> t != null && t.getId() != null && t.getId().equals(talk.getId()));
       co.getTalks().add(talk);
     }
     // propagate updates to all events using this talk
@@ -143,27 +156,35 @@ public class SpeakerService {
 
   public Talk getTalk(String speakerId, String talkId) {
     Speaker sp = speakers.get(speakerId);
-    if (sp == null) {
+    if (sp == null || sp.getTalks() == null) {
       return null;
     }
-    return sp.getTalks().stream().filter(t -> t.getId().equals(talkId)).findFirst().orElse(null);
+    return sp.getTalks().stream()
+        .filter(t -> t != null && t.getId() != null && t.getId().equals(talkId))
+        .findFirst()
+        .orElse(null);
   }
 
   /** Finds a talk by id across all speakers. */
   public Talk findTalk(String talkId) {
     return speakers.values().stream()
+        .filter(s -> s.getTalks() != null)
         .flatMap(s -> s.getTalks().stream())
-        .filter(t -> t.getId().equals(talkId))
+        .filter(t -> t != null && t.getId() != null && t.getId().equals(talkId))
         .findFirst()
         .orElse(null);
   }
 
   public void deleteTalk(String speakerId, String talkId) {
     for (Speaker s : speakers.values()) {
-      s.getTalks().removeIf(t -> t.getId().equals(talkId));
+      if (s.getTalks() != null) {
+        s.getTalks().removeIf(t -> t != null && t.getId() != null && t.getId().equals(talkId));
+      }
     }
     for (Event e : eventService.listEvents()) {
-      e.getAgenda().removeIf(t -> t.getId().equals(talkId));
+      if (e.getAgenda() != null) {
+        e.getAgenda().removeIf(t -> t != null && t.getId() != null && t.getId().equals(talkId));
+      }
     }
     persistEvents();
     persistence.saveSpeakers(new ConcurrentHashMap<>(speakers));
@@ -180,14 +201,17 @@ public class SpeakerService {
       return;
     }
     for (Talk talk : sp.getTalks()) {
+      if (talk == null) continue;
       if (talk.getSpeakers() != null && !talk.getSpeakers().isEmpty()) {
         List<Speaker> updatedSpeakers =
             talk.getSpeakers().stream()
+                .filter(s -> s != null)
                 .map(s -> speakers.getOrDefault(s.getId(), s))
                 .collect(Collectors.toList());
         talk.setSpeakers(updatedSpeakers);
       }
       for (Talk evTalk : eventService.findTalkOccurrences(talk.getId())) {
+        if (evTalk == null) continue;
         evTalk.setName(talk.getName());
         evTalk.setDescription(talk.getDescription());
         evTalk.setDurationMinutes(talk.getDurationMinutes());

--- a/quarkus-app/src/test/java/com/scanales/homedir/service/BackupArchiveServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/service/BackupArchiveServiceTest.java
@@ -71,4 +71,49 @@ public class BackupArchiveServiceTest {
             () -> service.restoreArchive(new ByteArrayInputStream(zip), restoreDir));
     assertNotNull(error.getMessage());
   }
+
+  @Test
+  void restoreArchiveRejectsNullByteInEntryName() throws Exception {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
+      zos.putNextEntry(new ZipEntry("evil\0.txt"));
+      zos.write("bad".getBytes(StandardCharsets.UTF_8));
+      zos.closeEntry();
+    }
+
+    byte[] zip = baos.toByteArray();
+    Path restoreDir = tempDir.resolve("restore-nullbyte");
+    Files.createDirectories(restoreDir);
+
+    assertThrows(
+        Exception.class, () -> service.restoreArchive(new ByteArrayInputStream(zip), restoreDir));
+  }
+
+  @Test
+  void restoreArchiveRejectsSymlinkAtTarget() throws Exception {
+    Path restoreDir = tempDir.resolve("restore-symlink");
+    Files.createDirectories(restoreDir);
+    // Create a symlink inside the restore dir pointing outside
+    Path outsideFile = tempDir.resolve("outside-secret.txt");
+    Files.writeString(outsideFile, "secret", StandardCharsets.UTF_8);
+    Path link = restoreDir.resolve("stolen-link.txt");
+    try {
+      Files.createSymbolicLink(link, outsideFile);
+    } catch (UnsupportedOperationException | java.nio.file.FileSystemException e) {
+      // Symlinks not supported on this filesystem - skip test
+      return;
+    }
+
+    // Create a ZIP that tries to write to the symlink path
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
+      zos.putNextEntry(new ZipEntry("stolen-link.txt"));
+      zos.write("overwritten".getBytes(StandardCharsets.UTF_8));
+      zos.closeEntry();
+    }
+
+    assertThrows(
+        Exception.class,
+        () -> service.restoreArchive(new ByteArrayInputStream(baos.toByteArray()), restoreDir));
+  }
 }


### PR DESCRIPTION
## Summary

Security and stability fixes across five areas, identified via code audit:

### 1. File upload size validation (DoS prevention)
- `AdminEventResource.importEvent`: reject JSON imports > 10MB
- `AdminEventResource.importAgenda`: reject agenda JSON > 10MB
- `AdminBackupResource.upload`: reject backup ZIP > 500MB

### 2. SpeakerService NullPointerException protection
Multiple methods accessed `speaker.getTalks()` and `talk.getId()` without null checks, causing NPEs when:
- A speaker's talks list was null (possible after deserialization)
- A talk in the list was null
- An event's agenda was null

Fixed methods: `deleteSpeaker`, `saveTalk`, `getTalk`, `findTalk`, `deleteTalk`, `refreshEventsForSpeaker`

### 3. BackupArchiveService restore hardening
- **NUL byte rejection**: ZIP entry names with `\0` are rejected (filesystem injection prevention)
- **Symlink rejection**: restore targets that are symlinks are rejected before writing (path traversal via symlink)
- **Pre-write verification**: `verifyInsideRoot` now runs BEFORE `Files.copy`, not after (TOCTOU fix)
- **Non-existent path handling**: `verifyInsideRoot` uses `toAbsolutePath().normalize()` when the file doesn't exist yet, `toRealPath()` when it does

### 4. DateTimeParseException + NPE protection in Event model
- `Event.setDateStr`: catch invalid date format, set null instead of crashing
- `Event.getScenarioName`: null-check scenarios list and scenario IDs
- `Event.getAgendaForDay`: null-check agenda, null-safe sort
- `Event.getAgendaForDayAndScenario`: null-check agenda, location, scenarioId
- `Event.getAgendaGroupedByStartTime`: null-check agenda and startTime
- `Event.getAgendaGroupedByTimeSlot`: null-check agenda, filter null talks

### 5. EventService NPE protection
- `saveEvent`: null-check event and event ID
- `saveScenario/deleteScenario`: null-check scenario, initialize null scenarios list
- `saveTalk/deleteTalk`: null-check talk, initialize null agenda list
- `findOverlap`: null-check talk, agenda, and individual talk IDs
- `findScenario/findTalk/findEventByScenario/findEventByTalk/findEventsByTalk`: null-check parameters, agendas, and scenarios
- `findTalkOccurrences` (both overloads): null-check talkId, agenda, and individual talks

## Impact on live event operations

**These changes do NOT alter behavior for valid data during a live event.** All null checks are defensive: they only activate when data is incomplete/corrupt. For events with talks that have valid startTime, day, and location, the behavior is identical to before.

### Untouched real-time components
- `AppTemplateExtensions.talkState()` — the method that renders "Programada", "Por comenzar", "En curso", "Finalizada" in templates was **not modified**. It continues to calculate talk state in real time exactly as before.
- `TalkStateEvaluator` — the scheduler that emits runtime notifications (UPCOMING, STARTED, ENDING_SOON, FINISHED) was **not modified**. It continues to use `America/Santiago` as fallback timezone.
- `EventService.findTalkInfo()` — only delegates to `findTalk()` and `findEventByTalk()`, which now have extra null checks but **find the same talk for the same data**.

### Behavioral equivalence for valid data

| Method | Before | After | Diff with valid data |
|---|---|---|---|
| `getAgendaForDay` | `.filter(t -> t.getDay() == day)` | `.filter(t -> t != null && t.getDay() == day)` | None — `t` is never null in normal data |
| `findTalk` | `.filter(t -> t.getId().equals(talkId))` | `.filter(t -> t != null && t.getId() != null && t.getId().equals(talkId))` | None — finds the same talk |
| `findOverlap` | no null check on `talk` | `if (talk == null ...)` | None — if talk is not null, logic is identical |
| `getAgendaGroupedByStartTime` | no startTime null filter | filters `t.getStartTime() != null` | See below |

### The one intentional behavior change

`getAgendaGroupedByStartTime` and `getAgendaGroupedByTimeSlot` now **filter out talks with null startTime**. Previously, a talk without a start time caused a `NullPointerException` (because `Collectors.groupingBy` does not accept null keys in a `TreeMap`), which **crashed the entire agenda page**. Now that talk simply does not appear in the time-grouped view, and the rest of the agenda renders normally.

This is strictly an improvement: a talk without a start time should not appear in a view grouped by start time, and before it caused the whole agenda to fail.

**Conclusion**: during a live event, with talks that have start time, day, and room assigned, everything works identically to before. Real-time notifications, talk states, and the grouped agenda all continue to function. The changes only prevent crashes when data is incomplete.

## Test plan

- [x] 733 tests pass (0 failures, 0 errors, 1 skipped)
- [x] Spotless check passes
- [x] New tests: null-byte rejection, symlink rejection
- [ ] CI/CD pipeline passes

Generated with [Devin](https://devin.ai)