### PR TITLE
refactor(css): centralize design tokens and remove hardcoded colors (Issue #1018)

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,0 +1,39 @@
+# HomeDir CSS Style Guide
+
+Conventions for writing and naming CSS in the HomeDir codebase.
+
+## Design tokens
+
+- All colors, fonts, spacing, and other reusable values MUST be defined as CSS
+  custom properties in `css/tokens.css`.
+- Components MUST consume tokens via `var(--token-name)` — never hardcode a
+  color, font, or spacing value in component styles.
+- The palette is intentionally shared across the retro theme (`homedir.css`,
+  `retro-theme.css`) and feature stylesheets (`notifications.css`, etc.).
+- `styles.css` keeps its own `:root` for its independent modern token set; do
+  not redefine those names in feature sheets.
+
+## Naming conventions
+
+### Custom properties (`--token-name`)
+
+- Lowercase, `kebab-case`, descriptive: `--toast-bg`, `--notif-badge-bg`.
+- Semantic intent first: `--toast-bg`, not `--gray-333`.
+- RGB channel aliases (`--white-rgb`) exist so `rgba(var(--white-rgb), 0.7)`
+  can be used for translucent tones.
+
+### Classes
+
+- Use `kebab-case` for multi-word class names: `.notifications-bell`, `.filter-btn`.
+- BEM-lite: block prefix for related parts: `.ef-toast`, `.ef-toast__title`,
+  `.ef-toast__actions`.
+- Utility classes from `styles.css` (`.U-P-*`, `.u-elev-*`, `.container`)
+  may be composed in markup but must not be reimplemented in feature CSS.
+
+## Rules
+
+- Do NOT use `!important`. Use a higher-specificity selector instead.
+- Prefer `:focus-visible` for focus rings; ensure keyboard targets are ≥ 44×44px.
+- Respect `prefers-reduced-motion` for all animations/transitions.
+- Keep selector specificity low (single class or element + class where possible).
+- Inline `style="..."` attributes are forbidden in templates; use classes.

--- a/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
@@ -17,11 +17,11 @@
 }
 
 .ef-toast {
-  background: #333;
-  color: #fff;
+  background: var(--toast-bg);
+  color: var(--toast-text);
   padding: 0.75rem 1rem;
   border-radius: 4px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 8px rgba(var(--black-rgb), 0.2);
   width: min(360px, 90%);
   pointer-events: auto;
   display: flex;
@@ -37,7 +37,7 @@
 }
 
 .ef-toast[role="alert"] {
-  border-left: 3px solid var(--color-accent, #60a5fa);
+  border-left: 3px solid var(--color-accent);
 }
 
 .ef-toast__title {
@@ -59,8 +59,8 @@
   justify-content: center;
   padding: 0.25rem 0.5rem;
   border: none;
-  background: #555;
-  color: #fff;
+  background: var(--toast-action-bg);
+  color: var(--toast-text);
   text-decoration: none;
   border-radius: 4px;
 }
@@ -68,7 +68,7 @@
 .ef-toast button:focus,
 .ef-toast a:focus,
 #ef-toast-close-all:focus {
-  outline: 2px solid #fff;
+  outline: 2px solid var(--toast-text);
   outline-offset: 2px;
 }
 
@@ -77,8 +77,8 @@
   min-height: 44px;
   min-width: 88px;
   padding: 0.25rem 0.75rem;
-  background: #444;
-  color: #fff;
+  background: var(--toast-close-bg);
+  color: var(--toast-text);
   border: none;
   border-radius: 4px;
 }
@@ -123,7 +123,7 @@
 }
 
 #empty p {
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(var(--white-rgb), 0.7);
 }
 
 .notifications-empty-hint {
@@ -142,23 +142,23 @@
 
 .notifications-sample {
   margin-top: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(var(--white-rgb), 0.14);
   border-radius: 12px;
   padding: 0.9rem 1rem;
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(var(--white-rgb), 0.03);
 }
 
 .notifications-sample-title {
   margin: 0 0 0.5rem;
   font-size: 0.95rem;
   font-weight: 700;
-  color: rgba(255, 255, 255, 0.9);
+  color: rgba(var(--white-rgb), 0.9);
 }
 
 .notifications-sample-list {
   margin: 0;
   padding-left: 1.15rem;
-  color: rgba(255, 255, 255, 0.72);
+  color: rgba(var(--white-rgb), 0.72);
   font-size: 0.88rem;
   display: grid;
   gap: 0.3rem;
@@ -317,8 +317,8 @@
   position: absolute;
   top: 0;
   right: 0;
-  background: #d00;
-  color: #fff;
+  background: var(--notif-badge-bg);
+  color: var(--toast-text);
   border-radius: 999px;
   padding: 0 4px;
   font-size: 0.75rem;
@@ -353,5 +353,5 @@
   outline: none;
 }
 .notifications-center dialog::backdrop {
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay-dark);
 }

