### PR TITLE
fix(hub): align migration banner with page-grid width and centering

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/reputation-hub.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/reputation-hub.css
@@ -62,7 +62,8 @@
 }
 
 .hub-migration-banner {
-  margin: 0 0 1rem;
+  max-width: 1200px;
+  margin: 0 2rem 1rem;
   border: 1px solid rgba(255, 255, 255, 0.34);
   border-radius: 10px;
   padding: 0.75rem 0.9rem;
@@ -271,5 +272,12 @@
 
   .hub-recognition-item {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .hub-migration-banner {
+    margin-left: 1.25rem;
+    margin-right: 1.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- `.hub-migration-banner` en las páginas del Reputation Hub (`hub.html`, `how.html`) se estiraba al ancho completo de `.homedir-main` y quedaba descentrado respecto a las tarjetas `.section-card` dentro de `.page-grid`, que sí tienen `max-width: 1200px` y `padding: 0 2rem`.
- Se añade `max-width: 1200px` y `margin: 0 2rem 1rem` a `.hub-migration-banner` para alinear su borde con el de las tarjetas inferiores.
- Se añade breakpoint `@media (max-width: 768px)` que reduce el margen horizontal a `1.25rem`, coincidiendo con el padding responsive de `.page-grid`.

Closes #1401

#### Test plan
- [ ] Compila el proyecto (`./mvnw compile`)
- [ ] Visitar `/comunidad/reputation-hub` con `showHubMigrationBanner = true` y verificar que el banner alinea su borde horizontal con las `.section-card` inferiores
- [ ] Visitar `/comunidad/reputation-hub/how` y verificar el mismo alineamiento
- [ ] Probar en viewport ≤768px y confirmar que el banner se ajusta al padding responsive de `.page-grid`
- [ ] Probar en viewport >1200px y confirmar que el banner no excede `max-width: 1200px`

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the migration banner layout with a maximum width and balanced horizontal spacing.
  * Added responsive styling to reduce side margins on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->