### PR TITLE
refactor(js): remove defensive HomeDirUtils fallbacks from page scripts

### DIFF
--- a/docs/en/features/notifications.md
+++ b/docs/en/features/notifications.md
@@ -52,4 +52,4 @@ The notification runtime is consolidated (single owner), with page-specific UIs 
 Rules:
 - The WebSocket connection, notification inbox state (`ef_global_notifs`), and unread counter (`ef_global_unread_count`) are owned by `core-bundle.js`.
 - Page scripts must not re-open their own WebSocket; they consume notifications via `HomeDirNotifications` or `window.__EF_GLOBAL_NOTIF_ACCEPT__`.
-- HTML escaping belongs in `js/utils.js` (`HomeDirUtils.escapeHtml`); page scripts keep a defensive fallback only.
+- HTML escaping belongs in `js/utils.js` (`HomeDirUtils.escapeHtml`); page scripts reference `window.HomeDirUtils.*` directly — `utils.js` is a hard dependency loaded in the layout `<head>` before any page script, so defensive fallbacks are not needed.

--- a/quarkus-app/src/main/resources/META-INF/resources/js/community-bundle.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/community-bundle.js
@@ -68,23 +68,7 @@
     if (value == null) {
       return "";
     }
-    if (window.HomeDirUtils && window.HomeDirUtils.escapeHtml) {
-      return window.HomeDirUtils.escapeHtml(value);
-    }
-    return String(value).replace(/[&<>"']/g, (match) => {
-      switch (match) {
-        case "&":
-          return "&amp;";
-        case "<":
-          return "&lt;";
-        case ">":
-          return "&gt;";
-        case "\"":
-          return "&quot;";
-        default:
-          return "&#39;";
-      }
-    });
+    return window.HomeDirUtils.escapeHtml(value);
   }
 
   function showFeedback(message, isError) {

--- a/quarkus-app/src/main/resources/META-INF/resources/js/home-lightning.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/home-lightning.js
@@ -68,20 +68,7 @@
     if (value == null) {
       return "";
     }
-    return String(value).replace(/[&<>"']/g, (match) => {
-      switch (match) {
-        case "&":
-          return "&amp;";
-        case "<":
-          return "&lt;";
-        case ">":
-          return "&gt;";
-        case "\"":
-          return "&quot;";
-        default:
-          return "&#39;";
-      }
-    });
+    return window.HomeDirUtils.escapeHtml(value);
   }
 
   function showFeedback(message, isError) {

--- a/quarkus-app/src/main/resources/META-INF/resources/js/home-lta-preview.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/home-lta-preview.js
@@ -15,20 +15,7 @@
     if (value == null) {
       return "";
     }
-    return String(value).replace(/[&<>"']/g, (match) => {
-      switch (match) {
-        case "&":
-          return "&amp;";
-        case "<":
-          return "&lt;";
-        case ">":
-          return "&gt;";
-        case "\"":
-          return "&quot;";
-        default:
-          return "&#39;";
-      }
-    });
+    return window.HomeDirUtils.escapeHtml(value);
   }
 
   const formatDate = (raw) => window.HomeDirUtils.formatDate(raw, 'short');


### PR DESCRIPTION
## Summary
- Removed inline `escapeText` fallback implementations from 3 page scripts that duplicated `HomeDirUtils.escapeHtml` logic:
  - `community-bundle.js` — had `if (window.HomeDirUtils && ...)` guard with full inline fallback
  - `home-lightning.js` — had inline `escapeText` reimplementing escapeHtml (already used `HomeDirUtils.formatDate` directly)
  - `home-lta-preview.js` — same inline `escapeText` pattern (already used `HomeDirUtils.formatDate` directly)
- All three now call `window.HomeDirUtils.escapeHtml(value)` directly
- Updated `docs/en/features/notifications.md` to document that `utils.js` is a hard layout dependency and defensive fallbacks are not needed

`utils.js` is loaded in `<head>` with `defer` before any page script. If it fails to load, the entire page is broken — not just escaping. The fallbacks were dead code giving a false sense of resilience.

Closes #1380

#### Test plan
- [x] `node --check` passes for all 3 modified JS files
- [x] `node --test tests/js/utils-format-date.test.js` passes (8/8)
- [ ] Pre-existing `dom-injection-xss.test.js` failure is unrelated (fails on clean `main` too)
- [ ] Manual: verify `/comunidad/picks`, `/comunidad/lightning`, and home page LTA preview render correctly

Generated with [Devin](https://devin.ai)