### PR TITLE
refactor(js): use shared HomeDirUtils.escapeHtml in notification scripts (#1316)

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications-sim.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications-sim.js
@@ -5,14 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const resultsTable = document.getElementById('results');
   const resultsBody = resultsTable.querySelector('tbody');
   const optin = document.getElementById('optin');
-  function esc(s) {
-    if (window.HomeDirUtils && window.HomeDirUtils.escapeHtml) {
-      return window.HomeDirUtils.escapeHtml(s);
-    }
-    return String(s).replace(/[&<>"']/g, function(m) {
-      return m === '&' ? '&amp;' : m === '<' ? '&lt;' : m === '>' ? '&gt;' : m === '"' ? '&quot;' : '&#39;';
-    });
-  }
+  // Shared escaping lives in utils.js (window.HomeDirUtils), loaded first in
+  // the layout <head> before any deferred page script. No local fallback.
 
   // initialise opt-in state
   optin.checked = localStorage.getItem('ef_notif_test_optin') === '1';
@@ -42,7 +36,7 @@ document.addEventListener('DOMContentLoaded', () => {
     resultsBody.textContent = '';
     data.forEach(row => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td class="border px-2 py-1">${esc(row.recipient)}</td><td class="border px-2 py-1">${esc(row.message)}</td>`;
+      tr.innerHTML = `<td class="border px-2 py-1">${window.HomeDirUtils.escapeHtml(row.recipient)}</td><td class="border px-2 py-1">${window.HomeDirUtils.escapeHtml(row.message)}</td>`;
       resultsBody.appendChild(tr);
     });
     resultsTable.classList.remove('hidden');

--- a/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications.js
@@ -1,14 +1,8 @@
 (async function(){
   const listEl = document.getElementById('admin-list');
   const clearBtn = document.getElementById('clearAll');
-  function esc(s) {
-    if (window.HomeDirUtils && window.HomeDirUtils.escapeHtml) {
-      return window.HomeDirUtils.escapeHtml(s);
-    }
-    return String(s).replace(/[&<>"']/g, function(m) {
-      return m === '&' ? '&amp;' : m === '<' ? '&lt;' : m === '>' ? '&gt;' : m === '"' ? '&quot;' : '&#39;';
-    });
-  }
+  // Shared escaping lives in utils.js (window.HomeDirUtils), loaded first in
+  // the layout <head> before any deferred page script. No local fallback.
   async function load(){
     const res = await fetch('/admin/api/notifications/latest?limit=50', { cache:'no-store' });
     if(!res.ok) return;
@@ -17,14 +11,14 @@
     items.forEach(n=>{
       const row = document.createElement('div');
       row.className = 'card row justify-between items-center';
-      const audienceInfo = n.audience ? ` — Audiencia: ${esc(n.audience)}` : ' — Global';
+      const audienceInfo = n.audience ? ` — Audiencia: ${window.HomeDirUtils.escapeHtml(n.audience)}` : ' — Global';
       row.innerHTML = `
         <div class="grow">
-          <div class="font-medium">${esc(n.title)}</div>
-          <div class="text-sm text-muted-foreground">${esc(n.message)}</div>
-          <div class="text-xs">${new Date(n.createdAt).toLocaleString()} — ${esc(n.type)}${n.eventId? ' — '+esc(n.eventId):''}${audienceInfo}</div>
+          <div class="font-medium">${window.HomeDirUtils.escapeHtml(n.title)}</div>
+          <div class="text-sm text-muted-foreground">${window.HomeDirUtils.escapeHtml(n.message)}</div>
+          <div class="text-xs">${new Date(n.createdAt).toLocaleString()} — ${window.HomeDirUtils.escapeHtml(n.type)}${n.eventId? ' — '+window.HomeDirUtils.escapeHtml(n.eventId):''}${audienceInfo}</div>
         </div>
-        <button class="btn-danger" data-id="${esc(n.id)}">Eliminar</button>`;
+        <button class="btn-danger" data-id="${window.HomeDirUtils.escapeHtml(n.id)}">Eliminar</button>`;
       listEl.appendChild(row);
     });
   }

--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
@@ -132,13 +132,13 @@
         <div class="row items-start gap-3">
           <input type="checkbox" class="sel js-select" data-id="${n.id}" ${checked}>
           <div class="grow">
-            <div class="title">${escapeHtml(n.title || i18n.defaultTitle)}</div>
-            <div class="msg">${escapeHtml(n.message || '')}</div>
+            <div class="title">${window.HomeDirUtils.escapeHtml(n.title || i18n.defaultTitle)}</div>
+            <div class="msg">${window.HomeDirUtils.escapeHtml(n.message || '')}</div>
             <div class="meta text-xs">${fmt(n.createdAt)} ${chip}</div>
           </div>
           <div class="col shrink">
             <button class="btn-link js-read" data-id="${n.id}">${readLabel}</button>
-            <a class="btn-link js-open" data-id="${n.id}" href="${escapeAttr(url)}" rel="nofollow">${linkLabel}</a>
+            <a class="btn-link js-open" data-id="${n.id}" href="${window.HomeDirUtils.escapeHtml(url)}" rel="nofollow">${linkLabel}</a>
           </div>
         </div>`;
       listEl.appendChild(div);
@@ -163,31 +163,17 @@
     const sample = document.createElement('div');
     sample.className = 'notifications-sample';
     sample.innerHTML = `
-      <h3 class="notifications-sample-title">${escapeHtml(i18n.sampleTitle)}</h3>
+      <h3 class="notifications-sample-title">${window.HomeDirUtils.escapeHtml(i18n.sampleTitle)}</h3>
       <ul class="notifications-sample-list">
-        <li>${escapeHtml(i18n.sampleEvent)}</li>
-        <li>${escapeHtml(i18n.sampleCommunity)}</li>
-        <li>${escapeHtml(i18n.sampleProject)}</li>
+        <li>${window.HomeDirUtils.escapeHtml(i18n.sampleEvent)}</li>
+        <li>${window.HomeDirUtils.escapeHtml(i18n.sampleCommunity)}</li>
+        <li>${window.HomeDirUtils.escapeHtml(i18n.sampleProject)}</li>
       </ul>`;
     listEl.appendChild(sample);
   }
 
-  // Escapes básicos (shared util con fallback defensivo)
-  function escapeHtml(s) {
-    if (window.HomeDirUtils && window.HomeDirUtils.escapeHtml) {
-      return window.HomeDirUtils.escapeHtml(s);
-    }
-    return String(s).replace(/[&<>"']/g, m => ({
-      "&": "&amp;",
-      "<": "&lt;",
-      ">": "&gt;",
-      "\"": "&quot;",
-      "'": "&#039;"
-    }[m]));
-  }
-  function escapeAttr(s) {
-    return escapeHtml(s);
-  }
+  // Shared escaping lives in utils.js (window.HomeDirUtils), loaded first in
+  // the layout <head> before any deferred page script. No local fallback.
 
   function isValidUrl(str) {
     try {

--- a/tests/test_js_escape_html_dedup.py
+++ b/tests/test_js_escape_html_dedup.py
@@ -1,0 +1,35 @@
+"""Static assertions for issue #1316 (split from #1017): page scripts must not
+redefine escaping logic; they must use the shared `window.HomeDirUtils.escapeHtml`
+from `utils.js` (loaded first in the layout <head>).
+"""
+
+from pathlib import Path
+
+JS_DIR = Path("quarkus-app/src/main/resources/META-INF/resources/js")
+
+
+def _read(name: str) -> str:
+    return (JS_DIR / name).read_text()
+
+
+def test_utils_is_single_source_of_escape_html() -> None:
+    utils = _read("utils.js")
+    assert "window.HomeDirUtils = { escapeHtml" in utils
+    # utils.js must still own the actual replacement logic.
+    assert "&amp;" in utils
+
+
+def test_notification_scripts_do_not_redefine_escape() -> None:
+    for name in ("notifications-center.js", "admin-notifications.js", "admin-notifications-sim.js"):
+        src = _read(name)
+        # No local escaping implementation (no replace of the HTML special chars).
+        assert "function escapeHtml" not in src, name
+        assert "function esc(" not in src, name
+        assert "&amp;" not in src, name
+        # They delegate to the shared util.
+        assert "window.HomeDirUtils.escapeHtml" in src, name
+
+
+def test_notifications_center_call_sites_use_shared_util() -> None:
+    src = _read("notifications-center.js")
+    assert "${window.HomeDirUtils.escapeHtml(" in src


### PR DESCRIPTION
## Summary
Three notification scripts each carried their own copy of the HTML-escaping logic (with a defensive `HomeDirUtils` fallback). `utils.js` already exposes `window.HomeDirUtils.escapeHtml` and is loaded first in the layout `<head>` before any deferred page script, so the duplicates are unnecessary. This makes `utils.js` the single source of escaping logic.

## Issue
- Linked issue: `#1316` (split from `#1017`)
- Scope lock: [x] This PR stays within the linked issue and any new work is split into a new issue and PR.

## Why
#1017 criterion: "Extract shared utilities (escapeHtml, formatDate, etc.)". `utils.js` exists but scripts still redefined escaping. This removes the duplication without changing behavior.

## Scope
- In: `js/notifications-center.js`, `js/admin-notifications.js`, `js/admin-notifications-sim.js` — remove local `escapeHtml`/`esc` definitions; call `window.HomeDirUtils.escapeHtml` directly at every call site. Static tests in `tests/test_js_escape_html_dedup.py`.
- Out (deferred to follow-up sub-issues of #1017, to keep this PR atomic and conflict-free):
  - `js/homedir.js` defines a global `esc()` but is not referenced by any template (JsBundleE2ETest asserts the home page does NOT reference it) → dead-code removal sub-issue.
  - `js/retro-theme.js` defines a global `esc()`; it is loaded on the speaker page, but that file is also touched by open #1312 → deferred to avoid conflict.
  - `formatDate` is duplicated across 6+ files but `utils.js` does not yet expose it → separate sub-issue that first adds `formatDate` to `utils.js`.

## Validation
- [x] `node --check` passes for all three modified files.
- [x] `pytest tests/test_js_escape_html_dedup.py` → 3 passed.
- [x] No script-tag or template changes (JsBundleE2ETest reference assertions unaffected).
- [ ] CodeQL/Sanitization preflight (Rule #24) — via CI.
- [ ] UI/UX verification — manual: notification center, admin notifications list, admin simulator render escaped content correctly.

## Production Plan
- Verification: on `/notifications/center`, `/admin/notifications`, `/admin/notifications/sim`, confirm titles/messages/ids render with HTML special chars escaped (e.g. a notification containing `<b>` shows as text, not markup).
- Rollback: revert this commit; local fallbacks return.

## Operational Status
- [ ] auto-merge enabled (Rule #32).
- [ ] Workspace synced (Rule #29).

Generated with [Devin](https://devin.ai)