### PR TITLE
fix(i18n): replace placeholder trending_* keys with real EN/ES translations

### DIFF
--- a/quarkus-app/src/main/resources/i18n.properties
+++ b/quarkus-app/src/main/resources/i18n.properties
@@ -2684,16 +2684,17 @@ support_discord_banner_desc=Support Discord Banner Desc
 support_discord_banner_title=Support Discord Banner Title
 support_discord_footer_link=Support Discord Footer Link
 talk_label_duration=Talk Label Duration
-trending_error_loading=Trending Error Loading
-trending_heading=Trending Heading
+trending_error_loading=Unable to load trending repositories
+trending_heading=Trending Repositories
 trending_last_updated=Last updated {timestamp}
-trending_page_title=Trending Page Title
-trending_period_daily=Trending Period Daily
-trending_period_monthly=Trending Period Monthly
-trending_period_weekly=Trending Period Weekly
-trending_show_more=Trending Show More
+trending_page_title=GitHub Trending · Homedir
+trending_period_daily=Daily
+trending_period_monthly=Monthly
+trending_period_weekly=Weekly
+trending_show_less=Show less
+trending_show_more=Show more
 trending_stars={count} stars
-trending_visit_repo=Trending Visit Repo
+trending_visit_repo=Visit repository
 
 
 # Profile - Speaker Talks

--- a/quarkus-app/src/main/resources/i18n_en.properties
+++ b/quarkus-app/src/main/resources/i18n_en.properties
@@ -2684,16 +2684,17 @@ support_discord_banner_desc=Support Discord Banner Desc
 support_discord_banner_title=Support Discord Banner Title
 support_discord_footer_link=Support Discord Footer Link
 talk_label_duration=Talk Label Duration
-trending_error_loading=Trending Error Loading
-trending_heading=Trending Heading
+trending_error_loading=Unable to load trending repositories
+trending_heading=Trending Repositories
 trending_last_updated=Last updated {timestamp}
-trending_page_title=Trending Page Title
-trending_period_daily=Trending Period Daily
-trending_period_monthly=Trending Period Monthly
-trending_period_weekly=Trending Period Weekly
-trending_show_more=Trending Show More
+trending_page_title=GitHub Trending · Homedir
+trending_period_daily=Daily
+trending_period_monthly=Monthly
+trending_period_weekly=Weekly
+trending_show_less=Show less
+trending_show_more=Show more
 trending_stars={count} stars
-trending_visit_repo=Trending Visit Repo
+trending_visit_repo=Visit repository
 
 
 # Profile - Speaker Talks

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -2685,16 +2685,17 @@ support_discord_banner_desc=Support Discord Banner Desc
 support_discord_banner_title=Support Discord Banner Title
 support_discord_footer_link=Support Discord Footer Link
 talk_label_duration=Talk Label Duration
-trending_error_loading=Trending Error Loading
-trending_heading=Trending Heading
+trending_error_loading=No se pudieron cargar los repositorios en tendencia
+trending_heading=Repositorios en tendencia
 trending_last_updated=Última actualización {timestamp}
-trending_page_title=Trending Page Title
-trending_period_daily=Trending Period Daily
-trending_period_monthly=Trending Period Monthly
-trending_period_weekly=Trending Period Weekly
-trending_show_more=Trending Show More
+trending_page_title=Tendencias de GitHub · Homedir
+trending_period_daily=Diario
+trending_period_monthly=Mensual
+trending_period_weekly=Semanal
+trending_show_less=Mostrar menos
+trending_show_more=Mostrar más
 trending_stars={count} estrellas
-trending_visit_repo=Trending Visit Repo
+trending_visit_repo=Visitar repositorio
 
 # Profile - Speaker Talks
 profile_speaker_talks_title=Mis Charlas


### PR DESCRIPTION
## Summary
- Replace placeholder values (e.g. "Trending Page Title", "Trending Heading") with real English text in `i18n.properties` and `i18n_en.properties`
- Add Spanish translations for all `trending_*` keys in `i18n_es.properties` (previously English placeholders)
- Add missing `trending_show_less` key to all three bundles

The `/trending` page was rendering English text even when the locale was Spanish because the `trending_*` keys in the properties files contained placeholder values instead of real translations. The ES bundle had English text for most keys.

Closes #1281

#### Test plan
- [x] `./mvnw compile` passes
- [x] `./mvnw test -Dtest=TrendingResourceTest` passes (27 tests, 0 failures)
- [ ] With locale `es`, `/trending` shows "Repositorios en tendencia", "Diario/Semanal/Mensual", "Visitar repositorio", etc.
- [ ] With locale `en`, `/trending` shows "Trending Repositories", "Daily/Weekly/Monthly", "Visit repository", etc.

Generated with [Devin](https://devin.ai)