### PR TITLE
fix(ui): hide Loading volunteer data for unauthenticated users (#1305)

### DIFF
--- a/quarkus-app/src/main/resources/templates/EventResource/volunteers.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/volunteers.html
@@ -114,7 +114,7 @@
     <h2 style="margin-top: 0;">{i18n:events_volunteers_my_application_title}</h2>
     <div id="volunteerConfigInfo" class="volunteer-status-card">
       <strong>{i18n:events_volunteers_window_title}</strong>
-      <p id="volunteerWindowMessage" class="form-hint" style="margin: 0;">{i18n:events_volunteers_loading}</p>
+      <p id="volunteerWindowMessage" class="form-hint" style="margin: 0;">{#if userAuthenticated}{i18n:events_volunteers_loading}{#else}{i18n:events_volunteers_login_to_view}{/if}</p>
     </div>
     <div id="volunteerMineInfo" style="margin-top: 0.8rem;">
       <p class="form-hint">{#if userAuthenticated}{i18n:events_volunteers_loading}{#else}{i18n:events_volunteers_login_to_view}{/if}</p>


### PR DESCRIPTION
## Summary
- "Loading volunteer data..." message was stuck for unauthenticated users who can't load volunteer data
- Now hidden for non-authenticated sessions

Closes #1305

#### Test plan
- [ ] Visit volunteers page while logged out — no stuck loading message
- [ ] Visit volunteers page while logged in — loading works normally

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the volunteer window message to show a login prompt for unauthenticated visitors.
  * Authenticated visitors continue to see the loading message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->