### PR TITLE
feat(ui): add Bounty Hunters Dashboard & Leaderboard UI (#1375)

### DIFF
--- a/src/main/resources/META-INF/resources/js/bounty-hunters.js
+++ b/src/main/resources/META-INF/resources/js/bounty-hunters.js
@@ -8,9 +8,9 @@ document.addEventListener('DOMContentLoaded', () => {
       leaderboardTable.innerHTML = hunters.map((h, i) => `
         <tr class="hd-table-row">
           <td class="hd-rank">#${i + 1}</td>
-          <td class="hd-user"><a href="/bounty-hunters/${h.userId}">${h.username}</a></td>
+          <td class="hd-user"><a href="/bounty-hunters/${h.userId}">${h.userId}</a></td>
           <td class="hd-points">${h.totalPoints} pts</td>
-          <td class="hd-level"><span class="hd-badge hd-badge-${h.level.toLowerCase()}">${h.level}</span></td>
+          <td class="hd-level"><span class="hd-badge hd-badge-${(h.level || '').toLowerCase()}">${h.level}</span></td>
         </tr>
       `).join('');
     })

--- a/src/main/resources/META-INF/resources/js/bounty-hunters.js
+++ b/src/main/resources/META-INF/resources/js/bounty-hunters.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const leaderboardTable = document.getElementById('bounty-leaderboard-body');
+  if (!leaderboardTable) return;
+
+  fetch('/api/bounty-hunters/leaderboard?limit=50')
+    .then(res => res.json())
+    .then(hunters => {
+      leaderboardTable.innerHTML = hunters.map((h, i) => `
+        <tr class="hd-table-row">
+          <td class="hd-rank">#${i + 1}</td>
+          <td class="hd-user"><a href="/bounty-hunters/${h.userId}">${h.username}</a></td>
+          <td class="hd-points">${h.totalPoints} pts</td>
+          <td class="hd-level"><span class="hd-badge hd-badge-${h.level.toLowerCase()}">${h.level}</span></td>
+        </tr>
+      `).join('');
+    })
+    .catch(err => console.error('Failed to load bounty leaderboard:', err));
+});

--- a/src/test/resources/bounty-hunters-test.js
+++ b/src/test/resources/bounty-hunters-test.js
@@ -1,11 +1,37 @@
 describe('Bounty Hunters Leaderboard UI Component', () => {
-  it('should render leaderboard rows matching API schema', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('tbody');
+    container.id = 'bounty-leaderboard-body';
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    jest.restoreAllMocks();
+  });
+
+  it('should render leaderboard rows matching API schema', async () => {
     const mockHunters = [
-      { userId: 'user-1', totalPoints: 100, level: 'NOVICE' },
-      { userId: 'user-2', totalPoints: 250, level: 'PROFESSIONAL' }
+      { userId: 'user-1', totalPoints: 100, level: 'Novice Bounty Hunter' },
+      { userId: 'user-2', totalPoints: 250, level: 'Professional Bounty Hunter' }
     ];
-    
-    expect(mockHunters.length).toBe(2);
-    expect(mockHunters[0].userId).toBe('user-1');
+
+    global.fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockResolvedValue(mockHunters)
+    });
+
+    require('../META-INF/resources/js/bounty-hunters.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const rows = container.querySelectorAll('tr');
+    expect(rows.length).toBe(2);
+    expect(rows[0].querySelector('.hd-user').textContent).toBe('user-1');
+    expect(rows[0].querySelector('.hd-points').textContent).toBe('100 pts');
+    expect(rows[0].querySelector('.hd-level').textContent).toBe('Novice Bounty Hunter');
+    expect(rows[1].querySelector('.hd-level').textContent).toBe('Professional Bounty Hunter');
   });
 });

--- a/src/test/resources/bounty-hunters-test.js
+++ b/src/test/resources/bounty-hunters-test.js
@@ -1,0 +1,11 @@
+describe('Bounty Hunters Leaderboard UI Component', () => {
+  it('should render leaderboard rows matching API schema', () => {
+    const mockHunters = [
+      { userId: 'user-1', totalPoints: 100, level: 'NOVICE' },
+      { userId: 'user-2', totalPoints: 250, level: 'PROFESSIONAL' }
+    ];
+    
+    expect(mockHunters.length).toBe(2);
+    expect(mockHunters[0].userId).toBe('user-1');
+  });
+});


### PR DESCRIPTION
Resolves #1375.

Implements Bounty Hunters Dashboard & Leaderboard UI client script in src/main/resources/META-INF/resources/js/bounty-hunters.js consuming GET /api/bounty-hunters/leaderboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a leaderboard displaying up to 50 bounty hunters.
  * Shows rankings, user links, points, and level badges.
  * Leaderboard entries are populated from the latest available data.
* **Bug Fixes**
  * Improved resilience when leaderboard elements are unavailable or data cannot be loaded.
  * Prevented incomplete or malformed leaderboard responses from disrupting the page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->