### PR TITLE
fix(ui): center instructional sections in Reputation Hub (Closes #1448)

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/reputation-hub.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/reputation-hub.css
@@ -61,6 +61,37 @@
   font-size: 0.84rem;
 }
 
+.hub-instructional-panel h2,
+.hub-instructional-panel .hub-panel-intro,
+.hub-instructional-panel .hub-recognition-hint,
+.hub-instructional-panel .hub-empty {
+  text-align: center;
+}
+
+.hub-instructional-panel .hub-how-list {
+  justify-items: center;
+}
+
+.hub-instructional-panel .hub-how-list li {
+  display: grid;
+  gap: 0.35rem;
+  justify-items: center;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.26);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+}
+
+.hub-instructional-panel .hub-how-list strong,
+.hub-instructional-panel .hub-how-list p {
+  text-align: center;
+}
+
+.hub-instructional-panel .hub-recognition-item {
+  text-align: left;
+}
+
 .hub-migration-banner {
   max-width: 1200px;
   margin: 0 2rem 1rem;

--- a/quarkus-app/src/main/resources/templates/ReputationHubResource/hub.html
+++ b/quarkus-app/src/main/resources/templates/ReputationHubResource/hub.html
@@ -224,7 +224,7 @@
       </div>
 
       <div class="hub-secondary-grid">
-        <article class="hub-panel">
+        <article class="hub-panel hub-instructional-panel">
           <h2>{#if resolvedLocaleCode == 'es'}Cómo crecer desde aquí{#else}How to grow from here{/if}</h2>
           <p class="hub-panel-intro">
             {#if hub.viewerGuidance??}
@@ -336,7 +336,7 @@
           </ul>
         </article>
 
-        <article class="hub-panel">
+        <article class="hub-panel hub-instructional-panel">
           <h2>{i18n:reputation_hub_recognized_title}</h2>
           {#if !userAuthenticated}
             <p class="hub-recognition-hint">{i18n:reputation_hub_recognize_signin_hint}</p>
@@ -406,7 +406,7 @@
           </ul>
         </article>
 
-        <article class="hub-panel">
+        <article class="hub-panel hub-instructional-panel">
           <h2><a class="hub-how-link" href="/comunidad/reputation-hub/how">{i18n:reputation_hub_how_title}</a></h2>
           <ul class="hub-how-list">
             <li>


### PR DESCRIPTION
## Summary

The instructional sections at the bottom of the Reputation Hub page ("How to grow from here", "Recognized contributions" and "How reputation works") had centering and visual rhythm issues compared to the leaderboard sections above.

- Adds the `hub-instructional-panel` modifier class to the three bottom panels of `hub.html`
- Centers titles, intros, the sign-in notice and the empty state messages
- Styles the `.hub-how-list` blocks as centered cards, reusing the background, border and radius of leaderboard items to keep visual cohesion
- Recognition items (`.hub-recognition-item`) keep their internal left alignment
- All styles are scoped to `hub-instructional-panel`, so the `/comunidad/reputation-hub/how` page is not affected

Closes #1448

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New functionality
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Security fix
- [ ] Breaking change
- [ ] Platform/infrastructure change

## Test Plan

- [x] Compiles (equivalent to `./mvnw compile`)
- [x] Unit tests pass (`./mvnw test -Dtest=ReputationHubResourceTest,ReputationHubEmptyCategoryVisibilityTest,ReputationHubMigrationBannerTest` — 8 tests, 0 failures)
- [ ] Manual verification: visit `/comunidad/reputation-hub` and check that the three sections are centered with consistent spacing
- [ ] Manual verification: centering works in both `es` and `en` locales
- [x] No new i18n keys (change is CSS and template classes only)