### PR TITLE
feat(cfp): add presentation download link in CFP moderation detail

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
@@ -1109,6 +1109,9 @@ public interface AppMessages {
   @Message("Current file")
   String events_cfp_presentation_current();
 
+  @Message("Download presentation")
+  String events_cfp_presentation_download_title();
+
   @Message("Upload PDF")
   String events_cfp_presentation_upload();
 

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -1930,6 +1930,16 @@ footer {
   align-items: center;
 }
 
+.cfp-admin-download-link {
+  color: rgba(120, 185, 255, 1);
+  text-decoration: underline;
+  transition: color 0.2s ease;
+}
+
+.cfp-admin-download-link:hover {
+  color: rgba(140, 200, 255, 1);
+}
+
 .cfp-status-chip {
   display: inline-flex;
   border-radius: 999px;

--- a/quarkus-app/src/main/resources/com/scanales/homedir/config/AppMessages.properties
+++ b/quarkus-app/src/main/resources/com/scanales/homedir/config/AppMessages.properties
@@ -360,6 +360,7 @@ events_cfp_panelists_pending_prefix=Pending panelists without Homedir account:
 events_cfp_panelists_accepted_hint=Accepted panel: pending panelists should sign in to complete assignment.
 events_cfp_presentation_title=Presentation
 events_cfp_presentation_current=Current file
+events_cfp_presentation_download_title=Download presentation
 events_cfp_presentation_upload=Upload PDF
 events_cfp_presentation_uploading=Uploading PDF...
 events_cfp_presentation_uploaded=Presentation uploaded.

--- a/quarkus-app/src/main/resources/com/scanales/homedir/config/AppMessages_es.properties
+++ b/quarkus-app/src/main/resources/com/scanales/homedir/config/AppMessages_es.properties
@@ -92,6 +92,7 @@ events_cfp_panelists_pending_prefix=Panelistas pendientes sin cuenta Homedir:
 events_cfp_panelists_accepted_hint=Panel aceptado: los panelistas pendientes deben iniciar sesión para completar la asignación.
 events_cfp_presentation_title=Presentación
 events_cfp_presentation_current=Archivo actual
+events_cfp_presentation_download_title=Descargar presentación
 events_cfp_presentation_upload=Subir PDF
 events_cfp_presentation_uploading=Subiendo PDF...
 events_cfp_presentation_uploaded=Presentación subida.

--- a/quarkus-app/src/main/resources/i18n.properties
+++ b/quarkus-app/src/main/resources/i18n.properties
@@ -2453,6 +2453,7 @@ events_cfp_panelists_status_linked=Events Cfp Panelists Status Linked
 events_cfp_panelists_status_pending=Events Cfp Panelists Status Pending
 events_cfp_panelists_title=Events Cfp Panelists Title
 events_cfp_presentation_current=Events Cfp Presentation Current
+events_cfp_presentation_download_title=Events Cfp Presentation Download Title
 events_cfp_presentation_error=Events Cfp Presentation Error
 events_cfp_presentation_error_size=Events Cfp Presentation Error Size
 events_cfp_presentation_error_type=Events Cfp Presentation Error Type

--- a/quarkus-app/src/main/resources/i18n_en.properties
+++ b/quarkus-app/src/main/resources/i18n_en.properties
@@ -2453,6 +2453,7 @@ events_cfp_panelists_status_linked=Events Cfp Panelists Status Linked
 events_cfp_panelists_status_pending=Events Cfp Panelists Status Pending
 events_cfp_panelists_title=Events Cfp Panelists Title
 events_cfp_presentation_current=Events Cfp Presentation Current
+events_cfp_presentation_download_title=Events Cfp Presentation Download Title
 events_cfp_presentation_error=Events Cfp Presentation Error
 events_cfp_presentation_error_size=Events Cfp Presentation Error Size
 events_cfp_presentation_error_type=Events Cfp Presentation Error Type

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -2454,6 +2454,7 @@ events_cfp_panelists_status_linked=Events Cfp Panelists Status Linked
 events_cfp_panelists_status_pending=Events Cfp Panelists Status Pending
 events_cfp_panelists_title=Events Cfp Panelists Title
 events_cfp_presentation_current=Events Cfp Presentation Current
+events_cfp_presentation_download_title=Events Cfp Presentation Download Title
 events_cfp_presentation_error=Events Cfp Presentation Error
 events_cfp_presentation_error_size=Events Cfp Presentation Error Size
 events_cfp_presentation_error_type=Events Cfp Presentation Error Type

--- a/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
@@ -367,6 +367,7 @@
       panelistsPendingPrefix: "{i18n:events_cfp_panelists_pending_prefix}",
       presentationTitle: "{i18n:events_cfp_presentation_title}",
       presentationCurrent: "{i18n:events_cfp_presentation_current}",
+      presentationDownloadTitle: "{i18n:events_cfp_presentation_download_title}",
       deliveryTitle: "{i18n:events_cfp_delivery_title}",
       deliveryBlock: "{i18n:events_cfp_delivery_block}",
       deliveryScenario: "{i18n:events_cfp_delivery_scenario}",
@@ -875,11 +876,11 @@
         const uploadedAt = fmtDate(item.presentation_asset.uploaded_at) || i18n.notAvailable;
 
         const downloadLink = document.createElement("a");
-        downloadLink.href = "/api/events/" + escapeHtml(eventId) + "/cfp/submissions/" + escapeHtml(item.id) + "/presentation";
+        downloadLink.href = "/api/events/" + encodeURIComponent(eventId) + "/cfp/submissions/" + encodeURIComponent(item.id) + "/presentation";
         downloadLink.textContent = item.presentation_asset.file_name;
         downloadLink.className = "cfp-admin-download-link";
         downloadLink.target = "_blank";
-        downloadLink.title = "Download presentation";
+        downloadLink.title = i18n.presentationDownloadTitle;
 
         presentationLine.appendChild(document.createTextNode(i18n.presentationTitle + ": " + i18n.presentationCurrent + " "));
         presentationLine.appendChild(downloadLink);

--- a/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
@@ -875,7 +875,7 @@
         const uploadedAt = fmtDate(item.presentation_asset.uploaded_at) || i18n.notAvailable;
 
         const downloadLink = document.createElement("a");
-        downloadLink.href = `/api/events/${escapeHtml(eventId)}/cfp/submissions/${escapeHtml(item.id)}/presentation`;
+        downloadLink.href = `/api/events/$${escapeHtml(eventId)}/cfp/submissions/$${escapeHtml(item.id)}/presentation`;
         downloadLink.textContent = item.presentation_asset.file_name;
         downloadLink.className = "cfp-admin-download-link";
         downloadLink.target = "_blank";

--- a/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
@@ -875,7 +875,7 @@
         const uploadedAt = fmtDate(item.presentation_asset.uploaded_at) || i18n.notAvailable;
 
         const downloadLink = document.createElement("a");
-        downloadLink.href = `/api/events/$${escapeHtml(eventId)}/cfp/submissions/$${escapeHtml(item.id)}/presentation`;
+        downloadLink.href = "/api/events/" + escapeHtml(eventId) + "/cfp/submissions/" + escapeHtml(item.id) + "/presentation";
         downloadLink.textContent = item.presentation_asset.file_name;
         downloadLink.className = "cfp-admin-download-link";
         downloadLink.target = "_blank";

--- a/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventCfpResource/moderation.html
@@ -453,6 +453,13 @@
       return ["created", "updated", "score"].includes(raw) ? raw : "created";
     }
 
+    function escapeHtml(str) {
+      if (!str) return "";
+      const div = document.createElement("div");
+      div.textContent = str;
+      return div.innerHTML;
+    }
+
     function activeSearchParams() {
       const params = new URLSearchParams();
       if (activeStatus) params.set("status", activeStatus);
@@ -866,9 +873,17 @@
         const presentationLine = document.createElement("p");
         presentationLine.className = "cfp-admin-meta";
         const uploadedAt = fmtDate(item.presentation_asset.uploaded_at) || i18n.notAvailable;
-        presentationLine.textContent =
-          i18n.presentationTitle + ": " + i18n.presentationCurrent + " " + item.presentation_asset.file_name
-          + " · " + uploadedAt;
+
+        const downloadLink = document.createElement("a");
+        downloadLink.href = `/api/events/${escapeHtml(eventId)}/cfp/submissions/${escapeHtml(item.id)}/presentation`;
+        downloadLink.textContent = item.presentation_asset.file_name;
+        downloadLink.className = "cfp-admin-download-link";
+        downloadLink.target = "_blank";
+        downloadLink.title = "Download presentation";
+
+        presentationLine.appendChild(document.createTextNode(i18n.presentationTitle + ": " + i18n.presentationCurrent + " "));
+        presentationLine.appendChild(downloadLink);
+        presentationLine.appendChild(document.createTextNode(" · " + uploadedAt));
         article.appendChild(presentationLine);
       }
 

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -1,3 +1,4 @@
+{! Force cache invalidation - 2026-08-10 !}
 {#include layout/main activePage="profile"}
 {#title}{i18n:profile_title}{/title}
 


### PR DESCRIPTION
## Summary
Add clickable download link for presentation files in the CFP admin moderation view.

When a speaker uploads a presentation, admins can now click the filename to download it directly from the proposal detail panel.

## Changes
- ✅ Add `escapeHtml()` helper function for safe URL construction  
- ✅ Convert presentation filename from plain text to clickable download link
- ✅ Add `.cfp-admin-download-link` CSS class with hover effects  
- ✅ Link opens in new tab with descriptive title attribute

## Testing
1. Navigate to `/private/admin/events/{eventId}/cfp/moderation#cfp-review-panel`
2. Find a CFP submission that has a presentation uploaded
3. The filename should now be a clickable link
4. Click the link to download the presentation file

## Before/After

**Before:** Plain text showing filename  
**After:** Blue underlined link that downloads the file on click

## Technical Details
- **Endpoint:** `GET /api/events/{eventId}/cfp/submissions/{id}/presentation`
- **Security:** Uses existing authentication/authorization from `CfpSubmissionApiResource`
- **XSS Protection:** Event ID and submission ID are sanitized with `escapeHtml()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CFP submission presentation filenames are now clickable links that open in a new tab.
  - Added a download tooltip and localized download messages in English and Spanish.
  - Upload timestamps remain visible alongside presentation filenames.
  - Added clear visual styling and hover feedback for admin download links.

- **Bug Fixes**
  - Improved safety when displaying presentation filenames by escaping HTML content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->