### PR TITLE
chore(sdlc): implement issue #1115

### DIFF
--- a/.github/workflows/pr-quality-suite.yml
+++ b/.github/workflows/pr-quality-suite.yml
@@ -94,6 +94,13 @@ jobs:
         working-directory: quarkus-app
         run: ./mvnw verify -B -Pcoverage -Dsurefire.rerunFailingTestsCount=1
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+        with:
+          files: quarkus-app/target/site/jacoco/jacoco.xml
+          fail_ci_if_error: false
+          verbose: true
+
   deps:
     name: deps
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![PR Validation](https://img.shields.io/github/actions/workflow/status/os-santiago/homedir/pr-check.yml?style=for-the-badge&label=PR%20Validation&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/actions/workflows/pr-check.yml)
 [![PR CI Build](https://img.shields.io/github/actions/workflow/status/os-santiago/homedir/pr-ci-build-native-sbom.yml?style=for-the-badge&label=PR%20CI%20Build&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/actions/workflows/pr-ci-build-native-sbom.yml)
 [![PR Quality](https://img.shields.io/github/actions/workflow/status/os-santiago/homedir/pr-quality-suite.yml?style=for-the-badge&label=PR%20Quality&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/actions/workflows/pr-quality-suite.yml)
+[![Coverage](https://img.shields.io/codecov/c/github/os-santiago/homedir?style=for-the-badge&logo=codecov&logoColor=white)](https://codecov.io/gh/os-santiago/homedir)
 [![Language](https://img.shields.io/github/languages/top/os-santiago/homedir?style=for-the-badge&logo=java&logoColor=white&color=ED8B00)](https://github.com/os-santiago/homedir)
 [![Last Commit](https://img.shields.io/github/last-commit/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/commits/main)
 [![Version](https://img.shields.io/github/v/release/os-santiago/homedir?label=Version&style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/releases)

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -48,6 +48,7 @@ Spanish (`docs/es`) mirrors this tree with either full translations or stubs.
 - [Security Hardening Baseline](development/security-hardening-baseline.md)
 - [Production-Safe Delivery Playbook](development/production-safe-delivery-playbook.md)
 - [Release Stage Gates](development/release-stage-gates.md)
+- [Code Coverage with Codecov](development/codecov-coverage.md)
 
 ## AI Context
 

--- a/docs/en/development/codecov-coverage.md
+++ b/docs/en/development/codecov-coverage.md
@@ -1,0 +1,57 @@
+# Code Coverage with Codecov
+
+This document explains how code coverage is measured and published for HomeDir.
+
+## Overview
+
+Coverage is measured with JaCoCo inside the `coverage` Maven profile of the Quarkus
+application (`quarkus-app/pom.xml`). The `tests_cov` job of
+`.github/workflows/pr-quality-suite.yml` runs the test suite with that profile and
+uploads the report to Codecov. The README shows a live coverage badge fed by Codecov.
+
+## How it works
+
+1. The `tests_cov` job runs `./mvnw verify -B -Pcoverage`.
+2. JaCoCo generates the report at `quarkus-app/target/site/jacoco/jacoco.xml`.
+3. The `codecov/codecov-action` uploads that file to Codecov.
+4. Codecov renders the badge in the README and provides per-PR coverage comments.
+
+## Coverage gates
+
+JaCoCo enforces minimum ratios during `verify`:
+
+- Line coverage: `0.60` (60%)
+- Branch coverage: `0.40` (40%)
+
+These values are defined in the `check` execution of the `coverage` profile in
+`quarkus-app/pom.xml`. A PR that drops below these thresholds fails the `tests_cov`
+gate before any coverage is reported to Codecov.
+
+## Required setup (repository admin)
+
+The following steps require repository `Admin` permissions:
+
+1. Create a Codecov account for the `os-santiago` organization and authorize the
+   `homedir` repository.
+2. Add a repository secret named `CODECOV_TOKEN` in
+   `Settings > Secrets and variables > Actions`, using the repository token Codecov
+   provides.
+3. Verify the first PR run appears in the Codecov dashboard.
+
+Until the secret is configured, the upload step is non-blocking
+(`fail_ci_if_error: false`), so CI still passes but the badge shows no data.
+
+## Roles
+
+- Coverage data is public once the repository is public on Codecov.
+- Only members with `Admin` permission can change repository secrets. If you need
+  access, ask a current admin to grant you the `Admin` role on `os-santiago/homedir`.
+
+## How to check locally
+
+```bash
+cd quarkus-app
+./mvnw verify -Pcoverage
+```
+
+The HTML report is available at `target/site/jacoco/index.html`.

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -48,6 +48,7 @@ El idioma canonico para mantenimiento es **ingles**.
 - [Codex Optimization Notes (stub)](development/codex-optimization-notes.md)
 - [Production-Safe Delivery Playbook (stub)](development/production-safe-delivery-playbook.md)
 - [Release Stage Gates (stub)](development/release-stage-gates.md)
+- [Cobertura de codigo con Codecov](development/codecov-coverage.md)
 
 ## Contexto AI
 

--- a/docs/es/development/codecov-coverage.md
+++ b/docs/es/development/codecov-coverage.md
@@ -1,0 +1,59 @@
+# Cobertura de Código con Codecov
+
+Este documento explica cómo se mide y publica la cobertura de código de HomeDir.
+
+## Resumen
+
+La cobertura se mide con JaCoCo dentro del perfil `coverage` de Maven de la aplicación
+Quarkus (`quarkus-app/pom.xml`). El job `tests_cov` de
+`.github/workflows/pr-quality-suite.yml` ejecuta la suite de pruebas con ese perfil y
+sube el reporte a Codecov. El README muestra un badge de cobertura en vivo alimentado
+por Codecov.
+
+## Cómo funciona
+
+1. El job `tests_cov` ejecuta `./mvnw verify -B -Pcoverage`.
+2. JaCoCo genera el reporte en `quarkus-app/target/site/jacoco/jacoco.xml`.
+3. El `codecov/codecov-action` sube ese archivo a Codecov.
+4. Codecov renderiza el badge en el README y provee comentarios de cobertura por PR.
+
+## Umbrales de cobertura
+
+JaCoCo aplica ratios mínimos durante `verify`:
+
+- Cobertura de líneas: `0.60` (60%)
+- Cobertura de ramas: `0.40` (40%)
+
+Estos valores están definidos en la ejecución `check` del perfil `coverage` en
+`quarkus-app/pom.xml`. Un PR que baje de estos umbrales falla la compuerta `tests_cov`
+antes de que se reporte cualquier cobertura a Codecov.
+
+## Configuración requerida (admin del repositorio)
+
+Los siguientes pasos requieren permisos de `Admin` del repositorio:
+
+1. Crea una cuenta de Codecov para la organización `os-santiago` y autoriza el
+   repositorio `homedir`.
+2. Agrega un secreto de repositorio llamado `CODECOV_TOKEN` en
+   `Settings > Secrets and variables > Actions`, usando el token de repositorio que
+   provee Codecov.
+3. Verifica que la primera ejecución de un PR aparezca en el panel de Codecov.
+
+Hasta que el secreto esté configurado, el paso de subida no bloquea
+(`fail_ci_if_error: false`), por lo que CI sigue pasando pero el badge no muestra datos.
+
+## Roles
+
+- Los datos de cobertura son públicos una vez que el repositorio es público en Codecov.
+- Solo los miembros con permiso `Admin` pueden cambiar los secretos del repositorio. Si
+  necesitas acceso, pide a un admin actual que te conceda el rol `Admin` en
+  `os-santiago/homedir`.
+
+## Cómo verificarlo localmente
+
+```bash
+cd quarkus-app
+./mvnw verify -Pcoverage
+```
+
+El reporte HTML está disponible en `target/site/jacoco/index.html`.


### PR DESCRIPTION
Implements #1115

- Adds Codecov upload of the JaCoCo report to the tests_cov job in pr-quality-suite.yml
- Adds a live Codecov coverage badge to the README
- Adds an instructive document (EN canonical + ES mirror) with setup steps and coverage gates

Refs #1115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code coverage report uploads to the pull request quality checks.
  * Coverage upload issues will not interrupt continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->