### PR TITLE
feat(dev): add containerized local development workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,31 @@ For local auth in dev mode, you can use:
 - `user@example.com / userpass`
 - `admin@example.org / adminpass`
 
-### 2) Run using public Quay images
+### 2) Run in a container (no JDK required)
+If you prefer not to install JDK 21 and Maven on your machine, `scripts/dev-container.sh`
+runs the same developer mode inside a disposable container. Edit files with your usual
+editor on the host; Quarkus live reload picks the changes up.
+
+Prerequisites:
+- Docker (or Podman with a `docker` alias)
+
+```bash
+scripts/dev-container.sh              # dev mode with live reload on http://localhost:8080
+scripts/dev-container.sh test         # run the test suite
+scripts/dev-container.sh clean package
+```
+
+The dependency cache is kept in `.tmp/m2` inside the repository (git-ignored) rather than
+in `~/.m2`, so nothing is written outside the project. To remove every trace:
+
+```bash
+rm -rf .tmp/m2 .tmp/maven-home quarkus-app/target
+docker rmi maven:3.9-eclipse-temurin-21
+```
+
+Override the image or port with `DEV_CONTAINER_IMAGE` and `DEV_CONTAINER_PORT`.
+
+### 3) Run using public Quay images
 Public image repository:
 - `quay.io/sergio_canales_e/homedir`
 
@@ -79,7 +103,7 @@ docker run --rm --name homedir \
   quay.io/sergio_canales_e/homedir:3.360.1
 ```
 
-### 3) Build your own image from source
+### 4) Build your own image from source
 Build a JVM image with the project Dockerfile:
 
 ```bash

--- a/scripts/dev-container.sh
+++ b/scripts/dev-container.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Run Maven/Quarkus inside a disposable container, so contributors do not need
+# JDK 21 or Maven installed on the host.
+#
+#   scripts/dev-container.sh                 # quarkus:dev with live reload on :8080
+#   scripts/dev-container.sh test            # run the test suite
+#   scripts/dev-container.sh clean package   # any other Maven goal
+#
+# The dependency cache lives in .tmp/m2 (git-ignored) instead of ~/.m2, so the
+# workflow leaves nothing outside the repository. To remove every trace:
+#
+#   rm -rf .tmp/m2 .tmp/maven-home quarkus-app/target
+#   docker rmi maven:3.9-eclipse-temurin-21
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+M2_DIR="$REPO_ROOT/.tmp/m2"
+# Container HOME must be writable, otherwise jgit fails to save its config.
+HOME_DIR="$REPO_ROOT/.tmp/maven-home"
+IMAGE="${DEV_CONTAINER_IMAGE:-maven:3.9-eclipse-temurin-21}"
+PORT="${DEV_CONTAINER_PORT:-8080}"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "ERROR: docker not found. Install Docker, or use podman with an alias." >&2
+    exit 1
+fi
+
+mkdir -p "$M2_DIR" "$HOME_DIR"
+
+# Only dev mode claims the container name and publishes the port, so goals like
+# `test` can still be run while dev mode is up.
+SERVE_FLAGS=()
+if [ "$#" -eq 0 ]; then
+    # Bind to 0.0.0.0 so the port is reachable from outside the container.
+    set -- quarkus:dev -Dquarkus.http.host=0.0.0.0
+    SERVE_FLAGS=(--name homedir-dev -p "$PORT":8080)
+fi
+
+# Allocate a TTY only when there is one, so the script also works in CI.
+TTY_FLAGS=(-i)
+[ -t 0 ] && TTY_FLAGS+=(-t)
+
+exec docker run --rm "${TTY_FLAGS[@]}" "${SERVE_FLAGS[@]}" \
+    -u "$(id -u):$(id -g)" \
+    -v "$REPO_ROOT":/project \
+    -v "$HOME_DIR":/var/maven \
+    -v "$M2_DIR":/var/maven/.m2 \
+    -w /project/quarkus-app \
+    -e MAVEN_CONFIG=/var/maven/.m2 \
+    "$IMAGE" \
+    mvn -Duser.home=/var/maven "$@"


### PR DESCRIPTION
## Summary

Adds `scripts/dev-container.sh`, so contributors can run Quarkus developer mode with live reload **without installing JDK 21 or Maven on the host**. Purely additive — the existing JDK/Maven instructions are untouched.

The existing container assets do not cover local development:

| Asset | Why it does not fit |
|---|---|
| `quarkus-app/src/main/docker/Dockerfile.*` | Build production images (JVM/native) — no live reload |
| `container/` | Podman pod deployment of the SDLC worker, not app development |
| Public Quay image | Runs a released build, cannot test local changes |

The `dev` profile has no external dependencies (`%dev.quarkus.devservices.enabled=false`, `%dev.quarkus.oidc.enabled=false`, embedded users), so a single disposable container is enough — no database, no companion services.

### Design notes

- Runs as the invoking user (`-u "$(id -u):$(id -g)"`), so `quarkus-app/target/` is not root-owned on the host.
- Dependency cache lives in `.tmp/m2` (already git-ignored) instead of `~/.m2`, so the workflow writes nothing outside the repository.
- Container `HOME` is a writable bind mount — mounting only `.m2` leaves `$HOME` root-owned and jgit then fails with `[ERROR] Cannot save config file '.../jgit/config'` on every startup.
- Only the default dev-mode invocation claims the container name and publishes the port, so `scripts/dev-container.sh test` works while dev mode is already running.
- The `-t` flag is conditional, so the script is usable from non-interactive contexts.
- `DEV_CONTAINER_IMAGE` and `DEV_CONTAINER_PORT` override the defaults.

## Linked Issue

Closes #1433

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Security fix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Platform/infrastructure change

## Test Plan

- [x] Manual verification performed — full acceptance run on Linux, Docker 29.7.2, **no JDK or Maven on the host**
- [ ] Code compiles / unit tests pass (not applicable — no application code changed)
- [ ] E2E tests pass (not applicable)
- [ ] i18n keys updated (not applicable — no user-facing text)

Every acceptance criterion from #1433, verified:

| Criterion | Result |
|---|---|
| Dev mode starts, HTTP 200, no host JDK | `started in 3.554s`, `status=200` |
| Live reload on host edit | added a `@Path` endpoint → `Live reload total time: 1.459s`, no restart |
| Arbitrary Maven goals | `help:evaluate -Dexpression=project.version` → `3.403.1`, run **while dev mode was up** |
| Build output not root-owned | `quarkus-app/target` → `pangolin:pangolin` |
| Nothing written outside the repo | `~/.m2`, `~/.quarkus` → not created |
| `git status` clean during use | empty |
| No `ERROR` lines at startup | 0 |
| Works without a TTY | yes — the entire verification ran non-interactively |

## Breaking Changes

None. New script plus a README section; no existing file behaviour changes.

## Additional Notes

Open question for maintainers: would you also like a `.devcontainer/devcontainer.json` for VS Code? The shell script was chosen as the primary approach because it is editor-agnostic and needs no extension, but the two are complementary and I am happy to add it.

The README section was inserted as "2) Run in a container (no JDK required)", which renumbers the two sections that followed. No cross-references to those numbers exist elsewhere in the docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a development container script for running Maven and Quarkus tasks in an isolated Docker environment.
  * Supports Quarkus dev mode with live reload, configurable container images and ports, local dependency caching, and host-user execution.
  * Automatically validates Docker availability and adapts terminal support when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->