### PR TITLE
fix(ui): localize footer privacy/terms links based on resolvedLocaleCode (#1306)

### DIFF
--- a/quarkus-app/src/main/resources/templates/fragments/footer.html
+++ b/quarkus-app/src/main/resources/templates/fragments/footer.html
@@ -7,9 +7,9 @@
       ·
       <a href="https://discord.gg/3eawzc9ybc" class="footer-link" target="_blank" rel="noopener noreferrer" aria-label="{i18n:footer_support_aria}">{i18n:footer_support}</a>
       ·
-      <a href="/privacy-policy" class="footer-link">{i18n:footer_privacy_policy}</a>
+      <a href="{#if resolvedLocaleCode == 'es'}/politica-de-privacidad{#else}/privacy-policy{/if}" class="footer-link">{i18n:footer_privacy_policy}</a>
       ·
-      <a href="/terms-of-service" class="footer-link">{i18n:footer_terms_of_service}</a>
+      <a href="{#if resolvedLocaleCode == 'es'}/condiciones-del-servicio{#else}/terms-of-service{/if}" class="footer-link">{i18n:footer_terms_of_service}</a>
     </p>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
- Footer was linking only to English versions of privacy/terms pages, ignoring Spanish routes
- Now localizes based on `resolvedLocaleCode`

Closes #1306

#### Test plan
- [ ] With `QP_LOCALE=es`, footer links to Spanish privacy/terms pages
- [ ] With `QP_LOCALE=en`, footer links to English privacy/terms pages

Generated with [Devin](https://devin.ai)