### PR TITLE
feat(notifications): loading skeleton and error state in notification center (#1022)

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
@@ -2888,6 +2888,9 @@ public interface AppMessages {
   @Message("You will see new events, schedule changes, and key project updates here.")
   String notifications_center_empty_hint();
 
+  @Message("Could not load notifications. Local storage may be unavailable or corrupted.")
+  String notifications_center_error();
+
   @Message("Explore Events")
   String notifications_center_empty_cta_events();
 

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -6422,3 +6422,60 @@ footer {
     padding: 0.5rem;
   }
 }
+
+/* =========================================================
+   Reusable Loading Pattern (issue #1022)
+   - Skeleton cards for initial content load
+   - Button loading state (disabled + visual feedback)
+   - Designed for progressive enhancement: add the `no-js`
+     class in HTML so the skeleton is hidden without JS,
+     then JS removes it on load.
+   ========================================================= */
+
+.hd-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1;
+}
+
+.hd-skeleton.hidden {
+  display: none;
+}
+
+/* Hide skeleton by default when JS is disabled */
+.hd-skeleton.no-js {
+  display: none;
+}
+
+.hd-skeleton-card {
+  min-height: 92px;
+  border: 3px solid rgba(var(--white-rgb), 0.7);
+  border-bottom: 6px solid rgba(var(--black-rgb), 0.7);
+  border-right: 5px solid rgba(var(--black-rgb), 0.6);
+  background: rgba(var(--black-rgb), 0.45);
+  box-shadow: 0 6px 0 rgba(var(--black-rgb), 0.6);
+  opacity: 0.6;
+  border-radius: 10px;
+}
+
+/* Button loading state: disables interaction and shows visual feedback */
+.hd-btn.is-loading {
+  pointer-events: none;
+  opacity: 0.6;
+  position: relative;
+}
+
+.hd-btn.is-loading::after {
+  content: '...';
+  display: inline-block;
+  margin-left: 0.25rem;
+  animation: hd-loading-dots 1s steps(4, end) infinite;
+}
+
+@keyframes hd-loading-dots {
+  0% { content: ''; }
+  25% { content: '.'; }
+  50% { content: '..'; }
+  75% { content: '...'; }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
@@ -106,6 +106,63 @@
   flex: 1;
 }
 
+#notif-list.hidden {
+  display: none;
+}
+
+/* Loading skeleton: shown on initial paint until the first render completes. */
+.notif-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1;
+}
+
+.notif-skeleton.hidden {
+  display: none;
+}
+
+/* Hide the skeleton by default when JS is disabled (no-js class is removed
+   by JS on load). This prevents no-JS users from being stuck on a loading
+   state forever. */
+.notif-skeleton.no-js {
+  display: none;
+}
+
+.notif-skeleton-card {
+  min-height: 92px;
+  border: 3px solid rgba(var(--white-rgb), 0.7);
+  border-bottom: 6px solid rgba(var(--black-rgb), 0.7);
+  border-right: 5px solid rgba(var(--black-rgb), 0.6);
+  background: rgba(var(--black-rgb), 0.45);
+  box-shadow: 0 6px 0 rgba(var(--black-rgb), 0.6);
+  opacity: 0.6;
+  border-radius: 10px;
+}
+
+/* Error state: visually distinct from loading (skeleton) and empty. */
+.notif-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  min-height: 300px;
+  flex: 1;
+  color: rgba(var(--white-rgb), 0.85);
+}
+
+.notif-error.hidden {
+  display: none;
+}
+
+.notif-error .material-symbols-outlined {
+  font-size: 3rem;
+  opacity: 0.7;
+  margin-bottom: 1rem;
+  color: var(--danger, #e5484d);
+}
+
 #empty {
   display: flex;
   flex-direction: column;

--- a/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
@@ -110,37 +110,9 @@
   display: none;
 }
 
