### PR TITLE
fix(ci): correct YAML in update-docs-on-release workflow (body-file approach)

### DIFF
--- a/.github/workflows/update-docs-on-release.yml
+++ b/.github/workflows/update-docs-on-release.yml
@@ -92,20 +92,16 @@ jobs:
             git push origin "$BRANCH_NAME"
 
             # Create PR
+            BODY_FILE="$(mktemp)"
+            printf 'Automated documentation update for release %s\n' "${TAG_NAME}" > "$BODY_FILE"
+            printf '\n**Changes:**\n' >> "$BODY_FILE"
+            printf -- '- Updated CHANGELOG.md with %s release notes\n' "${TAG_NAME}" >> "$BODY_FILE"
+            printf -- '- Updated RELEASE_NOTES.md with latest release information\n' >> "$BODY_FILE"
+            printf '\n**Source:** Triggered by release publication event\n' >> "$BODY_FILE"
+            printf '\nThis PR should be merged to complete the release documentation update.\n' >> "$BODY_FILE"
             gh pr create \
               --title "docs: sync changelog for ${TAG_NAME}" \
-              --body "$(cat <<EOF
-Automated documentation update for release ${TAG_NAME}
-
-**Changes:**
-- Updated CHANGELOG.md with ${TAG_NAME} release notes
-- Updated RELEASE_NOTES.md with latest release information
-
-**Source:** Triggered by release publication event
-
-This PR should be merged to complete the release documentation update.
-EOF
-)" \
+              --body-file "$BODY_FILE" \
               --base main \
               --head "$BRANCH_NAME"
           else


### PR DESCRIPTION
Follow-up to #1387 (merged as 434cc6e9).

## Problem

Merge #1387 shipped the heredoc version of the PR-body generation, but that version still places the body lines at **column zero** inside the \un: |\ block scalar. The workflow is therefore **still invalid YAML** — it fails at parse time with:

\\\
yaml.scanner.ScannerError: while scanning a simple key
  in update-docs-on-release.yml, line 98, column 1
could not find expected ':'
\\\

Evidence: a \push\ run on head 434cc6e9 of this workflow reports 'This run likely failed because of a workflow file issue' — i.e. it cannot even parse.

## Solution

Rework PR body generation so every line of the \un:\ block stays indented:

- Write the body into a temp file with consecutive \printf\ lines (no heredoc, no multiline inline string).
- Pass the file with \gh pr create --body-file\.

Verified with \yaml.safe_load\ — the updated file parses cleanly.

Closes follow-up for #1387.