--- a/quarkus-app/src/main/resources/META-INF/resources/css/tokens.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/tokens.css
@@ -1,0 +1,49 @@
+/* =========================================================
+   HomeDir Design Tokens (source of truth)
+   - Loaded AFTER homedir.css so these values win in cascade.
+   - Palette intentionally matches the active retro theme.
+   - See STYLEGUIDE.md for naming conventions.
+   ========================================================= */
+
+:root {
+  --font-display: 'Orbitron', sans-serif;
+  --font-body: 'Exo 2', sans-serif;
+
+  /* Color Palette — RGB channels (for rgba()) */
+  --gold-rgb: 255, 215, 0;
+  --white-rgb: 255, 255, 255;
+  --black-rgb: 0, 0, 0;
+  --primary-rgb: 102, 126, 234;
+  --mint-rgb: 120, 255, 160;
+
+  --color-accent: #ffd700;
+  --color-text-main: #ffffff;
+  --color-text-muted: rgba(var(--white-rgb), 0.9);
+  --card-bg: rgba(var(--black-rgb), 0.45);
+  --color-primary: #667eea;
+  --color-mint: rgba(var(--mint-rgb), 0.85);
+  --color-surface-dark: rgba(var(--black-rgb), 0.35);
+  --color-border: rgba(var(--white-rgb), 0.2);
+  --color-gradient-end: #764ba2;
+  --color-error: #ff4444;
+  --color-warning: #ffa500;
+  --color-success: #55c47a;
+  --color-dark-bg: #111;
+  --color-dark-text: #333;
+
+  /* Notification-specific tokens */
+  --toast-bg: #333;
+  --toast-text: #fff;
+  --toast-action-bg: #555;
+  --toast-close-bg: #444;
+  --notif-badge-bg: #d00;
+  --overlay-dark: rgba(0, 0, 0, 0.5);
+
+  --text-xs: 0.85rem;
+  --text-sm: 0.95rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+}

--- a/quarkus-app/src/main/resources/templates/layout/main.html
+++ b/quarkus-app/src/main/resources/templates/layout/main.html
@@ -33,6 +33,7 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v={app:version()}" />
   <link rel="icon" href="/favicon.ico?v={app:version()}" />
   <link rel="stylesheet" href="/styles.css?v={app:version()}" />
+  <link rel="stylesheet" href="/css/tokens.css?v={app:version()}" />
   <link rel="stylesheet" href="/css/retro-theme.css?v={app:version()}" />
   <link rel="stylesheet" href="/css/homedir.css?v={app:version()}" />
   <link rel="stylesheet" href="/css/notifications.css?v={app:version()}" />


### PR DESCRIPTION
Closes #1018

## Summary

Addresses the inconsistent CSS architecture in the notifications area by
centralizing all design tokens in a new `tokens.css` and replacing hardcoded
colors in `notifications.css` with `var()` references.

## Changes

- **New `css/tokens.css`** — single source of truth for design tokens: mirrors
  the existing `homedir.css :root` palette (colors, RGB channel aliases, font,
  typography scale) and adds notification-specific tokens (`--toast-bg`,
  `--toast-text`, `--toast-action-bg`, `--toast-close-bg`, `--notif-badge-bg`,
  `--overlay-dark`).
- **`css/notifications.css`** — replaced every hardcoded color (`#333`, `#444`,
  `#555`, `#fff`, `#d00`, `rgba(...)`) with token references. Visual output is
  byte-identical to before (verified in-browser).
- **`templates/layout/main.html`** — loads `tokens.css` before component
  stylesheets so tokens are available across the site.
- **New `STYLEGUIDE.md`** — documents the CSS naming conventions (token naming,
  BEM-lite classes, no `!important`, focus/reduced-motion rules).

## Notes

- The inline styles and `border: none !important` overrides cited in the issue
  for `center.html` were already removed in earlier refactors; `center.html`
  currently uses classes only, and `#confirmDeleteAll` is styled in CSS.
- `!important` occurrences left in `homedir.css`/`retro-theme.css` are all
  inside `prefers-reduced-motion` blocks (accessibility) and are intentionally
  kept.

## Validation

- `JsBundleE2ETest` (asset serving incl. `tokens.css`): 10/10 passed (JDK 21).
- In-browser check on `/notifications/center`: `tokens.css` served 200; computed
  styles of `.ef-toast`, toast buttons, and `.notifications-bell .badge` resolve
  to the original values (`rgb(51,51,51)`, `rgb(255,255,255)`, `rgb(85,85,85)`,
  `rgb(221,0,0)`).