-/* Loading skeleton: shown on initial paint until the first render completes. */
-.notif-skeleton {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  flex: 1;
-}
-
-.notif-skeleton.hidden {
-  display: none;
-}
-
-/* Hide the skeleton by default when JS is disabled (no-js class is removed
-   by JS on load). This prevents no-JS users from being stuck on a loading
-   state forever. */
-.notif-skeleton.no-js {
-  display: none;
-}
-
-.notif-skeleton-card {
-  min-height: 92px;
-  border: 3px solid rgba(var(--white-rgb), 0.7);
-  border-bottom: 6px solid rgba(var(--black-rgb), 0.7);
-  border-right: 5px solid rgba(var(--black-rgb), 0.6);
-  background: rgba(var(--black-rgb), 0.45);
-  box-shadow: 0 6px 0 rgba(var(--black-rgb), 0.6);
-  opacity: 0.6;
-  border-radius: 10px;
-}
-
-/* Error state: visually distinct from loading (skeleton) and empty. */
+/* Error state: visually distinct from loading (skeleton) and empty.
+   The reusable skeleton pattern (.hd-skeleton / .hd-skeleton-card) is
+   defined in homedir.css and shared across templates (issue #1022). */
 .notif-error {
   display: flex;
   flex-direction: column;

--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
@@ -27,6 +27,8 @@
   const UNREAD_KEY = 'ef_global_unread_count';
   const listEl  = document.getElementById('notif-list');
   const emptyEl = document.getElementById('empty');
+  const skeletonEl = document.getElementById('notif-skeleton');
+  const errorEl = document.getElementById('notif-error');
   const markAllBtn = document.getElementById('markAllRead');
   const deleteBtn  = document.getElementById('deleteSelected');
   const selectAllBtn = document.getElementById('selectAll');
@@ -44,11 +46,16 @@
   // Estado de selección en memoria (se preserva entre renders)
   const selected = new Set();
   let currentFilter = 'all';
+  let storageFailed = false;
 
   // Utilidades de almacenamiento
   function getAll() {
     try { return JSON.parse(localStorage.getItem(LS_KEY) || '[]'); }
-    catch (e) { console.warn('notifications-center: failed to read storage', e); return []; }
+    catch (e) {
+      console.warn('notifications-center: failed to read storage', e);
+      storageFailed = true;
+      return [];
+    }
   }
   function saveAll(arr) {
     try {
@@ -84,10 +91,32 @@
     try { return new Date(ts || Date.now()).toLocaleString(); } catch { return ''; }
   }
 
+  // Remove the no-js class so the skeleton becomes visible (CSS hides it
+  // when no-js is present, for users without JavaScript).
+  if (skeletonEl) skeletonEl.classList.remove('no-js');
+
+  // Oculta el skeleton de carga inicial (se muestra en el HTML hasta el primer render).
+  function hideSkeleton() {
+    if (skeletonEl) skeletonEl.classList.add('hidden');
+  }
+
   // Render de la lista aplicando filtro y preservando selección
   function render() {
     const all = getAll();
     syncUnread(all);
+    hideSkeleton();
+
+    // Estado de error de almacenamiento: distinto de "vacío" (criterio #1022).
+    if (storageFailed && errorEl) {
+      errorEl.classList.remove('hidden');
+      listEl.classList.add('hidden');
+      emptyEl.classList.add('hidden');
+      actionsRight?.classList.add('hidden');
+      updateSelectAllBtn();
+      return;
+    }
+    if (errorEl) errorEl.classList.add('hidden');
+
     let items = all.filter(n => !n.dismissedAt);
 
     const startOfDay = new Date();
@@ -105,12 +134,14 @@
 
     listEl.innerHTML = '';
     if (items.length === 0) {
+      listEl.classList.add('hidden');
       emptyEl.classList.remove('hidden');
       actionsRight?.classList.add('hidden');
       renderSampleCards();
       updateSelectAllBtn();
       return;
     }
+    listEl.classList.remove('hidden');
     emptyEl.classList.add('hidden');
     actionsRight?.classList.remove('hidden');
 

--- a/quarkus-app/src/main/resources/com/scanales/homedir/config/AppMessages.properties
+++ b/quarkus-app/src/main/resources/com/scanales/homedir/config/AppMessages.properties
@@ -946,6 +946,7 @@ notifications_center_action_delete_selected=Delete selected
 notifications_center_action_delete_all=Delete all
 notifications_center_empty=No notifications for now.
 notifications_center_empty_hint=You will see new events, schedule changes, and key project updates here.
+notifications_center_error=Could not load notifications. Local storage may be unavailable or corrupted.
 notifications_center_empty_cta_events=Explore Events
 notifications_center_empty_cta_board=Open Community Board
 notifications_center_confirm_title=Delete all?

--- a/quarkus-app/src/main/resources/com/scanales/homedir/config/AppMessages_es.properties
+++ b/quarkus-app/src/main/resources/com/scanales/homedir/config/AppMessages_es.properties
@@ -1448,6 +1448,7 @@ notifications_center_confirm_btn=Confirmar
 notifications_center_confirm_desc=¿Estás seguro de que deseas eliminar todas las notificaciones recibidas?
 notifications_center_confirm_title=¿Eliminar todo?
 notifications_center_empty=No hay notificaciones por ahora.
+notifications_center_error=No se pudieron cargar las notificaciones. El almacenamiento local podría no estar disponible o estar corrupto.
 notifications_center_empty_cta_board=Junta de comunidad abierta
 notifications_center_empty_cta_events=Explorar eventos
 notifications_center_empty_hint=Verá nuevos eventos, cambios de programación y actualizaciones clave del proyecto aquí.

--- a/quarkus-app/src/main/resources/i18n.properties
+++ b/quarkus-app/src/main/resources/i18n.properties
@@ -1613,6 +1613,7 @@ notifications_center_confirm_btn=Confirm
 notifications_center_confirm_desc=Are you sure you want to delete all received notifications?
 notifications_center_confirm_title=Delete all?
 notifications_center_empty=No notifications for now.
+notifications_center_error=Could not load notifications. Local storage may be unavailable or corrupted.
 notifications_center_empty_cta_board=Open Community Board
 notifications_center_empty_cta_events=Explore Events
 notifications_center_empty_hint=You will see new events, schedule changes, and key project updates here.

--- a/quarkus-app/src/main/resources/i18n_en.properties
+++ b/quarkus-app/src/main/resources/i18n_en.properties
@@ -1613,6 +1613,7 @@ notifications_center_confirm_btn=Confirm
 notifications_center_confirm_desc=Are you sure you want to delete all received notifications?
 notifications_center_confirm_title=Delete all?
 notifications_center_empty=No notifications for now.
+notifications_center_error=Could not load notifications. Local storage may be unavailable or corrupted.
 notifications_center_empty_cta_board=Open Community Board
 notifications_center_empty_cta_events=Explore Events
 notifications_center_empty_hint=You will see new events, schedule changes, and key project updates here.

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -672,6 +672,7 @@ notifications_center_action_mark_all_read=Marcar todas como leídas
 notifications_center_action_delete_selected=Eliminar seleccionadas
 notifications_center_action_delete_all=Eliminar todas
 notifications_center_empty=No hay notificaciones por ahora.
+notifications_center_error=No se pudieron cargar las notificaciones. El almacenamiento local podría no estar disponible o estar corrupto.
 notifications_center_empty_hint=Aquí verás nuevos eventos, cambios de agenda y actualizaciones importantes de proyectos que sigues.
 notifications_center_empty_cta_events=Explorar eventos
 notifications_center_empty_cta_board=Abrir Community Board

--- a/quarkus-app/src/main/resources/templates/notifications/center.html
+++ b/quarkus-app/src/main/resources/templates/notifications/center.html
@@ -28,10 +28,10 @@
         </div>
       </div>
 
-      <div id="notif-skeleton" class="notif-skeleton no-js" aria-hidden="true">
-        <div class="notif-skeleton-card"></div>
-        <div class="notif-skeleton-card"></div>
-        <div class="notif-skeleton-card"></div>
+      <div id="notif-skeleton" class="hd-skeleton no-js" aria-hidden="true">
+        <div class="hd-skeleton-card"></div>
+        <div class="hd-skeleton-card"></div>
+        <div class="hd-skeleton-card"></div>
       </div>
       <div id="notif-error" class="notif-error hidden" role="alert">
         {#include fragments/empty-state message=i18n:notifications_center_error icon="error" hintClass="notifications-empty-hint"}

--- a/quarkus-app/src/main/resources/templates/notifications/center.html
+++ b/quarkus-app/src/main/resources/templates/notifications/center.html
@@ -28,6 +28,15 @@
         </div>
       </div>
 
+      <div id="notif-skeleton" class="notif-skeleton no-js" aria-hidden="true">
+        <div class="notif-skeleton-card"></div>
+        <div class="notif-skeleton-card"></div>
+        <div class="notif-skeleton-card"></div>
+      </div>
+      <div id="notif-error" class="notif-error hidden" role="alert">
+        {#include fragments/empty-state message=i18n:notifications_center_error icon="error" hintClass="notifications-empty-hint"}
+        {/include}
+      </div>
       <div id="notif-list" aria-live="polite"></div>
       <div id="empty" class="hidden">
         {#include fragments/empty-state message=i18n:notifications_center_empty icon="notifications_off" hint=i18n:notifications_center_empty_hint hintClass="notifications-empty-hint"}

--- a/tests/test_notifications_center_loading_states.py
+++ b/tests/test_notifications_center_loading_states.py
@@ -1,0 +1,74 @@
+"""Static assertions for issue #1022: the notifications center must show a
+loading skeleton on initial paint, hide it after the first render, and present
+an error state that is visually distinct from the empty state when local
+storage cannot be read.
+
+The skeleton must be hidden when JS is disabled (via a ``no-js`` CSS class that
+JS removes on load) so users are not stuck on a loading state forever, and the
+list must NOT start with ``class="hidden"`` so it remains accessible without JS.
+"""
+
+from pathlib import Path
+
+CENTER = Path("quarkus-app/src/main/resources/templates/notifications/center.html").read_text()
+JS = Path("quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js").read_text()
+CSS = Path("quarkus-app/src/main/resources/META-INF/resources/css/notifications.css").read_text()
+I18N = Path("quarkus-app/src/main/resources/i18n.properties").read_text()
+I18N_ES = Path("quarkus-app/src/main/resources/i18n_es.properties").read_text()
+APP_MESSAGES = Path(
+    "quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java"
+).read_text()
+
+
+def test_center_has_skeleton_and_error_markup() -> None:
+    assert 'id="notif-skeleton"' in CENTER
+    assert 'class="notif-skeleton-card"' in CENTER
+    assert 'id="notif-error"' in CENTER
+    assert 'role="alert"' in CENTER
+    # The list must NOT start hidden — otherwise no-JS users are stuck on the
+    # skeleton forever. JS manages visibility on first render instead.
+    assert 'id="notif-list" aria-live="polite" class="hidden"' not in CENTER
+    assert 'id="notif-list" aria-live="polite"' in CENTER
+
+
+def test_skeleton_uses_no_js_class_for_progressive_enhancement() -> None:
+    """The skeleton has a 'no-js' class in HTML that CSS hides by default.
+    JS removes it on load so the skeleton becomes visible for JS users."""
+    assert 'class="notif-skeleton no-js"' in CENTER
+    assert ".notif-skeleton.no-js" in CSS
+    assert "display: none" in CSS
+    # JS must remove the no-js class so the skeleton is visible for JS users.
+    assert "classList.remove('no-js')" in JS
+
+
+def test_no_qute_breaking_noscript_inline_style() -> None:
+    """The previous <noscript><style> approach broke Qute because {display:none}
+    was parsed as a template expression. Ensure it's gone."""
+    assert "<noscript>" not in CENTER or "display:none" not in CENTER
+
+
+def test_js_hides_skeleton_and_distinguishes_error_from_empty() -> None:
+    assert "hideSkeleton()" in JS
+    assert "skeletonEl" in JS
+    assert "errorEl" in JS
+    assert "storageFailed" in JS
+    # Error path returns before the empty-state path (distinct states).
+    assert JS.index("storageFailed") < JS.index("items = all.filter")
+
+
+def test_css_has_loading_and_error_styles_distinct_from_empty() -> None:
+    assert ".notif-skeleton" in CSS
+    assert ".notif-skeleton-card" in CSS
+    assert ".notif-error" in CSS
+    assert ".notif-error.hidden" in CSS
+
+
+def test_i18n_keys_exist_for_error_state() -> None:
+    assert "notifications_center_error=" in I18N
+    assert "notifications_center_error=" in I18N_ES
+
+
+def test_app_messages_defines_error_method() -> None:
+    """The Qute template uses {i18n:notifications_center_error} which requires a
+    matching method on AppMessages.java — without it the build fails."""
+    assert "notifications_center_error()" in APP_MESSAGES

--- a/tests/test_notifications_center_loading_states.py
+++ b/tests/test_notifications_center_loading_states.py
@@ -6,6 +6,11 @@ storage cannot be read.
 The skeleton must be hidden when JS is disabled (via a ``no-js`` CSS class that
 JS removes on load) so users are not stuck on a loading state forever, and the
 list must NOT start with ``class="hidden"`` so it remains accessible without JS.
+
+The skeleton uses the reusable ``hd-skeleton`` / ``hd-skeleton-card`` classes
+defined in the shared ``homedir.css`` (criterion 4: reusable loading pattern).
+The error state remains page-specific (``.notif-error``) in ``notifications.css``
+because its visual treatment is unique to this page.
 """
 
 from pathlib import Path
@@ -13,6 +18,7 @@ from pathlib import Path
 CENTER = Path("quarkus-app/src/main/resources/templates/notifications/center.html").read_text()
 JS = Path("quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js").read_text()
 CSS = Path("quarkus-app/src/main/resources/META-INF/resources/css/notifications.css").read_text()
+HOMEDIR_CSS = Path("quarkus-app/src/main/resources/META-INF/resources/css/homedir.css").read_text()
 I18N = Path("quarkus-app/src/main/resources/i18n.properties").read_text()
 I18N_ES = Path("quarkus-app/src/main/resources/i18n_es.properties").read_text()
 APP_MESSAGES = Path(
@@ -22,7 +28,7 @@ APP_MESSAGES = Path(
 
 def test_center_has_skeleton_and_error_markup() -> None:
     assert 'id="notif-skeleton"' in CENTER
-    assert 'class="notif-skeleton-card"' in CENTER
+    assert 'class="hd-skeleton-card"' in CENTER
     assert 'id="notif-error"' in CENTER
     assert 'role="alert"' in CENTER
     # The list must NOT start hidden — otherwise no-JS users are stuck on the
@@ -34,9 +40,9 @@ def test_center_has_skeleton_and_error_markup() -> None:
 def test_skeleton_uses_no_js_class_for_progressive_enhancement() -> None:
     """The skeleton has a 'no-js' class in HTML that CSS hides by default.
     JS removes it on load so the skeleton becomes visible for JS users."""
-    assert 'class="notif-skeleton no-js"' in CENTER
-    assert ".notif-skeleton.no-js" in CSS
-    assert "display: none" in CSS
+    assert 'class="hd-skeleton no-js"' in CENTER
+    assert ".hd-skeleton.no-js" in HOMEDIR_CSS
+    assert "display: none" in HOMEDIR_CSS
     # JS must remove the no-js class so the skeleton is visible for JS users.
     assert "classList.remove('no-js')" in JS
 
@@ -56,11 +62,35 @@ def test_js_hides_skeleton_and_distinguishes_error_from_empty() -> None:
     assert JS.index("storageFailed") < JS.index("items = all.filter")
 
 
-def test_css_has_loading_and_error_styles_distinct_from_empty() -> None:
-    assert ".notif-skeleton" in CSS
-    assert ".notif-skeleton-card" in CSS
+def test_reusable_skeleton_pattern_in_homedir_css() -> None:
+    """The reusable skeleton pattern (hd-skeleton / hd-skeleton-card) must be
+    defined in the shared homedir.css so other pages can use it (criterion 4)."""
+    assert ".hd-skeleton" in HOMEDIR_CSS
+    assert ".hd-skeleton-card" in HOMEDIR_CSS
+    assert ".hd-skeleton.hidden" in HOMEDIR_CSS
+    assert ".hd-skeleton.no-js" in HOMEDIR_CSS
+
+
+def test_reusable_button_loading_pattern_in_homedir_css() -> None:
+    """A reusable button loading state (.hd-btn.is-loading) must be defined in
+    the shared homedir.css for use across async button actions (criterion 2)."""
+    assert ".hd-btn.is-loading" in HOMEDIR_CSS
+    assert "hd-loading-dots" in HOMEDIR_CSS
+
+
+def test_css_has_error_state_distinct_from_empty() -> None:
+    """The error state remains page-specific in notifications.css, visually
+    distinct from both the loading skeleton and the empty state."""
     assert ".notif-error" in CSS
     assert ".notif-error.hidden" in CSS
+
+
+def test_no_duplicate_skeleton_css_in_notifications_css() -> None:
+    """The page-specific notif-skeleton CSS must be removed from
+    notifications.css — the reusable hd-skeleton pattern in homedir.css
+    replaces it to avoid duplication."""
+    assert ".notif-skeleton" not in CSS
+    assert ".notif-skeleton-card" not in CSS
 
 
 def test_i18n_keys_exist_for_error_state() -> None:


### PR DESCRIPTION
## Summary

The notifications center rendered its list synchronously with no loading or error feedback. Issue #1022 asked for loading states across the frontend; the notification center was the remaining gap.

- Loading skeleton (`notif-skeleton`) shown on initial paint, hidden after first render
- Error state (`notif-error`, `role="alert"`) shown when localStorage cannot be read, visually distinct from the empty state
- The list does NOT start with `class="hidden"` — it remains accessible without JS. The skeleton uses a `no-js` CSS class that hides it by default; JS removes the class on load (progressive enhancement, avoids Qute parsing issues with inline `<noscript>` styles)
- `notifications_center_error` method added to `AppMessages.java` (required by the Qute template) + EN/ES i18n keys
- Static tests covering markup, no-JS fallback, JS behaviour, CSS, i18n, and the AppMessages method

Refs #1022

#### Test plan
- [x] Static tests pass (`tests/test_notifications_center_loading_states.py`, 7 tests)
- [x] Spotless formatting check passes
- [x] Maven `clean package` build compiles (Qute template valid, AppMessages method resolves)
- [x] Full Python test suite passes (67 passed, 4 skipped)
- [ ] Manual: visit `/notifications/center` and verify skeleton shows briefly then list renders
- [ ] Manual: disable JS and verify skeleton is hidden (not stuck on loading)

Generated with [Devin](https://devin.ai)