### PR TITLE
fix(ui): X icon, inline LinkedIn SVG, remove Tailwind CDN, fix retro-theme.js (#1300, #1295)

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/retro-theme.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/retro-theme.js
@@ -81,7 +81,7 @@ var retroDefaultConfig = {
   accent_color: "#FFD700"
 };
 
-let config = defaultConfig;
+let config = retroDefaultConfig;
 
 // Data SDK Handler
 var dataHandler = {

--- a/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
@@ -2,7 +2,6 @@
 {#title}{#if speaker}{speaker.name}{#else}Orador{/if}{/title}
 {#head}
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Courier+Prime&display=swap" rel="stylesheet" />
-<script src="https://cdn.tailwindcss.com"></script>
 <script src="/js/retro-theme.js?v={app:version()}" defer></script>
 {/head}
 {#breadcrumbs}
@@ -73,11 +72,12 @@
             class="btn"><span class="material-symbols-outlined"
               style="font-size: 1.2em; vertical-align: middle;">language</span> Sitio web</a>{/if}
           {#if app:validUrl(speaker.twitter)}<a href="{speaker.twitter}" target="_blank" rel="noopener" class="btn"><img
-              src="https://cdn.simpleicons.org/twitter/white" width="16" height="16" alt="Twitter"
-              style="vertical-align: middle;"> Twitter</a>{/if}
+              src="https://cdn.simpleicons.org/x/white" width="16" height="16" alt="X"
+              style="vertical-align: middle;"> X</a>{/if}
           {#if app:validUrl(speaker.linkedin)}<a href="{speaker.linkedin}" target="_blank" rel="noopener"
-            class="btn"><img src="https://cdn.simpleicons.org/linkedin/FFFFFF" width="16" height="16" alt="LinkedIn"
-              style="vertical-align: middle;"> LinkedIn</a>{/if}
+            class="btn"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-label="LinkedIn"
+              style="vertical-align: middle;"><path d="M20.45 20.45h-3.56v-5.57c0-1.33-.02-3.04-1.85-3.04-1.85 0-2.13 1.45-2.13 2.94v5.67H9.35V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29zM5.34 7.43a2.06 2.06 0 1 1 0-4.13 2.06 2.06 0 0 1 0 4.13zM7.12 20.45H3.56V9h3.56v11.45zM22.22 0H1.77C.79 0 0 .77 0 1.72v20.56C0 23.23.79 24 1.77 24h20.45c.98 0 1.78-.77 1.78-1.72V1.72C24 .77 23.2 0 22.22 0z"/></svg>
+            LinkedIn</a>{/if}
           {#if app:validUrl(speaker.instagram)}<a href="{speaker.instagram}" target="_blank" rel="noopener"
             class="btn"><img src="https://cdn.simpleicons.org/instagram/white" width="16" height="16" alt="Instagram"
               style="vertical-align: middle;"> Instagram</a>{/if}


### PR DESCRIPTION
## Summary
- **#1300**: Replace broken simpleicons twitter/white with x/white (X icon) + replace LinkedIn icon with inline SVG (more reliable than CDN)
- **#1295**: Remove Tailwind CDN script tag from speaker page (unused in prod) + fix `retro-theme.js` ReferenceError

Note: #1339 already fixed the LinkedIn URL format (`white`→`FFFFFF`); this PR goes further with inline SVG and X icon replacement.

Closes #1300, #1295

#### Test plan
- [ ] Speaker page shows X icon (not broken Twitter icon)
- [ ] Speaker page shows LinkedIn SVG (not CDN image)
- [ ] No Tailwind CDN script tag in speaker page HTML
- [ ] No retro-theme.js ReferenceError in console

Generated with [Devin](https://devin.ai)