### PR TITLE
HOTFIX: force Maven cache invalidation for profile template

### DIFF
--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -1,3 +1,4 @@
+{! Force cache invalidation - 2026-08-10 !}
 {#include layout/main activePage="profile"}
 {#title}{i18n:profile_title}{/title}
 


### PR DESCRIPTION
## 🚨 Critical Hotfix - Maven Cache Issue

**Problem:**
Maven cache in GitHub Actions is preserving old compiled template files, causing v3.628.3 and v3.628.4 to be built with the OLD code despite having the correct source in Git.

**Root Cause:**
- Source code in Git: ✅ Correct (double-dollar escaping)
- Compiled artifact in Maven cache: ❌ Old version (without escaping)
- Docker images built from: ❌ Cached artifacts

**Solution:**
Add a Qute comment to the template file to force Maven to recompile it, invalidating the cache.

**Verification:**
This is a trivial change (comment only) that forces cache invalidation. The actual fix from PR #1398 is already in main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated profile page template metadata to refresh cached content.
  * No visible functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->