### PR TITLE
docs: fix high-priority documentation audit items (#1363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
+> **⚠️ Known gap** · This changelog is out of sync: it stops at `3.330.1` while the repo is at `v3.630.0` (568 releases published). Entries were not generated because the `update-docs-on-release.yml` workflow was not producing PRs. Syncing all missing entries and fixing the workflow is tracked separately ([#1363](https://github.com/os-santiago/homedir/issues/1363)).
+
 ## [3.330.1] - 2026-02-10
 ### Changed
 - Community section now resolves UI text from i18n keys in Picks, Propose Content, and Moderation flows.
 - Community client-side date formatting now follows browser/document locale.
-- `full_release_cycle` default version updated to `3.330.1`.
+- Default version updated to `3.330.1`.
 
 ### Fixed
 - Removed `z-index` from `.alpha-banner` to prevent overlap with the user profile popup.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Language](https://img.shields.io/github/languages/top/os-santiago/homedir?style=for-the-badge&logo=java&logoColor=white&color=ED8B00)](https://github.com/os-santiago/homedir)
 [![Last Commit](https://img.shields.io/github/last-commit/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/commits/main)
 [![Version](https://img.shields.io/github/v/release/os-santiago/homedir?label=Version&style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir/releases)
-[![Maven Version](https://img.shields.io/badge/version-3.403.1-blue?style=for-the-badge&logo=apache-maven&logoColor=white)](https://github.com/os-santiago/homedir/releases)
+[![Maven Version](https://img.shields.io/badge/version-3.630.0-blue?style=for-the-badge&logo=apache-maven&logoColor=white)](https://github.com/os-santiago/homedir/releases)
 [![Discord](https://img.shields.io/badge/Discord-Join%20the%20chat-5865F2?logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/3eawzc9ybc)
 [![Repo Size](https://img.shields.io/github/repo-size/os-santiago/homedir?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir)
 [![Project Status: Active](https://img.shields.io/badge/status-active-brightgreen?style=for-the-badge&logo=github&logoColor=white)](https://github.com/os-santiago/homedir)
@@ -29,7 +29,14 @@ Homedir is a Quarkus-based community platform for DevRel/Open Source initiatives
 ## Repository Layout
 - `quarkus-app/`: main Quarkus application (backend + templates + static assets).
 - `docs/`: product and technical documentation (EN/ES).
+- `config/`: governance documentation (labels, branch protection, priorities).
 - `platform/`: VPS deployment scripts, env template, systemd/nginx assets.
+- `scripts/`: shared CI/ops scripts (versioning, tests, i18n validation).
+- `deployment/`: deployment and orchestration assets.
+- `container/`: container build assets.
+- `modules/`: optional modular prototypes/proposals.
+- `src/`: support tooling (e.g., Python worker).
+- `tests/`: Playwright E2E and JS unit tests.
 - `tools/community-curator/`: curated content generation and deployment tooling.
 
 ## Getting Started
@@ -57,7 +64,7 @@ Public image repository:
 
 Tags published by release pipeline:
 - `latest`
-- semantic tags like `3.360.1` (see [Releases](https://github.com/os-santiago/homedir/releases))
+- semantic tags like `3.630.0` (see [Releases](https://github.com/os-santiago/homedir/releases))
 
 Create an env file from `platform/env.example` and fill required values (do not commit secrets), then run:
 
@@ -76,7 +83,7 @@ docker run --rm --name homedir \
   -p 8080:8080 \
   --env-file ./.env.homedir \
   -v "$(pwd)/.data:/work/data" \
-  quay.io/sergio_canales_e/homedir:3.360.1
+  quay.io/sergio_canales_e/homedir:3.630.0
 ```
 
 ### 3) Build your own image from source

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,7 @@
 ## Changes since v3.629.0
 
 ### ✨ Features
-- feat(cfp): add PPTX support for presentation uploads (#1402) (@) #1402
+- feat(cfp): add PPTX support for presentation uploads (#1402) (@scanalesespinoza)
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,15 @@
-# HomeDir 3.330.1
+# HomeDir 3.630.0
+
+> Release date: 2026-08-11 · See [Releases](https://github.com/os-santiago/homedir/releases) for the full list.
+
+## Changes since v3.629.0
+
+### ✨ Features
+- feat(cfp): add PPTX support for presentation uploads (#1402) (@) #1402
+
+---
+
+## HomeDir 3.330.1
 
 **Summary**
 - Community UI now uses locale-aware copy in browser-facing flows for Picks, Propose Content, and Moderation.
@@ -20,7 +31,7 @@
 - `CommunityBoardResourceTest`
 - Result: `19 tests, 0 failures`.
 
-## Homedir 2.2.3
+## HomeDir 2.2.3
 
 **Resumen**
 - Canonicaliza el `redirect_uri` de GitHub para que siempre apunte a `/auth/post-login` y mueve la lógica a `GithubLinkService`, evitando diferencias entre entornos y el callback registrado.
@@ -30,13 +41,12 @@
 **Detalles**
 - La interacción con GitHub ya no reconstruye URIs manualmente; el nuevo servicio gestiona cookies y respuestas coherentes con el OAuth app configurado.
 - Las instrucciones de tagging/release se actualizaron a `2.2.3` y los Dockerfiles comentados muestran el tag actual para referencia.
-- Deploy workflow (tag `fix/deploy-logging`) publica el digest, loguea el estado de podman y usa las variables de entorno requeridas sin tocar `URI`s desde el recurso.
 
 **Container**
 - `quay.io/sergio_canales_e/homedir:2.2.3` (alias)
 - Despliegue por digest siempre que sea posible; el pipeline lo registra en el artefacto `pr-image-ref`.
 
-## Homedir 2.2.2
+## HomeDir 2.2.2
 
 **Resumen**
 - Correcciones menores y mejoras de documentación.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,11 +37,12 @@ Use one of these private channels:
 
 We support only the **current major version**. Previous majors become unsupported (EOL) immediately upon new major release.
 
-**Current active major: 2.x**
+**Current active major: 3.x**
 
 | Version | Supported |
 |---------|-----------|
-| 2.x | ✅ Active |
+| 3.x | ✅ Active |
+| 2.x | ❌ Unsupported |
 | < 2.0 | ❌ Unsupported |
 
 ## Security Features

--- a/docs/en/SECURITY.md
+++ b/docs/en/SECURITY.md
@@ -10,11 +10,12 @@ Homedir takes the security of our users and contributors seriously. If you belie
 
 We support **only the currently active major release line**. When a new major is released, all previous majors become **unsupported** (EOL) immediately.
 
-**Current active major: `2.x`**
+**Current active major: `3.x`**
 
 | Version | Supported |
 |--------:|-----------|
-| 2.x     | Active    |
+| 3.x     | Active    |
+| 2.x     | Unsupported |
 | < 2.x   | Unsupported |
 
 > This major-only policy keeps the project fast and secure in line with our trunk-based development approach.

--- a/docs/en/development/ARCHITECTURE.md
+++ b/docs/en/development/ARCHITECTURE.md
@@ -5,10 +5,11 @@ This document describes architectural patterns, design decisions, and technical 
 
 ## Key Improvements (Issue #733)
 
-### 1. H2 Database Credentials Externalization ✅
+### 1. H2 Database Path Externalization ✅
 - **File**: CommunityVoteService.java
-- **Change**: Hardcoded credentials removed
-- **Configuration**: Use `community.votes.db.username` and `community.votes.db.password`
+- **Change**: The H2 database **path** is configurable via `community.votes.db.path` (no longer a hardcoded location); credentials are **not** externalized
+- **Configuration**: Use `community.votes.db.path` (defaults to `data/community/votes/community-votes`)
+- **Note**: The connection still uses hardcoded embedded-H2 credentials (`DriverManager.getConnection(jdbcUrl, "sa", "")` in `CommunityVoteService.connection()`), which is acceptable for an embedded file database but should be externalized if credentials ever need to change
 
 ### 2. HTTP Client Reuse ✅
 - **Pattern**: Singleton HttpClient instances (not per-request)
@@ -23,7 +24,7 @@ This document describes architectural patterns, design decisions, and technical 
 
 ### Persistence
 - File-based JSON with atomic writes (PersistenceService)
-- H2 embedded for votes (credentials now externalized)
+- H2 embedded for votes (path configurable via `community.votes.db.path`; embedded credentials `sa`/`""` hardcoded)
 - Schema versioning
 
 ### Concurrency
@@ -76,9 +77,9 @@ The TrendingService scrapes GitHub's trending page to display popular repositori
 The implementation uses only JDK HttpClient and regex parsing, avoiding external scraping libraries to maintain minimal dependencies.
 
 ## Pending Improvements
-- AppMessages.java split by domain (2589 lines → multiple files)
+- AppMessages.java split by domain (7358 lines → multiple files, still pending)
 - WebSocket race condition fixes
 - Bounded deduplication maps
 - Template i18n improvements
 
-See REFACTORING.md for implementation details.
+See the project backlog and archive for refactoring implementation details.

--- a/docs/es/SECURITY.md
+++ b/docs/es/SECURITY.md
@@ -8,11 +8,12 @@ Homedir toma la seguridad de nuestros usuarios y colaboradores en serio. Si cree
 
 Solo damos soporte a la línea de versión mayor actualmente activa. Cuando se publica una nueva versión mayor, las anteriores quedan sin soporte inmediatamente.
 
-**Versión mayor activa actual: `2.x`**
+**Versión mayor activa actual: `3.x`**
 
 | Versión | Soporte |
 |-------:|-----------|
-| 2.x | Activa |
+| 3.x | Activa |
+| 2.x | Sin soporte |
 | < 2.x | Sin soporte |
 
 > Esta política mantiene el proyecto rápido y seguro, en línea con nuestro enfoque de desarrollo basado en trunk.


### PR DESCRIPTION
Closes #1363 (PR 1 de 3 — parte 🔴 alta prioridad)

## Cambios

### SECURITY.md (EN/ES/root)
- `Current active major: 2.x` → **`3.x`**
- Tabla de soporte: `2.x` marcado como ❌ unsupported

### docs/en/development/ARCHITECTURE.md
- Corregido claim falso de "H2 credentials externalized": solo se externalizó el **path** (`community.votes.db.path`); las credenciales siguen hardcodeadas (`CommunityVoteService.connection()` con `"sa"/""`)
- `AppMessages.java`: `2589 lines → 7358 lines`, oversplit sigue pendiente
- Referencia a `REFACTORING.md` (eliminado en #1391) reemplazada

### README.md
- Badge Maven `3.403.1` y tags `3.360.1` → **`3.630.0`** (última release)
- Repository Layout: añadidos `config/`, `scripts/`, `deployment/`, `container/`, `modules/`, `src/`, `tests/`

### CHANGELOG.md
- Eliminada referencia al workflow deprecado `full_release_cycle`
- Nota de brecha de sincronización (workflow `update-docs-on-release.yml` no genera entradas; sync pendiente)

### RELEASE_NOTES.md
- Encabezado regenerado para **v3.630.0** con notas reales de la release

## Notas
- Los archivos `REFACTORING.md`, `backlog.md`, `SDLC-STATUS-REPORT.md`, `EXECUTIVE-SUMMARY.md` y `AUTONOMOUS-DECISIONS*.md` citados en #1363 fueron **eliminados por #1391** y quedan resueltos de facto.

Refs #1363