### PR TITLE
docs: fix feature/security documentation and rename Eventflow to homedir (#1363)

### DIFF
--- a/docs/ci/action-versioning-policy.md
+++ b/docs/ci/action-versioning-policy.md
@@ -5,53 +5,82 @@ This document establishes the canonical versions for all GitHub Actions used acr
 
 ## Current Inventory
 
-| Workflow | Line | Action | Current | Target |
-|----------|------|--------|---------|--------|
-| cfp-go-live-resilience.yml | 89 | actions/checkout | v6 | v6 |
-| cfp-go-live-resilience.yml | 100 | webfactory/ssh-agent | v0.9.0 | v0.9.0 |
-| cfp-go-live-resilience.yml | 298 | actions/checkout | v6 | v6 |
-| cfp-go-live-resilience.yml | 301 | webfactory/ssh-agent | v0.9.0 | v0.9.0 |
-| cfp-go-live-resilience.yml | 359 | actions/upload-artifact | v7 | v7 |
-| full_release_cycle.yml | 16 | actions/checkout | v6 | v6 |
-| full_release_cycle.yml | 18 | actions/setup-java | v5 | v5 |
-| full_release_cycle.yml | 30 | actions/checkout | v6 | v6 |
-| full_release_cycle.yml | 32 | actions/setup-java | v5 | v5 |
-| full_release_cycle.yml | 39 | actions/upload-artifact | v7 | v7 |
-| full_release_cycle.yml | 49 | actions/checkout | v6 | v6 |
-| i18n-validation.yml | 20 | actions/checkout | **v4** | v6 |
-| i18n-validation.yml | 23 | actions/setup-python | **v5** | v6 |
-| pipeline-health.yml | 26 | actions/checkout | v6 | v6 |
-| pipeline-health.yml | 29 | actions/setup-python | v6 | v6 |
-| pipeline-health.yml | 62 | actions/upload-artifact | v7 | v7 |
-| pr-check.yml | 23 | actions/checkout | v6 | v6 |
-| pr-check.yml | 26 | actions/setup-java | v5 | v5 |
-| quality-gates.yml | 34 | actions/checkout | v6 | v6 |
-| quality-gates.yml | 37 | actions/setup-java | v5 | v5 |
-| quality-gates.yml | 58 | anchore/sbom-action | v0 | v0 |
-| quality-gates.yml | 66 | anchore/scan-action | v6 | v6 |
-| quality-gates.yml | 76 | github/codeql-action/upload-sarif | **v3** | v4 |
-| quality-gates.yml | 82 | actions/upload-artifact | **v4** | v7 |
-| quality-gates.yml | 111 | actions/checkout | v6 | v6 |
-| quality-gates.yml | 114 | actions/dependency-review-action | v4 | v4 |
-| quality-gates.yml | 137 | actions/checkout | v6 | v6 |
-| quality-gates.yml | 140 | github/codeql-action/init | **v3** | v4 |
-| quality-gates.yml | 146 | actions/setup-java | v5 | v5 |
-| quality-gates.yml | 159 | github/codeql-action/analyze | **v3** | v4 |
-| quality-gates.yml | 169 | actions/checkout | v6 | v6 |
-| quality-gates.yml | 174 | trufflesecurity/trufflehog | main | main |
-| release.yml | 49 | actions/checkout | v6 | v6 |
-| release.yml | 54 | actions/setup-java | v5 | v5 |
-| release.yml | 70 | mathieudutour/github-tag-action | v6.2 | v6.2 |
-| release.yml | 262 | webfactory/ssh-agent | v0.9.0 | v0.9.0 |
-| security-advisory.yml | 28 | actions/checkout | v6 | v6 |
-| security-advisory.yml | 32 | actions/dependency-review-action | v4 | v4 |
-| security-advisory.yml | 60 | actions/checkout | v6 | v6 |
-| security-advisory.yml | 64 | github/codeql-action/init | v4 | v4 |
-| security-advisory.yml | 72 | actions/setup-java | v5 | v5 |
-| security-advisory.yml | 81 | github/codeql-action/autobuild | v4 | v4 |
-| security-advisory.yml | 87 | github/codeql-action/analyze | v4 | v4 |
+> Inventory regenerated on **2026-08-11** from the actual workflow files. Workflows use **SHA pinning with a version comment** (e.g., `@<sha> # v6.5.1`); the comment is the effective version. Version tags shown for actions pinned by tag.
 
-**Bold** indicates current version differs from target.
+| Workflow | Line | Action | Version |
+|----------|------|--------|---------|
+| cfp-go-live-resilience.yml | 89 | actions/checkout | v6 |
+| cfp-go-live-resilience.yml | 100 | webfactory/ssh-agent | v0.9.0 |
+| cfp-go-live-resilience.yml | 298 | actions/checkout | v6 |
+| cfp-go-live-resilience.yml | 301 | webfactory/ssh-agent | v0.9.0 |
+| cfp-go-live-resilience.yml | 359 | actions/upload-artifact | v7 |
+| deploy-worker.yml | 40 | actions/checkout | v6 |
+| i18n-validation.yml | 26 | actions/checkout | v4 |
+| i18n-validation.yml | 29 | actions/setup-python | v5 |
+| issue-metadata-validation.yml | 23 | actions/checkout | v4 |
+| issue-metadata-validation.yml | 26 | actions/setup-python | v5 |
+| issue-metadata-validation.yml | 45 | actions/github-script | v7 |
+| issue-metadata-validation.yml | 62 | actions/github-script | v7 |
+| issue-metadata-validation.yml | 76 | actions/github-script | v7 |
+| pipeline-health.yml | 26 | actions/checkout | v6 |
+| pipeline-health.yml | 29 | actions/setup-python | v6 |
+| pipeline-health.yml | 62 | actions/upload-artifact | v7 |
+| pr-check.yml | 27 | actions/checkout | v6.5.1 |
+| pr-check.yml | 30 | actions/setup-java | v5.4.0 |
+| pr-check.yml | 144 | actions/checkout | v6.5.1 |
+| pr-check.yml | 147 | actions/setup-java | v5.4.0 |
+| pr-check.yml | 154 | actions/setup-node | v4.2.0 |
+| pr-check.yml | 161 | actions/cache | v4.2.3 |
+| pr-check.yml | 173 | actions/upload-artifact | v4.6.2 |
+| pr-check.yml | 182 | actions/upload-artifact | v4.6.2 |
+| pr-check.yml | 196 | actions/checkout | v6.5.1 |
+| pr-check.yml | 201 | actions/setup-java | v5.4.0 |
+| pr-ci-build-native-sbom.yml | 24 | actions/checkout | v6.5.1 |
+| pr-ci-build-native-sbom.yml | 27 | actions/setup-java | v5.4.0 |
+| pr-ci-build-native-sbom.yml | 38 | actions/upload-artifact | v4.6.2 |
+| pr-quality-suite.yml | 24 | actions/checkout | v6.5.1 |
+| pr-quality-suite.yml | 27 | actions/setup-java | v5.4.0 |
+| pr-quality-suite.yml | 44 | actions/checkout | v6.5.1 |
+| pr-quality-suite.yml | 47 | actions/setup-java | v5.4.0 |
+| pr-quality-suite.yml | 64 | actions/checkout | v6.5.1 |
+| pr-quality-suite.yml | 67 | actions/setup-java | v5.4.0 |
+| pr-quality-suite.yml | 84 | actions/checkout | v6.5.1 |
+| pr-quality-suite.yml | 87 | actions/setup-java | v5.4.0 |
+| pr-quality-suite.yml | 98 | codecov/codecov-action | v7.0.0 |
+| pr-quality-suite.yml | 111 | actions/checkout | v6.5.1 |
+| pr-quality-suite.yml | 114 | actions/setup-java | v5.4.0 |
+| quality-gates.yml | 34 | actions/checkout | v6.5.1 |
+| quality-gates.yml | 37 | actions/setup-java | v5.4.0 |
+| quality-gates.yml | 58 | anchore/sbom-action | v0.24.0 |
+| quality-gates.yml | 65 | anchore/scan-action | v6.5.1 |
+| quality-gates.yml | 94 | actions/checkout | v6.5.1 |
+| quality-gates.yml | 97 | actions/dependency-review-action | v4.9.0 |
+| quality-gates.yml | 120 | actions/checkout | v6.5.1 |
+| quality-gates.yml | 123 | github/codeql-action/init | v3.36.2 |
+| quality-gates.yml | 129 | actions/setup-java | v5.4.0 |
+| quality-gates.yml | 142 | github/codeql-action/analyze | v3.36.2 |
+| quality-gates.yml | 152 | actions/checkout | v6.5.1 |
+| quality-gates.yml | 157 | trufflesecurity/trufflehog | main |
+| release.yml | 54 | actions/checkout | v6 |
+| release.yml | 100 | actions/setup-java | v5 |
+| release.yml | 115 | mathieudutour/github-tag-action | v6.2 |
+| release.yml | 425 | webfactory/ssh-agent | v0.9.0 |
+| security-advisory.yml | 28 | actions/checkout | v6.5.1 |
+| security-advisory.yml | 32 | actions/dependency-review-action | v4.9.0 |
+| security-advisory.yml | 60 | actions/checkout | v6.5.1 |
+| security-advisory.yml | 64 | github/codeql-action/init | v3.36.2 |
+| security-advisory.yml | 72 | actions/setup-java | v5.4.0 |
+| security-advisory.yml | 81 | github/codeql-action/autobuild | v3.36.2 |
+| security-advisory.yml | 87 | github/codeql-action/analyze | v3.36.2 |
+| spotless-apply.yml | 22 | actions/checkout | v6.0.0 |
+| spotless-apply.yml | 28 | actions/setup-java | v5.4.0 |
+| update-docs-on-release.yml | 20 | actions/checkout | v6 |
+
+## Notes
+
+- **full_release_cycle.yml is DEPRECATED**: its workflow only prints an "obsolete" notice. It is excluded from the inventory above and should be removed (see #1363).
+- **CodeQL**: the policy previously targeted `v4`; the actual pinned version in `security-advisory.yml` and `quality-gates.yml` is **v3.36.2** (`github/codeql-action/*@8272c...`).
+- `quality-gates.yml` no longer uses `github/codeql-action/upload-sarif` or `actions/upload-artifact`; those rows were removed.
 
 ## Standard Versions Table
 
@@ -103,15 +132,17 @@ Run before commits:
 ./scripts/verify-action-versions.sh
 ```
 
-## Current Discrepancies (2026-06-22)
+## Current Discrepancies (2026-08-11)
 
 1. i18n-validation.yml: checkout v4→v6, setup-python v5→v6
-2. quality-gates.yml: codeql v3→v4 (3 instances), upload-artifact v4→v7
+2. issue-metadata-validation.yml: checkout v4→v6, setup-python v5→v6
+3. quality-gates.yml + security-advisory.yml: CodeQL pinned at v3.36.2 (policy target v4)
+4. pr-check.yml / pr-ci-build-native-sbom.yml / pr-quality-suite.yml: `actions/upload-artifact` pinned at v4.6.2 (policy target v7)
 
-**Action Required**: Separate PR to remediate.
+**Action Required**: Separate PRs to remediate; tracked under #1363.
 
 ## References
 - Parent Issue: #838
 - This Policy: #862
 
-**Version**: 1.0 | **Updated**: 2026-06-22 | **Next Review**: 2026-07-01
+**Version**: 1.1 | **Updated**: 2026-08-11 | **Next Review**: 2026-10-01

--- a/docs/en/architecture/ADR-2025-09-07-persistence-service-centralized.md
+++ b/docs/en/architecture/ADR-2025-09-07-persistence-service-centralized.md
@@ -1,14 +1,14 @@
 # ADR 2025-09-07: centralized persistence
 
 ## Context
-Eventflow needs to climb multiple replicas and persist shared. Three options were evaluated: Sidecar, Centralized Service and Object Storage.
+homedir needs to climb multiple replicas and persist shared. Three options were evaluated: Sidecar, Centralized Service and Object Storage.
 
 ## Decision
 Adopt a ** centralized persistence service ** (solution b) in this phase.
 
 ## Consequences
 - ** Positive: ** Strong consistency and simpler operation.
-- ** Positive: ** Independent Scale of Eventflow.
+- ** Positive: ** Independent Scale of homedir.
 - ** Negative: ** Extra network latency.
 - ** Future: ** Planned Migration to Object Storage (S3/Minio).
 

--- a/docs/en/architecture/persistence-options.md
+++ b/docs/en/architecture/persistence-options.md
@@ -1,4 +1,4 @@
-# Persistence options - Eventflow
+# Persistence options - homedir
 
 ## Option A - Sidecar by Pod
 ### Pros
@@ -13,7 +13,7 @@
 ## Option B - Centralized Service
 ### Pros
 - Strong consistency and concurrence control.
-- Eventflow independent scale.
+- homedir independent scale.
 ### cons
 - Add a network latency.
 - Requires high availability.

--- a/docs/en/architecture/persistence-service.md
+++ b/docs/en/architecture/persistence-service.md
@@ -1,6 +1,6 @@
 # Centralized persistence service
 
-The implemented solution exposes an HTTP service dedicated to storing and recovering the state of Eventflow.
+The implemented solution exposes an HTTP service dedicated to storing and recovering the state of homedir.
 
 ## Endpoints
 - `Get /State /{key}`: obtains the state associated with `Key`.
@@ -18,4 +18,4 @@ Optimistic and pessimistic locks are offered. Customers can request an explicit 
 All mutations are recorded in a Wal. In case of failure, the service can reproduce tickets to restore the State. The Wal also serves as a source for replication.
 
 ## Events
-When the State changes, the service publishes an `state.updated` event. This allows other Eventflow components to react to the modification and maintain materialized caches or views.
+When the State changes, the service publishes an `state.updated` event. This allows other homedir components to react to the modification and maintain materialized caches or views.

--- a/docs/en/features/event-discovery-registration.md
+++ b/docs/en/features/event-discovery-registration.md
@@ -1,6 +1,6 @@
 # User history - "Explore and record talks at my pace"
 
-I am Javier. From my laptop I enter Eventflow and see the clues and talks available. I frame as favorites that interest me and my personal agenda is updated instantly.
+I am Javier. From my laptop I enter homedir and see the clues and talks available. I frame as favorites that interest me and my personal agenda is updated instantly.
 
 While I can filter by theme, schedule or speaker, and each talk has its card with description, room and a button to add or remove it from my list. On mobile view it adapts and I can reorganize my day with a thumb.
 

--- a/docs/en/features/google-sign-in.md
+++ b/docs/en/features/google-sign-in.md
@@ -1,6 +1,6 @@
 # User history - "Enter with my Google account in seconds"
 
-I am Mary. I arrive at the Eventflow site and instead of creating another password, I press "Continue with Google". Authorize and ready: I ​​am already inside with my name and photo.
+I am Mary. I arrive at the homedir site and instead of creating another password, I press "Continue with Google". Authorize and ready: I ​​am already inside with my name and photo.
 
 I can check my saved talks or create new ones without extra steps. If I close session, I know that next time a touch will suffice to return.
 

--- a/docs/en/features/metrics.md
+++ b/docs/en/features/metrics.md
@@ -3,7 +3,7 @@
 Homedir records interaction events and persists them asynchronously to provide insights via the Admin Dashboard.
 
 ## Overview
-- **Storage**: `data/metrics-v1.json` (Atomic writes, configurable flush interval).
+- **Storage**: `data/metrics-v2.json` (preferred; falls back to legacy `metrics-v1.json`). Atomic writes, configurable flush interval.
 - **Display**: Admin Dashboard (`/private/admin`).
 - **Privacy**: No PII in exports; aggregated data only.
 
@@ -88,5 +88,5 @@ The dashboard aggregates these events to show:
 ## Local Validation
 1. Run `mvn quarkus:dev`.
 2. Browse the site to generate events.
-3. Check `quarkus-app/data/metrics-v1.json`.
+3. Check `quarkus-app/data/metrics-v2.json`.
 4. View dashboard at `/private/admin`.

--- a/docs/en/features/supply-chain-security.md
+++ b/docs/en/features/supply-chain-security.md
@@ -1,6 +1,6 @@
 # User history - "end -to -end trust"
 
-I am Elena, in charge of Devops. Every time we publish a version, Eventflow generates Sboms and signs the images of the container. The pipeline scan an dependencies and alerts me if a vulnerability appears.
+I am Elena, in charge of Devops. Every time we publish a version, homedir generates Sboms and signs the images of the container. The pipeline scan an dependencies and alerts me if a vulnerability appears.
 
 From a panel I can see the reports and share them with external audits. I know exactly what bookstore we use and what version.
 

--- a/docs/en/product-user-experience.md
+++ b/docs/en/product-user-experience.md
@@ -1,6 +1,6 @@
-# User experience - Why is Eventflow for me?
+# User experience - Why is homedir for me?
 
-Eventflow helps me plan and enjoy events without friction. These stories show how each functionality is lived:
+homedir helps me plan and enjoy events without friction. These stories show how each functionality is lived:
 
 -[Explore and record talks at my pace] (features/event-discovery-registration.md)
 -[Enter with my Google account in seconds] (features/google-sign-in.md)

--- a/docs/es/features/metrics.md
+++ b/docs/es/features/metrics.md
@@ -3,7 +3,7 @@
 Homedir registra eventos de interacción y los persiste asincrónicamente para mostrar insights a través del Dashboard de Administración.
 
 ## Descripción General
-- **Almacenamiento**: `data/metrics-v1.json` (Escritura atómica, intervalo configurable).
+- **Almacenamiento**: `data/metrics-v2.json` (preferido; fallback al legacy `metrics-v1.json`). Escritura atómica, intervalo configurable.
 - **Visualización**: Panel de Administración (`/private/admin`).
 - **Privacidad**: Sin PII en exportaciones y vistas; datos agregados solamente.
 
@@ -88,5 +88,5 @@ El dashboard agrega estos eventos para mostrar:
 ## Validación Local
 1. Ejecuta `mvn quarkus:dev`.
 2. Navega el sitio para generar eventos.
-3. Revisa `quarkus-app/data/metrics-v1.json`.
+3. Revisa `quarkus-app/data/metrics-v2.json`.
 4. Ve al dashboard en `/private/admin`.

--- a/docs/es/modules/hackathon/README.md
+++ b/docs/es/modules/hackathon/README.md
@@ -1,5 +1,7 @@
 # Módulo Hackathon
 
+> **Status**: 📋 **Propuesta / roadmap**. No hay código implementado: no existe ruta `/hackathon`, ni `/private/hackathon`, ni el flag `feature.hackathon.enabled`. Lo único existente en el código es `EventType.HACKATHON` (modelo de datos). Este documento describe el diseño propuesto, no una implementación entregada.
+
 ## Propósito
 - Preparar funcionalidades enfocadas en hackatones sin añadir una base de datos nueva.
 - Reutilizar el motor de persistencia actual (JSON + `PersistenceService`) para eventos, speakers y agendas.
@@ -8,7 +10,7 @@
 ## Alcance inicial (MVP)
 - Plantillas y endpoints mínimos sobre el modelo actual para publicar agenda y resultados del hackatón.
 - Soporte de registro y seguimiento rápido (equipos/proyectos) usando el storage existente.
-- UI: mostrar badges de tipo Hackatón y permitir selección desde el panel Admin (ya habilitado en #62).
+- UI: mostrar badges de tipo Hackatón (propuesto; se apoyaría en `EventType.HACKATHON`).
 
 ## Enfoque técnico
 - Persistencia: misma carpeta `data/` y archivos JSON utilizados por `PersistenceService` (sin SQL ni migraciones).

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -2,12 +2,14 @@
 
 This directory contains security analysis and audit reports for the Quarkus application.
 
+> **Snapshot**: This endpoint authorization audit was generated on **2026-06-22** (issue #854). The repository has evolved since then (now 83 `*Resource.java` files / 337 `@Path` routes), so the raw counts below are historical. Findings that were remediated are noted inline.
+
 ## Issue #854 - Endpoint Authorization Audit
 
 ### Files
 
 1. **endpoint-authorization-matrix.yaml** - Complete authorization matrix
-   - 255 REST endpoints analyzed from 74 Resource.java files
+   - 255 REST endpoints analyzed from 74 Resource.java files *(snapshot, 2026-06-22)*
    - Includes route, HTTP method, security annotation, risk level, source file, and method name
    - Sorted by risk level (critical first)
    - Contains detailed statistics in YAML comments
@@ -31,17 +33,17 @@ This directory contains security analysis and audit reports for the Quarkus appl
 
 ### Key Findings
 
-- **5 Critical Issues**: Admin/private paths without security annotations
-  - `/api/internal/insights/events` (POST)
-  - `/api/internal/insights/initiatives/start` (POST)
-  - `/private/github/callback` (GET)
-  - `/private/github/connect` (GET)
-  - `/private/github/start` (GET)
+- **5 Critical Issues**: Admin/private paths without security annotations *(as of snapshot)*
+  - `/api/internal/insights/events` (POST) — **✅ remediated**: protected by feature flag `insights.ingest.enabled` (default `false` → 404) + required `X-Insights-Key` header
+  - `/api/internal/insights/initiatives/start` (POST) — **✅ remediated**: same protection as above
+  - `/private/github/callback` (GET) — review status
+  - `/private/github/connect` (GET) — review status
+  - `/private/github/start` (GET) — review status
 
 - **35 Endpoints with NONE**: No explicit security annotation
   - Requires review to add `@PermitAll`, `@Authenticated`, or `@RolesAllowed`
 
-- **Security Annotation Distribution**:
+- **Security Annotation Distribution** *(snapshot)*:
   - `@Authenticated`: 160 (62.7%)
   - `@PermitAll`: 50 (19.6%)
   - `NONE`: 35 (13.7%)
@@ -70,7 +72,7 @@ yq '.endpoints | group_by(.risk) | map({risk: .[0].risk, count: length})' docs/s
 
 ### Next Steps
 
-1. Review and fix the 5 critical issues immediately
+1. ✅ Review and fix the 5 critical issues — insights endpoints now protected (feature flag + key header); verify the remaining `/private/github/*` paths
 2. Add explicit security annotations to all 35 endpoints with NONE
 3. Verify OAuth callback security
 4. Consider implementing automated security annotation checks in CI/CD
@@ -80,3 +82,4 @@ yq '.endpoints | group_by(.risk) | map({risk: .[0].risk, count: length})' docs/s
 
 *Generated: 2026-06-22*
 *Issue: #854*
+*Snapshot status reviewed: 2026-08-11*

--- a/docs/security/dast-integration-spec.md
+++ b/docs/security/dast-integration-spec.md
@@ -3,6 +3,8 @@
 **Parent Issue:** [#838 - IA Governance](https://github.com/os-santiago/homedir/issues/838)  
 **Issue:** [#858 - DAST/Fuzzing Integration](https://github.com/os-santiago/homedir/issues/858)
 
+> **Status**: ⚠️ **DRAFT — NOT IMPLEMENTED.** The artifacts referenced in this spec do not exist in the repo (verified 2026-08-11): `.github/workflows/dast-scan.yml`, `docker-compose.test.yml`, `Dockerfile.test`, `.zap/`, and `docs/api/openapi.yaml` are all absent. The pinned action versions also contradict the current [action-versioning policy](../ci/action-versioning-policy.md). Treat this document as a design proposal to be re-validated if DAST is resumed.
+
 ## Executive Summary
 
 This specification defines the integration of Dynamic Application Security Testing (DAST) into the homedir CI/CD pipeline. It establishes a phased rollout strategy starting with passive scanning (advisory), progressing to active scanning (enforcing), and culminating in fuzzing-based testing for high-risk endpoints. The specification prioritizes endpoints based on the authorization matrix (issue #854) and input validation baseline (issue #857), with clear thresholds for blocking vs. advisory findings.

--- a/docs/security/endpoint-authorization-matrix.yaml
+++ b/docs/security/endpoint-authorization-matrix.yaml
@@ -54,7 +54,7 @@ endpoints:
   risk: DATOS_SENSIBLES
   source: quarkus-app/src/main/java/com/scanales/homedir/public_/GithubAuthResource.java
   method_name: callback
-- route: /auth/session/auth/session
+- route: /auth/session
   method: GET
   security: '@Authenticated'
   risk: DATOS_SENSIBLES

--- a/docs/security/endpoint-authorization-summary.md
+++ b/docs/security/endpoint-authorization-summary.md
@@ -60,7 +60,7 @@ These endpoints handle sensitive data (auth, tokens, credentials):
   - Security: `@PermitAll`
   - File: `quarkus-app/src/main/java/com/scanales/homedir/public_/GithubAuthResource.java`
 
-- **GET /auth/session/auth/session**
+- **GET /auth/session**
   - Security: `@Authenticated`
   - File: `quarkus-app/src/main/java/com/scanales/homedir/security/SessionResource.java`
 

--- a/modules/aexperience/README.md
+++ b/modules/aexperience/README.md
@@ -1,5 +1,7 @@
 # Módulo Experimental de Experiencia Aumentada (Homedir)
 
+> **Status**: 📋 **Propuesta / roadmap**. Este directorio contiene **solo documentación** — no hay código, feature flag (`feature.experimental.aexperience`), opción en UI ni soporte de build `--exclude aexperience` en el monorepo (verificado 2026-08-11). El contenido a continuación describe el diseño previsto, no una implementación entregada. El frontend (Navia) vive aparte en `os-santiago/navia-frontend`.
+
 ## Propósito
 
 El módulo de Experiencia Aumentada de Homedir es una iniciativa experimental orientada a explorar nuevas formas de interacción entre usuarios y plataformas en Homedir. Su objetivo es validar cómo la inteligencia artificial, la personalización dinámica y la navegación basada en intención pueden mejorar la experiencia digital sin comprometer la estabilidad del producto principal.
@@ -66,7 +68,7 @@ Componentes base:
 | Etapa | Descripción | Estado |
 | --- | --- | --- |
 | Exploración | Diseño conceptual, experimentación rápida | ✅ Activa |
-| Integración controlada | Integrado como módulo experimental (opt-in) | ⏳ Próxima fase |
+| Integración controlada | Integrado como módulo experimental (opt-in) | ⏳ Próxima fase (no implementado) |
 | Evaluación | Métricas de adopción, feedback y usabilidad | 📊 En planificación |
 | Promoción o retiro | Si aporta valor → feature estable; si no → se desconecta sin impacto | 🔁 Continuo |
 

--- a/platform/scripts/PIPELINE-ORCHESTRATOR.md
+++ b/platform/scripts/PIPELINE-ORCHESTRATOR.md
@@ -582,10 +582,10 @@ issues:
 
 Orchestrator is called automatically by worker:
 
-**File**: `platform/scripts/homedir-sdlc-worker.sh`
+**File**: `homedir-sdlc-worker.sh` (installed at `~/.local/bin/homedir-sdlc-worker.sh`; not part of this repo — see `platform/scripts/worker-health-check.sh` for the path)
 
 ```bash
-# After closing issue (line ~1470)
+# After closing issue (approx. L1942–1947 in the deployed worker script)
 gh issue close "${issue}" -R "${OWNER}/${REPO}" -c "${msg}"
 
 # Call pipeline orchestrator

--- a/platform/scripts/backup-system/INVENTORY.md
+++ b/platform/scripts/backup-system/INVENTORY.md
@@ -15,13 +15,13 @@
 | `homedir-persistent-backup.sh` | VPS `/usr/local/bin/` | Script legacy de backup servidor | ⚠️ Legacy |
 | `homedir-vps-backup-reference.ps1` | Reconstruido de logs | Script sincronización Windows→GDrive | ⚠️ Referencia |
 | `systemd/homedir-auto-deploy.service` | VPS `/etc/systemd/system/` | Auto-deploy desde GitHub | ✅ Activo |
-| `systemd/homedir-auto-deploy.timer` | VPS `/etc/systemd/system/` | Timer auto-deploy (cada 5min) | ✅ Activo |
+| `systemd/homedir-auto-deploy.timer` | VPS `/etc/systemd/system/` | Timer auto-deploy (cada 1min) | ✅ Activo |
 | `systemd/homedir-update.service` | VPS `/etc/systemd/system/` | Update container service | ✅ Activo |
-| `systemd/homedir-update.timer` | VPS `/etc/systemd/system/` | Update timer (diario) | ✅ Activo |
+| `systemd/homedir-update.timer` | VPS `/etc/systemd/system/` | Update timer (cada 5min) | ✅ Activo |
 | `systemd/homedir-webhook.service` | VPS `/etc/systemd/system/` | GitHub webhook listener | ✅ Activo |
 | `systemd/homedir-git-pull.service` | VPS `/etc/systemd/system/` | Git pull service | ⚠️ Dev only |
-| `systemd/homedir-git-pull.timer` | VPS `/etc/systemd/system/` | Git pull timer | ⚠️ Dev only |
-| `systemd/homedir-dev.service` | VPS `/etc/systemd/system/` | Dev environment service | ⚠️ Dev only |
+| `systemd/homedir-git-pull.timer` | VPS `/etc/systemd/system/` | Git pull timer (cada 1min) | ⚠️ Dev only |
+| `task-scheduler-backup.xml` | Creado | Config Task Scheduler Windows exportada | ✅ Activo |
 
 **Total:** 14 archivos versionados
 
@@ -128,7 +128,7 @@ Ver **`RESTORE-PLAYBOOK.md`**
   - Comparar con script de referencia
   - Versionar el real si se encuentra
 
-- [ ] **Exportar Task Scheduler config**
+- [x] **Exportar Task Scheduler config** ✅ (hecho — `task-scheduler-backup.xml` ya está versionado)
   ```powershell
   Export-ScheduledTask -TaskName "Homedir Production Backup" | Out-File platform/scripts/backup-system/task-scheduler-backup.xml
   ```

--- a/platform/scripts/backup-system/README.md
+++ b/platform/scripts/backup-system/README.md
@@ -18,7 +18,7 @@ Este directorio contiene todos los artefactos necesarios para restaurar el siste
 - Thread-safe: CAS-based locking
 - Auto-pruning: elimina backups antiguos automáticamente
 
-**Archivos protegidos (8 tipos):**
+**Archivos protegidos (9 tipos):**
 ```
 /work/data/backups/
 ├── events/              # 100 archivos × ~20 KB
@@ -148,7 +148,7 @@ ls -lh /work/data/backups/speakers/
 **Paso 1: Copiar script PowerShell**
 ```powershell
 Copy-Item platform/scripts/backup-system/homedir-vps-backup-reference.ps1 `
-    -Destination D:\git\homedir\backup-to-gdrive.ps1
+    -Destination D:\git\homedir\backup-to-gdrive-hybrid.ps1
 ```
 
 **Paso 2: Configurar Task Scheduler**
@@ -161,14 +161,14 @@ taskschd.msc
 # - Trigger: Diario, repetir cada 6 horas
 # - Action: 
 #   - Program: powershell.exe
-#   - Arguments: -NoProfile -ExecutionPolicy Bypass -File "D:\git\homedir\backup-to-gdrive.ps1"
+#   - Arguments: -NoProfile -ExecutionPolicy Bypass -File "D:\git\homedir\backup-to-gdrive-hybrid.ps1"
 # - Conditions: Desmarcar "Start only if on AC power"
 ```
 
 **Paso 3: Prueba manual**
 ```powershell
 cd D:\git\homedir
-.\backup-to-gdrive.ps1
+.\backup-to-gdrive-hybrid.ps1
 ```
 
 **Paso 4: Verificar en Google Drive**
@@ -312,7 +312,7 @@ if ($Age.TotalHours -gt 12) {
 
 **Solución:** Usar script de referencia incluido:
 ```powershell
-cp platform/scripts/backup-system/homedir-vps-backup-reference.ps1 backup-to-gdrive.ps1
+cp platform/scripts/backup-system/homedir-vps-backup-reference.ps1 backup-to-gdrive-hybrid.ps1
 ```
 
 ### "SSH connection failed" (Windows → VPS)

--- a/tools/discord-bot/README.md
+++ b/tools/discord-bot/README.md
@@ -13,18 +13,13 @@ A Discord bot designed to help manage community interactions and GitHub issue tr
 
 ## Discord Slash Commands
 
-### `/ayuda` - Help Command
-Displays comprehensive help information about available bot commands and features.
+### `/crear-issue` - Create Issue Command
+Creates a new GitHub issue in the configured repository.
 
 **Usage:**
 ```
-/ayuda
+/crear-issue <titulo> [descripcion] [labels]
 ```
-
-**Response:** Provides a formatted embed with:
-- List of available commands
-- Brief description of each command
-- How to use the bot effectively
 
 ### `/mis-issues` - My Issues Command
 Retrieves and displays GitHub issues assigned to or created by the user.
@@ -80,14 +75,13 @@ DISCORD_GUILD_ID=your_guild_id_here  # Optional, for guild-specific commands
 
 # GitHub Configuration
 GITHUB_TOKEN=your_github_personal_access_token
-GITHUB_REPO_OWNER=your_organization_or_username
-GITHUB_REPO_NAME=your_repository_name
+GITHUB_REPO=owner/repository  # e.g. os-santiago/homedir
 
-# Bot Configuration (Optional)
-BOT_PREFIX=!  # Fallback prefix for non-slash commands
+# Logging (Optional)
 LOG_LEVEL=INFO  # DEBUG, INFO, WARNING, ERROR, CRITICAL
-COMMAND_COOLDOWN=5  # Seconds between command uses per user
 ```
+
+> **Note**: Aligns with `.env.example`. There is no `GITHUB_REPO_OWNER`/`GITHUB_REPO_NAME` split nor a `BOT_PREFIX` fallback; GitHub is configured with the single `GITHUB_REPO` variable in `owner/repo` format.
 
 ### Step 4: Configure Discord Bot Permissions
 
@@ -176,7 +170,7 @@ To deploy commands to a specific guild (faster updates during development):
 ┌─────────────────┐
 │  Discord User   │
 └────────┬────────┘
-         │ /ayuda or /mis-issues
+         │ /crear-issue or /mis-issues
          ▼
 ┌─────────────────────────┐
 │   Discord.py Client     │
@@ -285,7 +279,7 @@ Key metrics to monitor:
 - [ ] Implement database for persistent storage (PostgreSQL)
 - [ ] Add health check endpoint
 - [ ] Enhance error messages with suggested actions
-- [ ] Add more slash commands (e.g., `/create-issue`, `/search-issues`)
+- [ ] Add more slash commands (e.g., `/search-issues`, `/ayuda` help command)
 
 #### Medium-term (3-6 months)
 - [ ] Multi-server support with isolated configurations
@@ -396,6 +390,6 @@ For support, please:
 
 ---
 
-**Version:** 1.0.0  
-**Last Updated:** 2026-06-18  
+**Version:** 1.0.1  
+**Last Updated:** 2026-08-11  
 **Maintainer:** HomeDir Team


### PR DESCRIPTION
PR 3 de 3 — parte 🟡 baja prioridad (features/seguridad). Refs #1363

## Cambios

### docs/security
- `README.md`: marcado como snapshot histórico (2026-06-22); endpoints de insights documentados como **protegidos** (feature flag `insights.ingest.enabled` default `false` + header `X-Insights-Key`); nota de conteos actuales (83 Resource / 337 @Path)
- `endpoint-authorization-summary.md` + `matrix.yaml`: ruta corregida `GET /auth/session/auth/session` → `GET /auth/session`
- `dast-integration-spec.md`: marcado **DRAFT / no implementado** (artefactos referenciados no existen)

### docs/ci
- `action-versioning-policy.md`: inventario **regenerado desde los workflows reales**; eliminado `full_release_cycle.yml` (deprecado); CodeQL corregido a **v3.36.2**; quality-gates sin `upload-sarif`/`upload-artifact`

### features / modules
- `metrics.md` (EN+ES): `metrics-v2.json` es el archivo preferido (fallback v1)
- `hackathon/README.md` (ES) y `aexperience/README.md`: marcados como **propuesta/roadmap** (no existe código, flag ni rutas)
- `tools/discord-bot/README.md`: eliminado comando inexistente `/ayuda`; env alineado con `.env.example` (`DISCORD_BOT_TOKEN`, `GITHUB_TOKEN`, `GITHUB_REPO`)

### platform
- `backup-system/INVENTORY.md`: eliminado `systemd/homedir-dev.service` fantasma; timers corregidos (auto-deploy 1min, update 5min); `task-scheduler-backup.xml` ya versionado (marcado hecho); total corregido
- `backup-system/README.md`: "8 tipos" → 9; nombre del script unificado a `backup-to-gdrive-hybrid.ps1`
- `PIPELINE-ORCHESTRATOR.md`: worker no vive en repo (instalado en `~/.local/bin`); referencia de línea corregida

### Renombre de marca
- `Eventflow` → `homedir` en 7 archivos de `docs/en` (solo texto de producto, sin afectar enlaces)

Refs #1363