### PR TITLE
fix(seo): externalize public-url and prune dead routes from sitemap (#1294)

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -290,6 +290,9 @@ economy.purchase.max-per-minute=12
 # OG image
 homedir.og-image.default-url=/images/og-default.png
 
+# Public base URL used for sitemap.xml, robots.txt and absolute links (issue #1294)
+homedir.public-url=${HOMEDIR_PUBLIC_URL:http://localhost:8080}
+
 # Trending GitHub repositories
 trending.daily.cron=0 0 0 * * ?
 trending.weekly.cron=0 0 0 ? * MON

--- a/quarkus-app/src/main/resources/templates/SeoResource/sitemap.xml
+++ b/quarkus-app/src/main/resources/templates/SeoResource/sitemap.xml
@@ -37,6 +37,14 @@
     <loc>{publicUrl}/proyectos</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="{publicUrl}/projects" />
+  </url>
+
+  <url>
+    <loc>{publicUrl}/projects</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="{publicUrl}/proyectos" />
   </url>
 
   <url>
@@ -46,21 +54,9 @@
   </url>
 
   <url>
-    <loc>{publicUrl}/events</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <url>
     <loc>{publicUrl}/comunidad</loc>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>{publicUrl}/reputation-hub</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.6</priority>
   </url>
 
   <url>
@@ -73,18 +69,6 @@
     <loc>{publicUrl}/comunidad/propose</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
-  </url>
-
-  <url>
-    <loc>{publicUrl}/comunidad/moderation</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.3</priority>
-  </url>
-
-  <url>
-    <loc>{publicUrl}/comunidad/board</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.6</priority>
   </url>
 
   <url>


### PR DESCRIPTION
## Summary
- Externalize `homedir.public-url` via `HOMEDIR_PUBLIC_URL` env var (was hardcoded to `localhost:8080`)
- Remove dead routes from `sitemap.xml`: `/events`, `/reputation-hub`, `/comunidad/moderation`, `/comunidad/board`
- Add `hreflang` alternates for `/proyectos` ↔ `/projects` (locale routing)
- Fix `/events` → `/eventos` (canonical Spanish route)

Closes #1294

#### Test plan
- [ ] `curl https://homedir.opensourcesantiago.io/sitemap.xml` — no localhost URLs
- [ ] Sitemap does not list dead routes
- [ ] Sitemap includes hreflang alternates for /proyectos and /projects

Generated with [Devin](https://devin.ai)