### PR TITLE
fix(worker): handle label application failures in admission reconciliation (#1230)

### DIFF
--- a/platform/scripts/homedir-sdlc-worker.sh
+++ b/platform/scripts/homedir-sdlc-worker.sh
@@ -367,7 +367,11 @@ is_authorized_labeler() {
 add_label() {
   local issue="$1"
   local label="$2"
-  gh issue edit "${issue}" --repo "${REPO}" --add-label "${label}" >/dev/null
+  if ! gh issue edit "${issue}" --repo "${REPO}" --add-label "${label}" >/dev/null 2>&1; then
+    log "ERROR: add_label failed for issue #${issue} label='${label}'"
+    return 1
+  fi
+  return 0
 }
 
 remove_label() {
@@ -672,8 +676,17 @@ reconcile_admission_requests() {
       || issue_has_label "${labels}" "${FAILED_LABEL}" \
       || issue_has_label "${labels}" "${LEGAL_REVIEW_LABEL}" \
       || issue_has_label "${labels}" "${NEEDS_HUMAN_LABEL}" \
+      || issue_has_label "${labels}" "${REJECTED_LABEL}" \
       || issue_has_label "${labels}" "${MERGED_LABEL}"; then
       log "reconcile_admission_requests: skipping issue #${number} (already in terminal state)"
+      continue
+    fi
+
+    # Skip issues already in admission review — reconcile_stuck_admission_reviews
+    # handles them. Without this, every worker cycle re-adds the admission-review
+    # label and posts a duplicate comment (issue #1230).
+    if issue_has_label "${labels}" "${ADMISSION_REVIEW_LABEL}"; then
+      log "reconcile_admission_requests: skipping issue #${number} (already in ${ADMISSION_REVIEW_LABEL})"
       continue
     fi
 
@@ -698,29 +711,35 @@ reconcile_admission_requests() {
 
           if [[ "$requires_approval" != "true" ]] && [[ "$requires_legal" != "true" ]]; then
             # Auto-approve via policy
-            policy_approved="true"
-            add_label "${number}" "${ACCEPTED_LABEL}"
+            if add_label "${number}" "${ACCEPTED_LABEL}"; then
+              policy_approved="true"
 
-            local policy_ref
-            policy_ref=$(echo "$policy_decision" | jq -r '.policy' 2>/dev/null || echo "")
+              local policy_ref
+              policy_ref=$(echo "$policy_decision" | jq -r '.policy' 2>/dev/null || echo "")
 
-            local policy_text
-            policy_text=$(echo "$policy_decision" | jq -r '.decision' 2>/dev/null || echo "")
+              local policy_text
+              policy_text=$(echo "$policy_decision" | jq -r '.decision' 2>/dev/null || echo "")
 
-            comment_issue "${number}" "✅ **Auto-approved via policy \`${policy_ref}\`**
+              comment_issue "${number}" "✅ **Auto-approved via policy \`${policy_ref}\`**
 
 Autonomous decision: ${policy_text}
 
 Proceeding to admission..."
-            log "Issue #${number} auto-approved via policy on first check: ${policy_ref}"
+              log "Issue #${number} auto-approved via policy on first check: ${policy_ref}"
+            else
+              log "ERROR: reconcile_admission_requests: failed to apply ${ACCEPTED_LABEL} to issue #${number} (policy); deferring to standard review"
+            fi
           elif [[ "$requires_legal" == "true" ]]; then
-            add_label "${number}" "${LEGAL_REVIEW_LABEL}"
-            comment_issue "${number}" "⚠️ **Legal review required before implementation**
+            if add_label "${number}" "${LEGAL_REVIEW_LABEL}"; then
+              comment_issue "${number}" "⚠️ **Legal review required before implementation**
 
 Autonomous decision indicated legal/compliance review is needed.
 
 The worker will wait for legal review before proceeding."
-            log "Issue #${number} marked legal-review on first check"
+              log "Issue #${number} marked legal-review on first check"
+            else
+              log "ERROR: reconcile_admission_requests: failed to apply ${LEGAL_REVIEW_LABEL} to issue #${number}; deferring to standard review"
+            fi
             continue
           fi
         fi
@@ -728,9 +747,12 @@ The worker will wait for legal review before proceeding."
 
       # If not auto-approved, defer to standard admission review
       if [[ "$policy_approved" != "true" ]]; then
-        add_label "${number}" "${ADMISSION_REVIEW_LABEL}"
-        comment_issue "${number}" "AI SDLC admission is waiting for initial acceptance review. \`${TRIGGER_LABEL}\` requires \`${ACCEPTED_LABEL}\` before this issue can enter \`${QUEUE_LABEL}\`."
-        log "issue #${number} has ${TRIGGER_LABEL} but is missing ${ACCEPTED_LABEL}; admission deferred"
+        if add_label "${number}" "${ADMISSION_REVIEW_LABEL}"; then
+          comment_issue "${number}" "AI SDLC admission is waiting for initial acceptance review. \`${TRIGGER_LABEL}\` requires \`${ACCEPTED_LABEL}\` before this issue can enter \`${QUEUE_LABEL}\`."
+          log "issue #${number} has ${TRIGGER_LABEL} but is missing ${ACCEPTED_LABEL}; admission deferred"
+        else
+          log "ERROR: reconcile_admission_requests: failed to apply ${ADMISSION_REVIEW_LABEL} to issue #${number}; will retry next cycle"
+        fi
         continue
       fi
     fi
@@ -833,9 +855,9 @@ reconcile_stuck_admission_reviews() {
           policy_approved="true"
           log "Issue #${number} auto-approved via policy: ${policy_ref}"
 
-          add_label "${number}" "${ACCEPTED_LABEL}"
-          remove_label "${number}" "${ADMISSION_REVIEW_LABEL}"
-          comment_issue "${number}" "✅ **AI SDLC auto-approved via policy**
+          if add_label "${number}" "${ACCEPTED_LABEL}"; then
+            remove_label "${number}" "${ADMISSION_REVIEW_LABEL}"
+            comment_issue "${number}" "✅ **AI SDLC auto-approved via policy**
 
 **Policy Matched**: \`${policy_ref}\`
 **Autonomous Decision**: ${policy_text}
@@ -844,15 +866,18 @@ reconcile_stuck_admission_reviews() {
 The worker will implement this autonomously following the established policy.
 
 Proceeding to queue..."
-          log "Issue #${number} auto-accepted via policy: ${policy_ref}"
+            log "Issue #${number} auto-accepted via policy: ${policy_ref}"
+          else
+            log "ERROR: reconcile_stuck_admission_reviews: failed to apply ${ACCEPTED_LABEL} to issue #${number} (policy); leaving in ${ADMISSION_REVIEW_LABEL} for retry"
+          fi
           continue  # Skip standard review, already approved
         elif [[ "$requires_legal" == "true" ]]; then
           # Policy matched but requires legal/compliance review
           log "Issue #${number} matched policy ${policy_ref} but requires legal review"
 
-          remove_label "${number}" "${ADMISSION_REVIEW_LABEL}"
-          add_label "${number}" "${LEGAL_REVIEW_LABEL}"
-          comment_issue "${number}" "⚠️ **Policy matched but requires legal review**
+          if add_label "${number}" "${LEGAL_REVIEW_LABEL}"; then
+            remove_label "${number}" "${ADMISSION_REVIEW_LABEL}"
+            comment_issue "${number}" "⚠️ **Policy matched but requires legal review**
 
 **Policy**: \`${policy_ref}\`
 **Recommendation**: ${policy_text}
@@ -863,15 +888,18 @@ Legal review requested. Please review and approve by:
 2. Or closing the issue if rejected
 
 The worker will wait for your decision."
-          log "Issue #${number} marked legal-review (policy requires compliance check)"
+            log "Issue #${number} marked legal-review (policy requires compliance check)"
+          else
+            log "ERROR: reconcile_stuck_admission_reviews: failed to apply ${LEGAL_REVIEW_LABEL} to issue #${number} (policy); leaving in ${ADMISSION_REVIEW_LABEL} for retry"
+          fi
           continue
         elif [[ "$requires_approval" == "true" ]]; then
           # Policy matched but requires human approval
           log "Issue #${number} matched policy ${policy_ref} but requires human approval"
 
-          remove_label "${number}" "${ADMISSION_REVIEW_LABEL}"
-          add_label "${number}" "${NEEDS_HUMAN_LABEL}"
-          comment_issue "${number}" "⚠️ **Policy matched but requires approval**
+          if add_label "${number}" "${NEEDS_HUMAN_LABEL}"; then
+            remove_label "${number}" "${ADMISSION_REVIEW_LABEL}"
+            comment_issue "${number}" "⚠️ **Policy matched but requires approval**
 
 **Policy**: \`${policy_ref}\`
 **Recommendation**: ${policy_text}
@@ -882,7 +910,10 @@ Please review and approve by:
 2. Or closing the issue if you reject
 
 The worker will wait for your decision."
-          log "Issue #${number} marked needs-human (policy requires approval)"
+            log "Issue #${number} marked needs-human (policy requires approval)"
+          else
+            log "ERROR: reconcile_stuck_admission_reviews: failed to apply ${NEEDS_HUMAN_LABEL} to issue #${number} (policy); leaving in ${ADMISSION_REVIEW_LABEL} for retry"
+          fi
           continue
         fi
       fi
@@ -900,22 +931,31 @@ The worker will wait for your decision."
 
     case "${status}" in
       accepted)
-        add_label "${number}" "${ACCEPTED_LABEL}"
-        remove_label "${number}" "${ADMISSION_REVIEW_LABEL}"
-        comment_issue "${number}" "AI SDLC initial acceptance review passed (auto-reconciled). Criteria checked: improvement/correction intent, non-destructive scope, stability, security, maintainability, architecture, and good practices. ${reason_text}"
-        log "Issue #${number} auto-accepted via reconciliation"
+        if add_label "${number}" "${ACCEPTED_LABEL}"; then
+          remove_label "${number}" "${ADMISSION_REVIEW_LABEL}"
+          comment_issue "${number}" "AI SDLC initial acceptance review passed (auto-reconciled). Criteria checked: improvement/correction intent, non-destructive scope, stability, security, maintainability, architecture, and good practices. ${reason_text}"
+          log "Issue #${number} auto-accepted via reconciliation"
+        else
+          log "ERROR: reconcile_stuck_admission_reviews: failed to apply ${ACCEPTED_LABEL} to issue #${number}; leaving in ${ADMISSION_REVIEW_LABEL} for retry"
+        fi
         ;;
       needs-human)
-        remove_label "${number}" "${ADMISSION_REVIEW_LABEL}"
-        add_label "${number}" "${NEEDS_HUMAN_LABEL}"
-        comment_issue "${number}" "AI SDLC initial acceptance review needs human clarification before queue admission (auto-reconciled). ${reason_text}"
-        log "Issue #${number} marked needs-human via reconciliation"
+        if add_label "${number}" "${NEEDS_HUMAN_LABEL}"; then
+          remove_label "${number}" "${ADMISSION_REVIEW_LABEL}"
+          comment_issue "${number}" "AI SDLC initial acceptance review needs human clarification before queue admission (auto-reconciled). ${reason_text}"
+          log "Issue #${number} marked needs-human via reconciliation"
+        else
+          log "ERROR: reconcile_stuck_admission_reviews: failed to apply ${NEEDS_HUMAN_LABEL} to issue #${number}; leaving in ${ADMISSION_REVIEW_LABEL} for retry"
+        fi
         ;;
       *)
-        remove_label "${number}" "${ADMISSION_REVIEW_LABEL}"
-        add_label "${number}" "${REJECTED_LABEL}"
-        comment_issue "${number}" "AI SDLC initial acceptance review rejected this issue for autonomous implementation (auto-reconciled). ${reason_text}"
-        log "Issue #${number} rejected via reconciliation"
+        if add_label "${number}" "${REJECTED_LABEL}"; then
+          remove_label "${number}" "${ADMISSION_REVIEW_LABEL}"
+          comment_issue "${number}" "AI SDLC initial acceptance review rejected this issue for autonomous implementation (auto-reconciled). ${reason_text}"
+          log "Issue #${number} rejected via reconciliation"
+        else
+          log "ERROR: reconcile_stuck_admission_reviews: failed to apply ${REJECTED_LABEL} to issue #${number}; leaving in ${ADMISSION_REVIEW_LABEL} for retry"
+        fi
         ;;
     esac
   done < <(jq -c '.[]' <<<"${issues_json}")

--- a/tests/test_sdlc_worker_admission_reconcile_labels.py
+++ b/tests/test_sdlc_worker_admission_reconcile_labels.py
@@ -1,0 +1,123 @@
+"""Tests for issue #1230: worker must handle label application failures in
+admission reconciliation and avoid infinite duplicate-comment loops.
+
+Validates that:
+1. add_label returns non-zero and logs an ERROR on failure (no silent abort)
+2. reconcile_stuck_admission_reviews adds the terminal label BEFORE removing
+   scc-admission-review, so a failed add_label leaves the issue in review
+   for retry instead of dropping it into a labelless limbo
+3. reconcile_admission_requests skips issues already in scc-admission-review
+   (prevents duplicate comments every worker cycle)
+4. reconcile_admission_requests skips issues with scc-rejected (terminal state)
+"""
+
+from pathlib import Path
+import re
+
+WORKER = Path("platform/scripts/homedir-sdlc-worker.sh").read_text()
+
+
+def test_add_label_returns_nonzero_on_failure() -> None:
+    """add_label must return 1 on failure so callers can branch on it."""
+    # The function body should use `if ! gh issue edit ...` and `return 1`
+    add_label_body = re.search(
+        r"add_label\(\)\s*\{.*?\n\}", WORKER, re.DOTALL
+    )
+    assert add_label_body, "add_label function not found"
+    body = add_label_body.group(0)
+    assert "return 1" in body, "add_label must return 1 on failure"
+    assert "return 0" in body, "add_label must return 0 on success"
+    assert "ERROR" in body, "add_label must log an ERROR on failure"
+    assert "2>&1" in body, "add_label must redirect stderr to capture errors"
+
+
+def test_reconcile_stuck_adds_terminal_label_before_removing_review() -> None:
+    """In every case branch, add_label (terminal) must come before
+    remove_label (admission-review) so that a failed add leaves the issue
+    in scc-admission-review for retry."""
+    # Extract the case block in reconcile_stuck_admission_reviews
+    case_block = re.search(
+        r'case "\$\{status\}" in\s*'
+        r'accepted\)(.*?)'
+        r'needs-human\)(.*?)'
+        r'\*\)(.*?)'
+        r';;\s*esac',
+        WORKER,
+        re.DOTALL,
+    )
+    assert case_block, "case block in reconcile_stuck_admission_reviews not found"
+
+    for branch_name, branch_body in [
+        ("accepted", case_block.group(1)),
+        ("needs-human", case_block.group(2)),
+        ("rejected", case_block.group(3)),
+    ]:
+        add_pos = branch_body.find("add_label")
+        remove_pos = branch_body.find("remove_label")
+        assert add_pos != -1, f"{branch_name} branch: add_label not found"
+        assert remove_pos != -1, f"{branch_name} branch: remove_label not found"
+        assert add_pos < remove_pos, (
+            f"{branch_name} branch: add_label must come before remove_label "
+            f"(add at {add_pos}, remove at {remove_pos})"
+        )
+        # Must guard with if add_label ... else log ERROR
+        assert "if add_label" in branch_body, (
+            f"{branch_name} branch: must guard with 'if add_label'"
+        )
+        assert "ERROR" in branch_body, (
+            f"{branch_name} branch: must log ERROR on add_label failure"
+        )
+
+
+def test_reconcile_admission_requests_skips_already_in_review() -> None:
+    """reconcile_admission_requests must skip issues already in
+    scc-admission-review to prevent duplicate comments (issue #1230)."""
+    # Find the skip block for ADMISSION_REVIEW_LABEL in reconcile_admission_requests
+    assert "ADMISSION_REVIEW_LABEL}" in WORKER, (
+        "reconcile_admission_requests must check ADMISSION_REVIEW_LABEL"
+    )
+    # There should be a skip with a log message mentioning "already in"
+    assert re.search(
+        r'issue_has_label.*ADMISSION_REVIEW_LABEL.*\n.*already in.*ADMISSION_REVIEW_LABEL',
+        WORKER,
+        re.DOTALL,
+    ), "reconcile_admission_requests must skip issues already in admission review"
+
+
+def test_reconcile_admission_requests_skips_rejected() -> None:
+    """reconcile_admission_requests must skip issues with scc-rejected
+    (was missing from the terminal-state skip list)."""
+    # The terminal-state skip list must include REJECTED_LABEL before MERGED_LABEL
+    skip_block = re.search(
+        r'issue_has_label "\$\{labels\}" "\$\{REJECTED_LABEL\}"'
+        r'.*?issue_has_label "\$\{labels\}" "\$\{MERGED_LABEL\}"',
+        WORKER,
+        re.DOTALL,
+    )
+    assert skip_block, (
+        "reconcile_admission_requests must include REJECTED_LABEL in "
+        "terminal-state skip list before MERGED_LABEL"
+    )
+
+
+def test_policy_branches_in_reconcile_stuck_guard_add_label() -> None:
+    """Policy-driven auto-approval branches must also guard add_label calls."""
+    # All add_label calls in reconcile_stuck_admission_reviews should be
+    # inside if-blocks (no bare add_label calls)
+    stuck_section = re.search(
+        r'reconcile_stuck_admission_reviews\(\).*?^\}',
+        WORKER,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert stuck_section, "reconcile_stuck_admission_reviews function not found"
+    stuck_body = stuck_section.group(0)
+
+    # Find all add_label calls
+    add_label_calls = re.findall(r'add_label "\$\{number\}"', stuck_body)
+    # Each should be preceded by "if add_label" on the same or prior line
+    bare_calls = re.findall(r'(?<!if )add_label "\$\{number\}"', stuck_body)
+    # Remove the ones that are part of "if add_label"
+    truly_bare = [c for c in bare_calls if "if " + c not in stuck_body]
+    assert len(truly_bare) == 0, (
+        f"Found unguarded add_label calls in reconcile_stuck_admission_reviews: {truly_bare}"
+    )

--- a/tests/test_sdlc_worker_admission_reconcile_labels.py
+++ b/tests/test_sdlc_worker_admission_reconcile_labels.py
@@ -121,3 +121,25 @@ def test_policy_branches_in_reconcile_stuck_guard_add_label() -> None:
     assert len(truly_bare) == 0, (
         f"Found unguarded add_label calls in reconcile_stuck_admission_reviews: {truly_bare}"
     )
+
+
+def test_policy_branches_in_reconcile_admission_requests_guard_add_label() -> None:
+    """Policy-driven branches in reconcile_admission_requests must also guard
+    add_label calls (parallel coverage to the stuck-review test)."""
+    requests_section = re.search(
+        r"reconcile_admission_requests\(\)(.*?)\n\}",
+        WORKER,
+        re.DOTALL,
+    )
+    assert requests_section, "reconcile_admission_requests function not found"
+    requests_body = requests_section.group(1)
+
+    add_label_calls = re.findall(r'add_label "\$\{number\}"', requests_body)
+    assert len(add_label_calls) > 0, (
+        "reconcile_admission_requests must contain add_label calls"
+    )
+    bare_calls = re.findall(r'(?<!if )add_label "\$\{number\}"', requests_body)
+    truly_bare = [c for c in bare_calls if "if " + c not in requests_body]
+    assert len(truly_bare) == 0, (
+        f"Found unguarded add_label calls in reconcile_admission_requests: {truly_bare}"
+    )


### PR DESCRIPTION
## Summary

Fixes issue #1230: worker evaluates issues via `issue_acceptance_review()` but fails to apply the final label (`needs-human`, `scc-rejected`), leaving issues stuck in `scc-admission-review` with repetitive duplicate comments every worker cycle.

### Root Cause

1. `add_label` ran under `set -euo pipefail` without error handling — a failed `gh issue edit --add-label` would abort the worker silently (stderr not redirected, no log message).
2. The `needs-human` and `rejected` branches removed `scc-admission-review` **before** adding the terminal label. If `add_label` then failed and aborted the worker, the issue was left without `scc-admission-review` and without the terminal label. On the next cycle, `reconcile_admission_requests` re-added `scc-admission-review` and posted a duplicate comment → infinite loop.

### Fix

- `add_label` now logs an ERROR and returns 1 on failure instead of aborting the worker
- All `reconcile_stuck_admission_reviews` case branches (accepted, needs-human, rejected) now add the terminal label **first** and only remove `scc-admission-review` on success. On failure, the issue stays in `scc-admission-review` for retry
- Policy-driven auto-approval branches fixed the same way
- `reconcile_admission_requests` now skips issues already in `scc-admission-review` (prevents duplicate comments) and skips `scc-rejected` (was missing from terminal-state skip list)
- Policy branches in `reconcile_admission_requests` also guard `add_label` calls

### Acceptance Criteria Mapping

| Criterion | Status |
|---|---|
| Worker applies `needs-human` label when review indicates | ✅ Fixed — add terminal label first, handle failure |
| Worker applies `scc-rejected` label when review indicates | ✅ Fixed — same pattern |
| Issue exits `scc-admission-review` to terminal state | ✅ Fixed — only remove review label on success |
| Logging shows label update attempt and result | ✅ Added — ERROR log on add_label failure |
| Test case validates fix | ✅ `tests/test_sdlc_worker_admission_reconcile_labels.py` (5 tests) |
| Error handling for failed label updates | ✅ Added — all reconciliation branches guarded |

#### Test plan
- [x] `tests/test_sdlc_worker_admission_reconcile_labels.py` — 5 static assertions pass
- [x] `bash -n` syntax check passes
- [ ] Manual: create issue with VPS/deploy keywords, verify `needs-human` applied and no duplicate comments

Closes #1230

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of label-update failures with clear error reporting.
  * Prevented repeated admission-review labels and comments on issues already being reviewed.
  * Ensured failed label changes preserve the review state so they can be retried.
  * Improved reliability across acceptance, legal review, human review, accepted, needs-human, and rejected transitions.

* **Tests**
  * Added coverage for label failures, review-state handling, and label-update ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->