### PR TITLE
docs: add PR template for standardized traceability

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,8 @@
 
 ## Linked Issue
 
-Closes #<!-- issue number -->
+<!-- Replace N with the issue number. -->
+Closes #N
 
 <!-- If this PR references but does not close an issue, use: Refs #N -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Summary
+
+<!-- Brief description of what this PR changes and why -->
+
+## Linked Issue
+
+Closes #<!-- issue number -->
+
+<!-- If this PR references but does not close an issue, use: Refs #N -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] Security fix
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Platform/infrastructure change
+
+## Test Plan
+
+- [ ] Code compiles (`./mvnw compile` or equivalent)
+- [ ] Unit tests pass (`./mvnw test`)
+- [ ] E2E tests pass (if applicable)
+- [ ] Manual verification performed
+- [ ] i18n keys updated (EN + ES) if user-facing text added
+
+## Breaking Changes
+
+<!-- Describe breaking changes here, or write "None" -->
+
+## Additional Notes
+
+<!-- Optional: screenshots, context, follow-up issues, etc. -->


### PR DESCRIPTION
## Summary

Add `.github/PULL_REQUEST_TEMPLATE.md` to standardize PR structure and enforce issue traceability. Currently 8 of the last 50 merged PRs have no issue reference and 18 closed issues have no linked PR — this template is the preventive fix.

## Linked Issue

Closes #1408

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Security fix
- [ ] Breaking change
- [ ] Platform/infrastructure change

## Test Plan

- [x] File created at `.github/PULL_REQUEST_TEMPLATE.md`
- [x] Template includes: Summary, Linked Issue (`Closes #N`), Type of Change, Test Plan, Breaking Changes, Additional Notes
- [x] Uses `Closes #N` syntax for automatic issue closure on merge
- [x] No AI watermarks

## Breaking Changes

None

## Additional Notes

Part of Epic #1409 (Autonomous Board Organization). The template will be enforced by CI in #1411 (PR traceability check workflow).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a pull request template with structured sections for summaries, issue references, change classification, testing, breaking changes, and additional notes.
  * Included checklists and guidance to support consistent, thorough pull request submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->