### PR TITLE
refactor(js): consistent IIFE entry pattern with root-element guards (#1318)

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications-sim.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications-sim.js
@@ -1,10 +1,17 @@
-document.addEventListener('DOMContentLoaded', () => {
+(function () {
   const eventId = document.getElementById('eventId');
   const pivot = document.getElementById('pivot');
   const states = document.getElementById('states');
   const resultsTable = document.getElementById('results');
-  const resultsBody = resultsTable.querySelector('tbody');
   const optin = document.getElementById('optin');
+  // This script is loaded with `defer`, so the DOM is fully parsed when it
+  // runs; the previous DOMContentLoaded wrapper was redundant. Early-return
+  // when the simulator controls are not on the page (consistent with
+  // notifications-center.js).
+  if (!eventId || !pivot || !states || !resultsTable || !optin) {
+    return;
+  }
+  const resultsBody = resultsTable.querySelector('tbody');
   function esc(s) {
     if (window.HomeDirUtils && window.HomeDirUtils.escapeHtml) {
       return window.HomeDirUtils.escapeHtml(s);
@@ -51,4 +58,4 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('preview').addEventListener('click', () => call('/admin/api/notifications/sim/dry-run'));
   document.getElementById('execute').addEventListener('click', () => call('/admin/api/notifications/sim/execute'));
   document.getElementById('replay').addEventListener('click', () => call('/admin/api/notifications/sim/execute?mode=sequential'));
-});
+})();

--- a/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications.js
@@ -1,6 +1,12 @@
 (async function(){
   const listEl = document.getElementById('admin-list');
   const clearBtn = document.getElementById('clearAll');
+  // Early-return when the admin notifications list is not on the page
+  // (consistent with notifications-center.js). This script is loaded with
+  // `defer`, so the DOM is fully parsed when it runs.
+  if (!listEl) {
+    return;
+  }
   function esc(s) {
     if (window.HomeDirUtils && window.HomeDirUtils.escapeHtml) {
       return window.HomeDirUtils.escapeHtml(s);

--- a/tests/test_js_consistent_iife_pattern.py
+++ b/tests/test_js_consistent_iife_pattern.py
@@ -1,0 +1,35 @@
+"""Static assertions for issue #1318 (split from #1017): page scripts should
+use a consistent IIFE entry pattern and early-return when their root element is
+not on the page, instead of relying on a redundant DOMContentLoaded wrapper
+(scripts are loaded with `defer`).
+"""
+
+from pathlib import Path
+
+JS_DIR = Path("quarkus-app/src/main/resources/META-INF/resources/js")
+
+
+def _read(name: str) -> str:
+    return (JS_DIR / name).read_text()
+
+
+def test_admin_notifications_sim_uses_iife_not_domcontentloaded() -> None:
+    src = _read("admin-notifications-sim.js")
+    assert src.startswith("(function () {")
+    assert "document.addEventListener('DOMContentLoaded'" not in src
+    assert src.rstrip().endswith("})();")
+
+
+def test_admin_scripts_early_return_when_root_missing() -> None:
+    sim = _read("admin-notifications-sim.js")
+    assert "if (!eventId || !pivot || !states || !resultsTable || !optin)" in sim
+    assert "return;" in sim
+
+    admin = _read("admin-notifications.js")
+    assert "if (!listEl)" in admin
+    assert "return;" in admin
+
+
+def test_admin_notifications_uses_iife() -> None:
+    src = _read("admin-notifications.js")
+    assert src.startswith("(async function(){")


### PR DESCRIPTION
## Summary
`admin-notifications-sim.js` used a redundant `DOMContentLoaded` wrapper despite being loaded with `defer` (the DOM is already parsed when deferred scripts run), and `admin-notifications.js` had no guard against a missing root element. This normalizes both to the IIFE pattern used by the rest of the page scripts and adds early-return guards, matching `notifications-center.js`.

## Issue
- Linked issue: `#1318` (split from `#1017`)
- Scope lock: [x] This PR stays within the linked issue and any new work is split into a new issue and PR.

## Why
#1017 criterion: "Adopt consistent pattern (IIFE or ES modules)" and "Define clear module boundaries". The two admin notification scripts were the inconsistent outliers.

## Scope
- In: `js/admin-notifications-sim.js` — replace `DOMContentLoaded` listener with an IIFE and add an early-return guard for missing root controls; `js/admin-notifications.js` — add an early-return guard when `#admin-list` is absent. Static tests in `tests/test_js_consistent_iife_pattern.py`.
- Out: ES module migration (larger effort, tracked separately); other files already use IIFE.

## Validation
- [x] `node --check` passes for both modified files.
- [x] `pytest tests/test_js_consistent_iife_pattern.py` → 3 passed.
- [ ] CodeQL/Sanitization preflight (Rule #24) — via CI.
- [ ] UI/UX verification — manual: `/admin/notifications` and `/admin/notifications/sim` still work; pages without these elements do not throw.

## Notes for reviewers
- This PR intentionally does NOT touch the local `esc()` functions (that dedup is #1316 / PR #1319). Both PRs edit the same two files but in different regions (entry wrapper + guard here vs. the `esc()` body + call sites in #1319); a rebase may be needed depending on merge order. Recommended merge order: #1319 first, then rebase this PR.

## Production Plan
- Verification: on `/admin/notifications/sim`, the preview/execute/replay buttons still POST and render results; on a page without the simulator controls, the script no-ops.
- Rollback: revert this commit; `DOMContentLoaded` wrapper and missing-guard behavior return.

## Operational Status
- [ ] auto-merge enabled (Rule #32).
- [ ] Workspace synced (Rule #29).

Generated with [Devin](https://devin.ai)