### PR TITLE
feat(e2e): Playwright E2E tests with real Chromium browser (Issue #1218)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -135,6 +135,7 @@ jobs:
 
   e2e:
     name: E2E (Playwright)
+    needs: build-and-test
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
@@ -153,6 +154,16 @@ jobs:
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: tests/e2e/package-lock.json
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('tests/e2e/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Run Playwright E2E tests
         run: bash scripts/ci/e2e-playwright.sh
@@ -163,6 +174,15 @@ jobs:
         with:
           name: playwright-report
           path: tests/e2e/playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Quarkus dev log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: quarkus-dev-log
+          path: quarkus-app/quarkus-dev.log
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -133,6 +133,39 @@ jobs:
       #   working-directory: quarkus-app
       #   run: ./mvnw checkstyle:check
 
+  e2e:
+    name: E2E (Playwright)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.5.1
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@3274a636b6b8e7635c6cd12d6bf2f5aefd8d19d7 # v4.2.0
+        with:
+          node-version: '22'
+
+      - name: Run Playwright E2E tests
+        run: bash scripts/ci/e2e-playwright.sh
+
+      - name: Upload Playwright report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: playwright-report
+          path: tests/e2e/playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   load-test:
     name: Load Test (High-Impact Services)
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -150,7 +150,7 @@ jobs:
           cache: 'maven'
 
       - name: Set up Node.js
-        uses: actions/setup-node@3274a636b6b8e7635c6cd12d6bf2f5aefd8d19d7 # v4.2.0
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: '22'
 

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,11 @@ dist/
 build/
 node_modules/
 
+# Playwright E2E artifacts
+tests/e2e/test-results/
+tests/e2e/playwright-report/
+tests/e2e/blob-report/
+
 # Eclipse m2e generated files
 # Eclipse Core
 .project

--- a/scripts/ci/e2e-playwright.sh
+++ b/scripts/ci/e2e-playwright.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Run Playwright E2E tests against a locally started Quarkus (dev profile).
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${repo_root}"
+
+E2E_PORT="${E2E_PORT:-8080}"
+E2E_BASE_URL="http://localhost:${E2E_PORT}"
+MAVEN_ARGS=()
+if [ -n "${MAVEN_REPO_LOCAL:-}" ]; then
+  MAVEN_ARGS+=("-Dmaven.repo.local=${MAVEN_REPO_LOCAL}")
+fi
+
+echo "🚀 Starting Quarkus (dev profile) for E2E tests..."
+cd quarkus-app
+./mvnw quarkus:dev -Ddebug=false -Dquarkus.http.port="${E2E_PORT}" "${MAVEN_ARGS[@]}" > quarkus-dev.log 2>&1 &
+QUARKUS_PID=$!
+cd ..
+
+cleanup() {
+  if [ -n "${QUARKUS_PID:-}" ]; then
+    echo "🛑 Stopping Quarkus (PID: $QUARKUS_PID)..."
+    kill "$QUARKUS_PID" 2>/dev/null || true
+    wait "$QUARKUS_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+echo "⏳ Waiting for Quarkus..."
+max_wait=90
+elapsed=0
+while ! curl -sf "${E2E_BASE_URL}/q/health/ready" > /dev/null 2>&1; do
+  if [ "$elapsed" -ge "$max_wait" ]; then
+    echo "❌ Quarkus failed to start"
+    cat quarkus-app/quarkus-dev.log
+    exit 1
+  fi
+  sleep 2
+  elapsed=$((elapsed + 2))
+done
+echo "✅ Quarkus started at ${E2E_BASE_URL}"
+
+echo "📦 Installing Playwright dependencies..."
+cd tests/e2e
+npm ci
+if [ -n "${CI:-}" ]; then
+  npx playwright install --with-deps chromium
+else
+  npx playwright install chromium
+fi
+cd ../..
+
+echo "🧪 Running Playwright E2E tests..."
+E2E_BASE_URL="${E2E_BASE_URL}" npm --prefix tests/e2e run test:e2e

--- a/scripts/ci/e2e-playwright.sh
+++ b/scripts/ci/e2e-playwright.sh
@@ -14,13 +14,23 @@ fi
 
 echo "🚀 Starting Quarkus (dev profile) for E2E tests..."
 cd quarkus-app
-./mvnw quarkus:dev -Ddebug=false -Dquarkus.http.port="${E2E_PORT}" "${MAVEN_ARGS[@]}" > quarkus-dev.log 2>&1 &
+# Run in a new process group (when setsid is available, e.g. Linux CI) so we
+# can kill the forked JVM that quarkus:dev spawns, not just the mvnw wrapper.
+if command -v setsid >/dev/null 2>&1; then
+  setsid ./mvnw quarkus:dev -Ddebug=false -Dquarkus.http.port="${E2E_PORT}" "${MAVEN_ARGS[@]}" > quarkus-dev.log 2>&1 &
+else
+  ./mvnw quarkus:dev -Ddebug=false -Dquarkus.http.port="${E2E_PORT}" "${MAVEN_ARGS[@]}" > quarkus-dev.log 2>&1 &
+fi
 QUARKUS_PID=$!
 cd ..
 
 cleanup() {
   if [ -n "${QUARKUS_PID:-}" ]; then
     echo "🛑 Stopping Quarkus (PID: $QUARKUS_PID)..."
+    # Kill the whole process group (wrapper + forked JVM) so the dev server
+    # does not linger and hold the port after the script exits.
+    kill -- "-${QUARKUS_PID}" 2>/dev/null || true
+    pkill -P "${QUARKUS_PID}" 2>/dev/null || true
     kill "$QUARKUS_PID" 2>/dev/null || true
     wait "$QUARKUS_PID" 2>/dev/null || true
   fi
@@ -52,4 +62,12 @@ fi
 cd ../..
 
 echo "🧪 Running Playwright E2E tests..."
+set +e
 E2E_BASE_URL="${E2E_BASE_URL}" npm --prefix tests/e2e run test:e2e
+test_exit=$?
+set -e
+if [ "$test_exit" -ne 0 ]; then
+  echo "❌ Playwright E2E tests failed (exit code $test_exit). Dumping Quarkus dev log..."
+  tail -n 100 quarkus-app/quarkus-dev.log
+fi
+exit "$test_exit"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,63 @@
+# Homedir E2E Tests (Playwright)
+
+End-to-end tests that exercise the running Quarkus application in a **real
+Chromium browser**, covering flows that unit/REST tests cannot validate:
+Qute template rendering with JS bundles, navigation between pages, the global
+notifications WebSocket, and the local dev login flow.
+
+## Prerequisites
+
+- JDK 21
+- Maven (or the included wrapper)
+- Node.js 20+ with npm
+
+## Run locally
+
+1. Start Quarkus in dev mode (from the repository root):
+
+   ```bash
+   cd quarkus-app
+   ./mvnw quarkus:dev
+   ```
+
+   This runs the `dev` profile: OIDC is disabled and local form auth uses the
+   embedded users (`user@example.com / userpass`, `admin@example.org / adminpass`).
+
+2. In another terminal, install and run the E2E suite:
+
+   ```bash
+   cd tests/e2e
+   npm ci
+   npx playwright install chromium
+   npm run test:e2e
+   ```
+
+The `E2E_BASE_URL` env var overrides the app URL (default `http://localhost:8080`).
+
+## What is covered
+
+| Spec | Scenario |
+|------|----------|
+| `login.spec.ts` | Dev login flow: valid credentials land on `/profile`, invalid credentials are rejected |
+| `homepage.spec.ts` | Homepage renders with auth bootstrap + JS bundle; static assets served; navigation between public pages |
+| `notifications-ws.spec.ts` | Global notifications WebSocket opens and completes the `hello` handshake |
+
+## Full-stack runner
+
+`scripts/ci/e2e-playwright.sh` starts Quarkus in dev mode, waits for
+`/q/health/ready`, installs the Playwright browser, runs the suite, and stops
+Quarkus. This is the entrypoint used by the CI job.
+
+## CI
+
+The `e2e` job in `.github/workflows/pr-check.yml` runs the full-stack runner on
+every PR. A Playwright HTML report is uploaded as a build artifact.
+
+## Maintainer notes
+
+- Only Chromium is exercised in this first iteration (no cross-browser,
+  visual regression, or mobile viewport tests).
+- These tests complement — they do not replace — the existing
+  `@QuarkusTest` REST tests.
+- The tests rely on the `dev` profile embedded users; keep credentials in
+  `application.properties` (`%dev.*`) in sync with `login.spec.ts`.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -9,7 +9,7 @@ notifications WebSocket, and the local dev login flow.
 
 - JDK 21
 - Maven (or the included wrapper)
-- Node.js 20+ with npm
+- Node.js 22 with npm (CI uses Node 22)
 
 ## Run locally
 
@@ -51,7 +51,8 @@ Quarkus. This is the entrypoint used by the CI job.
 ## CI
 
 The `e2e` job in `.github/workflows/pr-check.yml` runs the full-stack runner on
-every PR. A Playwright HTML report is uploaded as a build artifact.
+every PR. A Playwright HTML report and the Quarkus dev log are uploaded as
+build artifacts.
 
 ## Maintainer notes
 

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -8,7 +8,7 @@
       "name": "homedir-e2e",
       "version": "1.0.0",
       "devDependencies": {
-        "@playwright/test": "^1.54.0"
+        "@playwright/test": "^1.62.1"
       }
     },
     "node_modules/@playwright/test": {

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "homedir-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "homedir-e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.54.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "homedir-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "description": "End-to-end tests for Homedir using Playwright against a real Chromium browser",
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.62.1"
+  }
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -17,7 +17,9 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './tests',
-  fullyParallel: true,
+  // CI forces a single worker to serialize against the one Quarkus instance,
+  // so there is no parallelism there; only parallelize locally.
+  fullyParallel: !process.env.CI,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * E2E test configuration for Homedir.
+ *
+ * Tests run against a locally started Quarkus instance (dev profile), which
+ * exposes:
+ *   - form login at /login.html with embedded users
+ *   - the public pages (/, /eventos, /comunidad, ...)
+ *   - the global notifications WebSocket at /ws/global-notifications
+ *
+ * Start Quarkus with:
+ *   cd quarkus-app && ./mvnw quarkus:dev
+ *
+ * Then run:
+ *   npm run test:e2e
+ */
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [['html', { open: 'never' }], ['github']]
+    : [['list']],
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'http://localhost:8080',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/tests/e2e/tests/homepage.spec.ts
+++ b/tests/e2e/tests/homepage.spec.ts
@@ -34,15 +34,8 @@ test.describe('homepage and main pages', () => {
     }
   });
 
-  test('navigates between public pages', async ({ page }) => {
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
-
-    for (const [label, path] of [
-      ['/eventos', '/eventos'],
-      ['/comunidad', '/comunidad'],
-      ['/proyectos', '/proyectos'],
-    ] as const) {
+  test('loads public pages', async ({ page }) => {
+    for (const path of ['/eventos', '/comunidad', '/proyectos'] as const) {
       await page.goto(path);
       await expect(page).toHaveURL(new RegExp(path.replace('/', '\\/')));
       await page.waitForLoadState('networkidle');

--- a/tests/e2e/tests/homepage.spec.ts
+++ b/tests/e2e/tests/homepage.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Smoke tests for the main public pages: they must render, serve their JS
+ * bundles, and bootstrap the authentication state.
+ */
+test.describe('homepage and main pages', () => {
+  test('loads the homepage with auth bootstrap and JS bundle', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    await page.goto('/');
+    await expect(page).toHaveTitle(/Home/i);
+
+    const authBootstrap = await page
+      .locator('script')
+      .evaluateAll((scripts) =>
+        scripts.some((s) => (s.textContent || '').includes('window.userAuthenticated')),
+      );
+    expect(authBootstrap).toBeTruthy();
+
+    // The core-bundle.js must be loaded and executed (it sets COLLECTIBLES).
+    await page.waitForLoadState('networkidle');
+    const collectiblesDefined = await page.evaluate(() => !!window.COLLECTIBLES);
+    expect(collectiblesDefined).toBeTruthy();
+
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('serves critical static assets', async ({ page, request }) => {
+    for (const asset of ['/js/core-bundle.js', '/js/homedir.js', '/css/homedir.css']) {
+      const res = await request.get(asset);
+      expect(res.status(), `asset ${asset}`).toBe(200);
+    }
+  });
+
+  test('navigates between public pages', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    for (const [label, path] of [
+      ['/eventos', '/eventos'],
+      ['/comunidad', '/comunidad'],
+      ['/proyectos', '/proyectos'],
+    ] as const) {
+      await page.goto(path);
+      await expect(page).toHaveURL(new RegExp(path.replace('/', '\\/')));
+      await page.waitForLoadState('networkidle');
+      expect((await page.content()).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/e2e/tests/login.spec.ts
+++ b/tests/e2e/tests/login.spec.ts
@@ -15,8 +15,8 @@ test.describe('login flow', () => {
     await expect(page.locator('h1.dev-login-title')).toHaveText('HomeDir');
     await expect(page.locator('form.dev-login-form')).toBeVisible();
 
-    await page.fill('#username', 'user@example.com');
-    await page.fill('#password', 'userpass');
+    await page.locator('#username').fill('user@example.com');
+    await page.locator('#password').fill('userpass');
     await Promise.all([
       page.waitForURL('**/profile'),
       page.locator('button[type="submit"]').click(),
@@ -28,8 +28,8 @@ test.describe('login flow', () => {
   test('rejects invalid credentials', async ({ page }) => {
     await page.goto('/login.html');
 
-    await page.fill('#username', 'user@example.com');
-    await page.fill('#password', 'wrong-password');
+    await page.locator('#username').fill('user@example.com');
+    await page.locator('#password').fill('wrong-password');
     await page.locator('button[type="submit"]').click();
 
     // Form auth redirects back to the error page on failure.

--- a/tests/e2e/tests/login.spec.ts
+++ b/tests/e2e/tests/login.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Login flow against the local dev profile.
+ *
+ * The `dev` profile disables OIDC and enables Quarkus form auth with embedded
+ * users (see application.properties):
+ *   - admin@example.org / adminpass (roles admin,user)
+ *   - user@example.com / userpass (role user)
+ */
+test.describe('login flow', () => {
+  test('logs in with embedded dev user and lands on profile', async ({ page }) => {
+    await page.goto('/login.html');
+
+    await expect(page.locator('h1.dev-login-title')).toHaveText('HomeDir');
+    await expect(page.locator('form.dev-login-form')).toBeVisible();
+
+    await page.fill('#username', 'user@example.com');
+    await page.fill('#password', 'userpass');
+    await Promise.all([
+      page.waitForURL('**/profile'),
+      page.locator('button[type="submit"]').click(),
+    ]);
+
+    await expect(page).toHaveURL(/\/profile/);
+  });
+
+  test('rejects invalid credentials', async ({ page }) => {
+    await page.goto('/login.html');
+
+    await page.fill('#username', 'user@example.com');
+    await page.fill('#password', 'wrong-password');
+    await page.locator('button[type="submit"]').click();
+
+    // Form auth redirects back to the error page on failure.
+    await expect(page).toHaveURL(/login\.html/);
+  });
+});

--- a/tests/e2e/tests/notifications-ws.spec.ts
+++ b/tests/e2e/tests/notifications-ws.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Global notifications WebSocket.
+ *
+ * The page bundles open a WebSocket to /ws/global-notifications and send a
+ * `hello` handshake. The server answers with a `hello-ack` and optionally a
+ * backlog of recent notifications.
+ */
+test.describe('global notifications WebSocket', () => {
+  test('opens the WebSocket and completes the hello handshake', async ({ page }) => {
+    const helloAck = new Promise<string | null>((resolve) => {
+      const timer = setTimeout(() => resolve(null), 5000);
+      page.on('websocket', (ws) => {
+        ws.on('framereceived', (frame) => {
+          const payload = frame.payload.toString();
+          if (payload.includes('"hello-ack"')) {
+            clearTimeout(timer);
+            resolve(payload);
+          }
+        });
+      });
+    });
+
+    await page.goto('/');
+
+    // The page sends the hello handshake on open (see core-bundle.js).
+    const ack = await helloAck;
+    expect(ack).not.toBeNull();
+    expect(ack).toContain('hello-ack');
+  });
+});

--- a/tests/e2e/tests/notifications-ws.spec.ts
+++ b/tests/e2e/tests/notifications-ws.spec.ts
@@ -9,9 +9,18 @@ import { expect, test } from '@playwright/test';
  */
 test.describe('global notifications WebSocket', () => {
   test('opens the WebSocket and completes the hello handshake', async ({ page }) => {
-    const helloAck = new Promise<string | null>((resolve) => {
-      const timer = setTimeout(() => resolve(null), 5000);
+    const helloAck = new Promise<string>((resolve, reject) => {
+      // Reject on timeout so Playwright reports a clear "timed out waiting for
+      // hello-ack" error instead of a bare null assertion, and lets the
+      // configured retries kick in.
+      const timer = setTimeout(
+        () => reject(new Error('timeout waiting for hello-ack')),
+        15000,
+      );
       page.on('websocket', (ws) => {
+        // Only accept the global notifications socket; ignore frames from any
+        // other WebSocket endpoint on the page.
+        if (new URL(ws.url()).pathname !== '/ws/global-notifications') return;
         ws.on('framereceived', (frame) => {
           const payload = frame.payload.toString();
           if (payload.includes('"hello-ack"')) {
@@ -26,7 +35,6 @@ test.describe('global notifications WebSocket', () => {
 
     // The page sends the hello handshake on open (see core-bundle.js).
     const ack = await helloAck;
-    expect(ack).not.toBeNull();
     expect(ack).toContain('hello-ack');
   });
 });


### PR DESCRIPTION
Closes #1218

## Summary

Integrates [Playwright](https://playwright.dev) as an E2E testing framework running against a **real Chromium browser**, covering flows that the existing `@QuarkusTest` REST tests cannot validate: Qute template rendering with JS bundles, page navigation, the global notifications WebSocket, and the local dev login flow.

## Changes

- **`tests/e2e/playwright.config.ts`** — Playwright config (Chromium, `baseURL` overridable via `E2E_BASE_URL`, CI-friendly retries/reporters).
- **`tests/e2e/package.json`** — `@playwright/test` dependency and `test:e2e` script.
- **`tests/e2e/tests/`** — 6 E2E tests across 3 specs:
  - `login.spec.ts` — dev login flow (valid creds land on `/profile`, invalid rejected).
  - `homepage.spec.ts` — homepage auth bootstrap + JS bundle execution, static assets, navigation between public pages.
  - `notifications-ws.spec.ts` — global notifications WebSocket opens and completes the `hello`/`hello-ack` handshake.
- **`scripts/ci/e2e-playwright.sh`** — full-stack runner: starts Quarkus (dev profile), waits for `/q/health/ready`, installs Chromium, runs the suite, stops Quarkus.
- **`.github/workflows/pr-check.yml`** — new `e2e` gate job that runs the suite and uploads the HTML report as an artifact.
- **`tests/e2e/README.md`** — local run + maintenance docs.

## Acceptance criteria

- [x] Playwright configurado con `playwright.config.ts` en `/tests/e2e/`
- [x] `package.json` con dependencias y script `test:e2e` en `/tests/e2e/`
- [x] Al menos 3 tests E2E críticos: login flow, homepage load, notifications WebSocket
- [x] GitHub Actions job que arranca Quarkus + ejecuta Playwright contra él
- [x] README con instrucciones de ejecución local

## Validation

- 6/6 tests pass locally against `quarkus:dev` (dev profile, embedded users `user@example.com`/`userpass`).
- Out of scope (per issue): cross-browser, visual regression, mobile viewport — first iteration is Chromium only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for homepage loading, authentication, navigation, and notification connectivity.
  * Added local and CI test commands with browser-based reporting.

* **Documentation**
  * Added setup, execution, covered scenarios, and reporting guidance for end-to-end tests.

* **Chores**
  * Added automated CI execution with downloadable test reports.
  * Added exclusions for generated browser test artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->