### PR TITLE
refactor(js): consistent IIFE pattern + shared escaping in notification scripts (#1017)

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications-sim.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications-sim.js
@@ -1,18 +1,21 @@
-document.addEventListener('DOMContentLoaded', () => {
+(function () {
   const eventId = document.getElementById('eventId');
   const pivot = document.getElementById('pivot');
   const states = document.getElementById('states');
   const resultsTable = document.getElementById('results');
-  const resultsBody = resultsTable.querySelector('tbody');
   const optin = document.getElementById('optin');
-  function esc(s) {
-    if (window.HomeDirUtils && window.HomeDirUtils.escapeHtml) {
-      return window.HomeDirUtils.escapeHtml(s);
-    }
-    return String(s).replace(/[&<>"']/g, function(m) {
-      return m === '&' ? '&amp;' : m === '<' ? '&lt;' : m === '>' ? '&gt;' : m === '"' ? '&quot;' : '&#39;';
-    });
+  // This script is loaded with `defer`, so the DOM is fully parsed when it
+  // runs; the previous DOMContentLoaded wrapper was redundant. Early-return
+  // when the simulator controls are not on the page (consistent with
+  // notifications-center.js).
+  if (!eventId || !pivot || !states || !resultsTable || !optin) {
+    return;
   }
+  if (!window.HomeDirUtils) {
+    console.error('admin-notifications-sim: HomeDirUtils not loaded');
+    return;
+  }
+  const resultsBody = resultsTable.querySelector('tbody');
 
   // initialise opt-in state
   optin.checked = localStorage.getItem('ef_notif_test_optin') === '1';
@@ -42,7 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
     resultsBody.textContent = '';
     data.forEach(row => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td class="border px-2 py-1">${esc(row.recipient)}</td><td class="border px-2 py-1">${esc(row.message)}</td>`;
+      tr.innerHTML = `<td class="border px-2 py-1">${window.HomeDirUtils.escapeHtml(row.recipient)}</td><td class="border px-2 py-1">${window.HomeDirUtils.escapeHtml(row.message)}</td>`;
       resultsBody.appendChild(tr);
     });
     resultsTable.classList.remove('hidden');
@@ -51,4 +54,4 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('preview').addEventListener('click', () => call('/admin/api/notifications/sim/dry-run'));
   document.getElementById('execute').addEventListener('click', () => call('/admin/api/notifications/sim/execute'));
   document.getElementById('replay').addEventListener('click', () => call('/admin/api/notifications/sim/execute?mode=sequential'));
-});
+})();

--- a/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications.js
@@ -1,13 +1,15 @@
 (async function(){
   const listEl = document.getElementById('admin-list');
   const clearBtn = document.getElementById('clearAll');
-  function esc(s) {
-    if (window.HomeDirUtils && window.HomeDirUtils.escapeHtml) {
-      return window.HomeDirUtils.escapeHtml(s);
-    }
-    return String(s).replace(/[&<>"']/g, function(m) {
-      return m === '&' ? '&amp;' : m === '<' ? '&lt;' : m === '>' ? '&gt;' : m === '"' ? '&quot;' : '&#39;';
-    });
+  // Early-return when the admin notifications list is not on the page
+  // (consistent with notifications-center.js). This script is loaded with
+  // `defer`, so the DOM is fully parsed when it runs.
+  if (!listEl) {
+    return;
+  }
+  if (!window.HomeDirUtils) {
+    console.error('admin-notifications: HomeDirUtils not loaded');
+    return;
   }
   async function load(){
     const res = await fetch('/admin/api/notifications/latest?limit=50', { cache:'no-store' });
@@ -17,14 +19,14 @@
     items.forEach(n=>{
       const row = document.createElement('div');
       row.className = 'card row justify-between items-center';
-      const audienceInfo = n.audience ? ` — Audiencia: ${esc(n.audience)}` : ' — Global';
+      const audienceInfo = n.audience ? ` — Audiencia: ${window.HomeDirUtils.escapeHtml(n.audience)}` : ' — Global';
       row.innerHTML = `
         <div class="grow">
-          <div class="font-medium">${esc(n.title)}</div>
-          <div class="text-sm text-muted-foreground">${esc(n.message)}</div>
-          <div class="text-xs">${new Date(n.createdAt).toLocaleString()} — ${esc(n.type)}${n.eventId? ' — '+esc(n.eventId):''}${audienceInfo}</div>
+          <div class="font-medium">${window.HomeDirUtils.escapeHtml(n.title)}</div>
+          <div class="text-sm text-muted-foreground">${window.HomeDirUtils.escapeHtml(n.message)}</div>
+          <div class="text-xs">${new Date(n.createdAt).toLocaleString()} — ${window.HomeDirUtils.escapeHtml(n.type)}${n.eventId? ' — '+window.HomeDirUtils.escapeHtml(n.eventId):''}${audienceInfo}</div>
         </div>
-        <button class="btn-danger" data-id="${esc(n.id)}">Eliminar</button>`;
+        <button class="btn-danger" data-id="${window.HomeDirUtils.escapeHtml(n.id)}">Eliminar</button>`;
       listEl.appendChild(row);
     });
   }

--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
@@ -3,6 +3,10 @@
   if (!root) {
     return;
   }
+  if (!window.HomeDirUtils) {
+    console.error('notifications-center: HomeDirUtils not loaded');
+    return;
+  }
 
   const I18N_DEFAULTS = {
     toggleMarkRead: 'Mark as read',
@@ -132,13 +136,13 @@
         <div class="row items-start gap-3">
           <input type="checkbox" class="sel js-select" data-id="${n.id}" ${checked}>
           <div class="grow">
-            <div class="title">${escapeHtml(n.title || i18n.defaultTitle)}</div>
-            <div class="msg">${escapeHtml(n.message || '')}</div>
+            <div class="title">${window.HomeDirUtils.escapeHtml(n.title || i18n.defaultTitle)}</div>
+            <div class="msg">${window.HomeDirUtils.escapeHtml(n.message || '')}</div>
             <div class="meta text-xs">${fmt(n.createdAt)} ${chip}</div>
           </div>
           <div class="col shrink">
             <button class="btn-link js-read" data-id="${n.id}">${readLabel}</button>
-            <a class="btn-link js-open" data-id="${n.id}" href="${escapeAttr(url)}" rel="nofollow">${linkLabel}</a>
+            <a class="btn-link js-open" data-id="${n.id}" href="${window.HomeDirUtils.escapeHtml(url)}" rel="nofollow">${linkLabel}</a>
           </div>
         </div>`;
       listEl.appendChild(div);
@@ -163,31 +167,18 @@
     const sample = document.createElement('div');
     sample.className = 'notifications-sample';
     sample.innerHTML = `
-      <h3 class="notifications-sample-title">${escapeHtml(i18n.sampleTitle)}</h3>
+      <h3 class="notifications-sample-title">${window.HomeDirUtils.escapeHtml(i18n.sampleTitle)}</h3>
       <ul class="notifications-sample-list">
-        <li>${escapeHtml(i18n.sampleEvent)}</li>
-        <li>${escapeHtml(i18n.sampleCommunity)}</li>
-        <li>${escapeHtml(i18n.sampleProject)}</li>
+        <li>${window.HomeDirUtils.escapeHtml(i18n.sampleEvent)}</li>
+        <li>${window.HomeDirUtils.escapeHtml(i18n.sampleCommunity)}</li>
+        <li>${window.HomeDirUtils.escapeHtml(i18n.sampleProject)}</li>
       </ul>`;
     listEl.appendChild(sample);
   }
 
-  // Escapes básicos (shared util con fallback defensivo)
-  function escapeHtml(s) {
-    if (window.HomeDirUtils && window.HomeDirUtils.escapeHtml) {
-      return window.HomeDirUtils.escapeHtml(s);
-    }
-    return String(s).replace(/[&<>"']/g, m => ({
-      "&": "&amp;",
-      "<": "&lt;",
-      ">": "&gt;",
-      "\"": "&quot;",
-      "'": "&#039;"
-    }[m]));
-  }
-  function escapeAttr(s) {
-    return escapeHtml(s);
-  }
+  // Shared escaping lives in utils.js (window.HomeDirUtils), loaded first in
+  // the layout <head> before any deferred page script. A guard at the top of
+  // this IIFE exits early if HomeDirUtils is unavailable.
 
   function isValidUrl(str) {
     try {

--- a/tests/test_js_notification_scripts_cleanup.py
+++ b/tests/test_js_notification_scripts_cleanup.py
@@ -1,0 +1,86 @@
+"""Static assertions for issue #1017: the notification page scripts should use
+a consistent IIFE entry pattern with early-return guards (instead of a redundant
+DOMContentLoaded wrapper, since they are loaded with ``defer``) and should not
+duplicate the HTML-escaping logic — they must delegate to the shared
+``window.HomeDirUtils.escapeHtml`` from ``utils.js``.
+
+Each script must guard against ``window.HomeDirUtils`` being unavailable so the
+page degrades gracefully (console.error + early return) instead of throwing a
+TypeError at a call site.
+"""
+
+from pathlib import Path
+
+JS_DIR = Path("quarkus-app/src/main/resources/META-INF/resources/js")
+
+
+def _read(name: str) -> str:
+    return (JS_DIR / name).read_text()
+
+
+# ---------------------------------------------------------------------------
+# IIFE entry pattern (issue #1017 / former #1318)
+# ---------------------------------------------------------------------------
+
+
+def test_admin_notifications_sim_uses_iife_not_domcontentloaded() -> None:
+    src = _read("admin-notifications-sim.js")
+    assert src.startswith("(function () {")
+    assert "document.addEventListener('DOMContentLoaded'" not in src
+    assert src.rstrip().endswith("})();")
+
+
+def test_admin_scripts_early_return_when_root_missing() -> None:
+    sim = _read("admin-notifications-sim.js")
+    assert "if (!eventId || !pivot || !states || !resultsTable || !optin)" in sim
+    assert "return;" in sim
+
+    admin = _read("admin-notifications.js")
+    assert "if (!listEl)" in admin
+    assert "return;" in admin
+
+
+def test_admin_notifications_uses_iife() -> None:
+    src = _read("admin-notifications.js")
+    assert src.startswith("(async function(){")
+
+
+# ---------------------------------------------------------------------------
+# Shared escaping — no duplicates (issue #1017 / former #1316)
+# ---------------------------------------------------------------------------
+
+
+def test_utils_is_single_source_of_escape_html() -> None:
+    utils = _read("utils.js")
+    assert "window.HomeDirUtils = { escapeHtml" in utils
+    # utils.js must still own the actual replacement logic.
+    assert "&amp;" in utils
+
+
+def test_notification_scripts_do_not_redefine_escape() -> None:
+    for name in ("notifications-center.js", "admin-notifications.js", "admin-notifications-sim.js"):
+        src = _read(name)
+        # No local escaping implementation (no replace of the HTML special chars).
+        assert "function escapeHtml" not in src, name
+        assert "function esc(" not in src, name
+        assert "function escapeAttr" not in src, name
+        assert "&amp;" not in src, name
+        # They delegate to the shared util.
+        assert "window.HomeDirUtils.escapeHtml" in src, name
+
+
+def test_notification_scripts_guard_against_missing_homedirutils() -> None:
+    """Each script must check window.HomeDirUtils before using it so a failed
+    utils.js load degrades gracefully instead of throwing."""
+    for name in ("notifications-center.js", "admin-notifications.js", "admin-notifications-sim.js"):
+        src = _read(name)
+        assert "if (!window.HomeDirUtils)" in src, name
+        assert "console.error" in src, name
+        assert "return;" in src, name
+
+
+def test_notifications_center_call_sites_use_shared_util() -> None:
+    src = _read("notifications-center.js")
+    assert "${window.HomeDirUtils.escapeHtml(" in src
+    # The old local escapeAttr function must be gone.
+    assert "escapeAttr(" not in src


### PR DESCRIPTION
## Summary

First step toward resolving #1017 (19 separate JS files with global namespace pollution and no module boundaries). This PR cleans up the three notification page scripts:

- **IIFE consistency**: `admin-notifications-sim.js` used a redundant `DOMContentLoaded` wrapper (unnecessary since scripts are loaded with `defer`). `admin-notifications.js` had no root-element guard. Both are normalized to the IIFE pattern with early-return guards used by `notifications-center.js`.
- **Shared escaping**: All three scripts had their own copy of the HTML-escaping logic with a defensive `HomeDirUtils` fallback. The duplicates are removed; all call sites now use `window.HomeDirUtils.escapeHtml` directly from `utils.js` (loaded first in the layout `<head>`).
- **Graceful degradation**: Each script guards against `window.HomeDirUtils` being unavailable (`console.error` + early return) so a failed `utils.js` load doesn't throw a `TypeError` at a call site.

No behavior change on pages that use these scripts when `utils.js` is loaded normally.

Refs #1017

#### Test plan
- [x] Static tests pass (`tests/test_js_notification_scripts_cleanup.py`, 7 tests)
- [x] Spotless formatting check passes
- [x] Maven build compiles
- [x] Full Python test suite passes (67 passed, 4 skipped)
- [ ] Manual: verify admin notifications page and simulator still work
- [ ] Manual: verify notifications center still renders correctly

Generated with [Devin](https://devin.ai)