### PR TITLE
docs(agents): fix multi-issue auto-close syntax in PR guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,10 @@ These labels track the automated AI SDLC workflow state:
 
 **When creating PRs:**
 1. **Always** reference the issue: `Closes #XXX` or `Refs #XXX`
+   - **IMPORTANT**: When closing multiple issues, repeat the keyword per issue:
+     `Closes #10` on one line, `Closes #11` on the next. Do NOT use `Closes #10, #11`
+     — GitHub only auto-closes the first issue in a comma-separated list without
+     repeated keywords. This caused 9 issues to stay open after their PRs merged.
 2. Add `wip-pr` if still working on it (draft PR)
 3. Do NOT add `scc-*` labels - these are managed by automation
 4. Let CI and human reviewers add other labels as needed


### PR DESCRIPTION
## Summary
- Documented that GitHub only auto-closes the **first** issue in a `Closes #N, #M` comma-separated list
- Correct syntax: repeat `Closes` keyword per issue on separate lines (`Closes #10` / `Closes #11`)
- This caused 9 issues to stay open after their PRs merged (fixed manually today)

## Root cause
Investigation of 6 issues assigned to @Axel-DaMage that were fixed by merged PRs but never auto-closed revealed that all PRs used the format `Closes #N, #M` (comma-separated without repeating the keyword). GitHub's auto-close parser only processes the first issue number after the keyword — subsequent numbers without their own `Closes` prefix are ignored.

| PR | Syntax | First issue | Remaining issues |
|----|--------|-------------|-----------------|
| #1352 | `Closes #1285, #1286` | #1285 closed | #1286 stayed open |
| #1355 | `Closes #1298, #1301, #1309` | #1298 closed | #1301, #1309 stayed open |
| #1353 | `Closes #1287, #1279, #1290` | #1287 closed | #1279, #1290 stayed open |
| #1354 | `Closes #1288, #1289, #1292, #1304` | #1288 closed | #1289, #1292, #1304 stayed open |
| #1350 | `Closes #1300, #1295` | #1300 closed | #1295 stayed open |

Closes #1431

#### Test plan
- [x] AGENTS.md updated with correct syntax guidance
- [ ] Future PRs use `Closes #N` per line for multiple issues

Generated with [Devin](https://devin.ai)