### PR TITLE
fix(ci): correct YAML syntax in update-docs-on-release workflow

### DIFF
--- a/.github/workflows/update-docs-on-release.yml
+++ b/.github/workflows/update-docs-on-release.yml
@@ -94,7 +94,8 @@ jobs:
             # Create PR
             gh pr create \
               --title "docs: sync changelog for ${TAG_NAME}" \
-              --body "Automated documentation update for release ${TAG_NAME}
+              --body "$(cat <<EOF
+Automated documentation update for release ${TAG_NAME}
 
 **Changes:**
 - Updated CHANGELOG.md with ${TAG_NAME} release notes
@@ -102,7 +103,9 @@ jobs:
 
 **Source:** Triggered by release publication event
 
-This PR should be merged to complete the release documentation update." \
+This PR should be merged to complete the release documentation update.
+EOF
+)" \
               --base main \
               --head "$BRANCH_NAME"
           else


### PR DESCRIPTION
## Summary

Fixes YAML syntax error on line 99 in `.github/workflows/update-docs-on-release.yml` that was blocking release workflows.

## Problem

The workflow was failing with:
```
Invalid workflow file: .github/workflows/update-docs-on-release.yml#L99
You have an error in your yaml syntax on line 99
```

The multiline string in the `gh pr create --body` parameter was not properly escaped in YAML.

## Solution

Changed from inline multiline string to heredoc format (`cat <<EOF`) for proper YAML parsing.

**Before:**
```yaml
--body "Automated documentation...
**Changes:**
..."```

**After:**
```yaml
--body "$(cat <<EOF
Automated documentation...
**Changes:**
...
EOF
)"
```

## Impact

- ✅ Fixes workflow syntax validation
- ✅ Unblocks release documentation automation
- ✅ Potentially unblocks deployments to production

This error was preventing the release workflow from completing, which may have been blocking prod deployments.

Refs https://github.com/os-santiago/homedir/actions/runs/31238724253