### PR TITLE
feat(trending): full EN+ES i18n, localized descriptions and new filters/metrics (#1284)

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
@@ -6758,6 +6758,45 @@ public interface AppMessages {
   @Message("Visit repository")
   String trending_visit_repo();
 
+  @Message("Trending period selector")
+  String trending_period_selector_aria();
+
+  @Message("Language")
+  String trending_filter_language();
+
+  @Message("All languages")
+  String trending_filter_language_all();
+
+  @Message("Minimum stars")
+  String trending_filter_min_stars();
+
+  @Message("Any amount")
+  String trending_filter_min_any();
+
+  @Message("Search")
+  String trending_filter_search();
+
+  @Message("Search by name or owner…")
+  String trending_filter_search_placeholder();
+
+  @Message("Apply")
+  String trending_filter_apply();
+
+  @Message("Retry")
+  String trending_retry();
+
+  @Message("No repositories match the current filters.")
+  String trending_no_results();
+
+  @Message("{count} stars today")
+  String trending_stars_today(int count);
+
+  @Message("{count} forks")
+  String trending_forks(int count);
+
+  @Message("{count} contributors")
+  String trending_contributors(int count);
+
   @Message("Support")
   String footer_support();
 

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/ApiTrendingResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/ApiTrendingResource.java
@@ -19,7 +19,11 @@ public class ApiTrendingResource {
   public TemplateInstance index(
       @QueryParam("period") String periodParam,
       @QueryParam("count") Integer countParam,
+      @QueryParam("lang") String langParam,
+      @QueryParam("minStars") Integer minStarsParam,
+      @QueryParam("q") String queryParam,
       @CookieParam("QP_LOCALE") String localeCookie) {
-    return delegate.index(periodParam, countParam, localeCookie);
+    return delegate.index(
+        periodParam, countParam, langParam, minStarsParam, queryParam, localeCookie);
   }
 }

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/TrendingResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/TrendingResource.java
@@ -60,7 +60,8 @@ public class TrendingResource {
     Integer minStars = normalizeMinStars(minStarsParam);
 
     List<TrendingRepo> repos = trendingService.getTrending(period, count);
-    List<TrendingRepo> filtered = trendingService.filterRepos(repos, langParam, minStars, queryParam);
+    List<TrendingRepo> filtered =
+        trendingService.filterRepos(repos, langParam, minStars, queryParam);
     List<String> languages = trendingService.extractLanguages(repos);
 
     String lastUpdated = formatLastUpdated(repos);

--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/TrendingResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/TrendingResource.java
@@ -34,7 +34,14 @@ public class TrendingResource {
   @CheckedTemplate
   static class Templates {
     static native TemplateInstance index(
-        List<TrendingRepo> repos, String period, int count, String lastUpdated);
+        List<TrendingRepo> repos,
+        String period,
+        int count,
+        String lastUpdated,
+        List<String> languages,
+        String selectedLanguage,
+        Integer minStars,
+        String query);
   }
 
   @GET
@@ -43,25 +50,47 @@ public class TrendingResource {
   public TemplateInstance index(
       @QueryParam("period") String periodParam,
       @QueryParam("count") Integer countParam,
+      @QueryParam("lang") String langParam,
+      @QueryParam("minStars") Integer minStarsParam,
+      @QueryParam("q") String queryParam,
       @jakarta.ws.rs.CookieParam("QP_LOCALE") String localeCookie) {
 
     TrendingPeriod period = TrendingPeriod.fromString(periodParam);
     int count = normalizeCount(countParam);
+    Integer minStars = normalizeMinStars(minStarsParam);
 
     List<TrendingRepo> repos = trendingService.getTrending(period, count);
+    List<TrendingRepo> filtered = trendingService.filterRepos(repos, langParam, minStars, queryParam);
+    List<String> languages = trendingService.extractLanguages(repos);
 
     String lastUpdated = formatLastUpdated(repos);
 
     boolean authenticated = isAuthenticated();
     String name = currentUserName();
 
-    TemplateInstance template = Templates.index(repos, period.toGithubPath(), count, lastUpdated);
+    TemplateInstance template =
+        Templates.index(
+            filtered,
+            period.toGithubPath(),
+            count,
+            lastUpdated,
+            languages,
+            langParam,
+            minStars,
+            queryParam);
 
     return TemplateLocaleUtil.apply(template, localeCookie)
         .data("activePage", "trending")
         .data("userAuthenticated", authenticated)
         .data("userName", name)
         .data("userInitial", initialFrom(name));
+  }
+
+  private Integer normalizeMinStars(Integer minStars) {
+    if (minStars == null || minStars < 0) {
+      return null;
+    }
+    return minStars;
   }
 
   private int normalizeCount(Integer count) {

--- a/quarkus-app/src/main/java/com/scanales/homedir/trending/TrendingDescriptionCatalog.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/trending/TrendingDescriptionCatalog.java
@@ -1,0 +1,84 @@
+package com.scanales.homedir.trending;
+
+import java.util.Map;
+
+/**
+ * Curated Spanish descriptions for well-known trending repositories. Keys are {@code owner/name}
+ * (lowercase). Falls back to the original description when a repo is not present.
+ */
+public final class TrendingDescriptionCatalog {
+
+  private static final Map<String, String> ES_DESCRIPTIONS =
+      Map.ofEntries(
+          Map.entry(
+              "facebook/react",
+              "Biblioteca declarativa, eficiente y flexible de JavaScript para construir interfaces de usuario."),
+          Map.entry(
+              "astral-sh/ruff",
+              "Linter y formateador de Python extremadamente rápido, escrito en Rust."),
+          Map.entry(
+              "langchain-ai/langchain",
+              "Construcción de aplicaciones con LLMs mediante composición."),
+          Map.entry("vhdl/hdl-lang", "Un lenguaje de descripción de hardware."),
+          Map.entry(
+              "sindresorhus/awesome",
+              "Listas increíbles sobre todo lo relacionado con el software."),
+          Map.entry(
+              "freeCodeCamp/freeCodeCamp",
+              "freeCodeCamp.org es un proyecto de código abierto y sin fines de lucro que te ayuda a aprender a programar."),
+          Map.entry(
+              "vuejs/core",
+              "Vue.js es un framework progresivo de JavaScript para construir interfaces de usuario."),
+          Map.entry(
+              "facebook/create-react-app",
+              "Configuración de aplicaciones React modernas sin configuración de compilación."),
+          Map.entry(
+              "twbs/bootstrap",
+              "El framework CSS más popular para desarrollar sitios y aplicaciones web responsivos."),
+          Map.entry(
+              "microsoft/vscode",
+              "Editor de código fuente optimizado para crear aplicaciones web modernas."),
+          Map.entry(
+              "flutter/flutter",
+              "Kit de herramientas de UI de Google para crear aplicaciones nativas hermosas y compiladas."),
+          Map.entry(
+              "tensorflow/tensorflow",
+              "Una plataforma de aprendizaje automático de código abierto de extremo a extremo."),
+          Map.entry(
+              "pytorch/pytorch",
+              "Tensores y redes neuronales dinámicas en Python con una fuerte aceleración por GPU."),
+          Map.entry(
+              "kubernetes/kubernetes",
+              "Sistema de orquestación de contenedores de código abierto para automatizar el despliegue, escalado y gestión."),
+          Map.entry(
+              "openai/whisper",
+              "Modelo de reconocimiento de voz robusto para transcripción y traducción multilingüe."),
+          Map.entry(
+              "microsoft/terminal",
+              "El nuevo terminal de Windows, una experiencia moderna y rápida para el símbolo del sistema."),
+          Map.entry(
+              "n8n-io/n8n",
+              "Automatización de flujos de trabajo con interfaz visual y extensibilidad ilimitada."),
+          Map.entry(
+              "github/docs",
+              "El repositorio público de la documentación de GitHub, que colabora con la comunidad."),
+          Map.entry(
+              "vercel/next.js",
+              "Framework de React para la web, con renderizado del lado del servidor y generación estática."),
+          Map.entry(
+              "facebook/jest",
+              "Framework de pruebas de JavaScript con enfoque en la simplicidad."),
+          Map.entry(
+              "npm/cli",
+              "La CLI de npm, el administrador de paquetes de JavaScript más grande del mundo."));
+
+  private TrendingDescriptionCatalog() {}
+
+  /** Returns the curated Spanish description for owner/name, or null if not present. */
+  public static String get(String owner, String name) {
+    if (owner == null || name == null) {
+      return null;
+    }
+    return ES_DESCRIPTIONS.get((owner + "/" + name).toLowerCase());
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/homedir/trending/TrendingDescriptionCatalog.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/trending/TrendingDescriptionCatalog.java
@@ -66,8 +66,7 @@ public final class TrendingDescriptionCatalog {
               "vercel/next.js",
               "Framework de React para la web, con renderizado del lado del servidor y generación estática."),
           Map.entry(
-              "facebook/jest",
-              "Framework de pruebas de JavaScript con enfoque en la simplicidad."),
+              "facebook/jest", "Framework de pruebas de JavaScript con enfoque en la simplicidad."),
           Map.entry(
               "npm/cli",
               "La CLI de npm, el administrador de paquetes de JavaScript más grande del mundo."));

--- a/quarkus-app/src/main/java/com/scanales/homedir/trending/TrendingRepo.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/trending/TrendingRepo.java
@@ -5,12 +5,49 @@ public record TrendingRepo(
     String owner,
     String description,
     int stars,
+    int starsToday,
+    int forks,
+    int contributors,
     String language,
     String url,
     String descriptionEs) {
 
   public TrendingRepo(
       String name, String owner, String description, int stars, String language, String url) {
-    this(name, owner, description, stars, language, url, null);
+    this(name, owner, description, stars, 0, 0, 0, language, url, null);
+  }
+
+  public TrendingRepo(
+      String name,
+      String owner,
+      String description,
+      int stars,
+      String language,
+      String url,
+      String descriptionEs) {
+    this(name, owner, description, stars, 0, 0, 0, language, url, descriptionEs);
+  }
+
+  public TrendingRepo(
+      String name,
+      String owner,
+      String description,
+      int stars,
+      int starsToday,
+      int forks,
+      int contributors,
+      String language,
+      String url,
+      String descriptionEs) {
+    this.name = name;
+    this.owner = owner;
+    this.description = description;
+    this.stars = stars;
+    this.starsToday = starsToday;
+    this.forks = forks;
+    this.contributors = contributors;
+    this.language = language;
+    this.url = url;
+    this.descriptionEs = descriptionEs;
   }
 }

--- a/quarkus-app/src/main/java/com/scanales/homedir/trending/TrendingService.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/trending/TrendingService.java
@@ -32,7 +32,7 @@ public class TrendingService {
   @ConfigProperty(name = "trending.request-timeout", defaultValue = "PT15S")
   Duration requestTimeout;
 
-  @ConfigProperty(name = "trending.cache-ttl", defaultValue = "PT48H")
+  @ConfigProperty(name = "trending.cache-ttl", defaultValue = "PT6H")
   Duration cacheTtl;
 
   @ConfigProperty(name = "trending.default-count", defaultValue = "10")
@@ -67,6 +67,20 @@ public class TrendingService {
   private static final Pattern STARS_PATTERN =
       Pattern.compile(
           "([\\d,]+)\\s*stars\\s+(?:today|this\\s+week|this\\s+month)", Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern STARS_TODAY_PATTERN =
+      Pattern.compile(
+          "([\\d,]+)\\s*</a>\\s*(?:</div>\\s*)?<span[^>]*>\\s*stars\\s+today",
+          Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern FORKS_PATTERN =
+      Pattern.compile(
+          "([\\d,]+)\\s*</a>\\s*(?:</div>\\s*)?<span[^>]*>\\s*forks", Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern CONTRIBUTORS_PATTERN =
+      Pattern.compile(
+          "([\\d,]+)\\s*</a>\\s*(?:</div>\\s*)?<span[^>]*>\\s*contributors",
+          Pattern.CASE_INSENSITIVE);
 
   private static final Pattern LANGUAGE_PATTERN =
       Pattern.compile(
@@ -244,6 +258,36 @@ public class TrendingService {
         }
       }
 
+      int starsToday = 0;
+      Matcher starsTodayMatcher = STARS_TODAY_PATTERN.matcher(article);
+      if (starsTodayMatcher.find()) {
+        String starsTodayStr = starsTodayMatcher.group(1).replace(",", "");
+        try {
+          starsToday = Integer.parseInt(starsTodayStr);
+        } catch (NumberFormatException ignored) {
+        }
+      }
+
+      int forks = 0;
+      Matcher forksMatcher = FORKS_PATTERN.matcher(article);
+      if (forksMatcher.find()) {
+        String forksStr = forksMatcher.group(1).replace(",", "");
+        try {
+          forks = Integer.parseInt(forksStr);
+        } catch (NumberFormatException ignored) {
+        }
+      }
+
+      int contributors = 0;
+      Matcher contributorsMatcher = CONTRIBUTORS_PATTERN.matcher(article);
+      if (contributorsMatcher.find()) {
+        String contributorsStr = contributorsMatcher.group(1).replace(",", "");
+        try {
+          contributors = Integer.parseInt(contributorsStr);
+        } catch (NumberFormatException ignored) {
+        }
+      }
+
       String language = "";
       Matcher langMatcher = LANGUAGE_PATTERN.matcher(article);
       if (langMatcher.find()) {
@@ -252,10 +296,51 @@ public class TrendingService {
 
       String url = "https://github.com/" + owner + "/" + name;
 
-      repos.add(new TrendingRepo(name, owner, description, stars, language, url));
+      String descriptionEs = TrendingDescriptionCatalog.get(owner, name);
+
+      repos.add(
+          new TrendingRepo(
+              name, owner, description, stars, starsToday, forks, contributors, language, url,
+              descriptionEs));
     }
 
     return repos;
+  }
+
+  /** Filters a list of repos by language, minimum stars and free-text search. */
+  public List<TrendingRepo> filterRepos(
+      List<TrendingRepo> repos, String language, Integer minStars, String query) {
+    if (repos == null || repos.isEmpty()) {
+      return repos;
+    }
+    return repos.stream()
+        .filter(r -> language == null || language.isBlank() || language.equalsIgnoreCase(r.language()))
+        .filter(r -> minStars == null || r.stars() >= minStars)
+        .filter(
+            r ->
+                query == null
+                    || query.isBlank()
+                    || matchesQuery(r, query.trim()))
+        .toList();
+  }
+
+  /** Returns the distinct non-blank languages from a repo list, sorted. */
+  public List<String> extractLanguages(List<TrendingRepo> repos) {
+    if (repos == null) {
+      return List.of();
+    }
+    return repos.stream()
+        .map(TrendingRepo::language)
+        .filter(l -> l != null && !l.isBlank())
+        .distinct()
+        .sorted(String.CASE_INSENSITIVE_ORDER)
+        .toList();
+  }
+
+  private static boolean matchesQuery(TrendingRepo repo, String query) {
+    String needle = query.toLowerCase();
+    return (repo.name() != null && repo.name().toLowerCase().contains(needle))
+        || (repo.owner() != null && repo.owner().toLowerCase().contains(needle));
   }
 
   private TrendingCacheSnapshot getCache(TrendingPeriod period) {

--- a/quarkus-app/src/main/java/com/scanales/homedir/trending/TrendingService.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/trending/TrendingService.java
@@ -300,7 +300,15 @@ public class TrendingService {
 
       repos.add(
           new TrendingRepo(
-              name, owner, description, stars, starsToday, forks, contributors, language, url,
+              name,
+              owner,
+              description,
+              stars,
+              starsToday,
+              forks,
+              contributors,
+              language,
+              url,
               descriptionEs));
     }
 
@@ -314,13 +322,10 @@ public class TrendingService {
       return repos;
     }
     return repos.stream()
-        .filter(r -> language == null || language.isBlank() || language.equalsIgnoreCase(r.language()))
-        .filter(r -> minStars == null || r.stars() >= minStars)
         .filter(
-            r ->
-                query == null
-                    || query.isBlank()
-                    || matchesQuery(r, query.trim()))
+            r -> language == null || language.isBlank() || language.equalsIgnoreCase(r.language()))
+        .filter(r -> minStars == null || r.stars() >= minStars)
+        .filter(r -> query == null || query.isBlank() || matchesQuery(r, query.trim()))
         .toList();
   }
 

--- a/quarkus-app/src/main/resources/META-INF/resources/css/trending.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/trending.css
@@ -8,8 +8,43 @@
 .trending-period-selector {
   display: flex;
   gap: 0.5rem;
-  margin-bottom: 2rem;
+  margin-bottom: 1.5rem;
   flex-wrap: wrap;
+}
+
+.trending-filters {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background: var(--bg-secondary, rgba(0, 0, 0, 0.03));
+  border-radius: 0.5rem;
+}
+
+.trending-filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.trending-filter-label {
+  font-size: 0.8125rem;
+  color: var(--text-muted, #6c757d);
+}
+
+.trending-filter-select {
+  min-width: 10rem;
+}
+
+.trending-filter-search {
+  flex-grow: 1;
+  min-width: 12rem;
+}
+
+.trending-filter-apply {
+  white-space: nowrap;
 }
 
 .trending-grid {
@@ -79,21 +114,35 @@
 }
 
 .trending-repo-language,
-.trending-repo-stars {
+.trending-repo-stars,
+.trending-repo-metric {
   display: flex;
   align-items: center;
   gap: 0.25rem;
 }
 
 .trending-repo-language .material-symbols-outlined,
-.trending-repo-stars .material-symbols-outlined {
+.trending-repo-stars .material-symbols-outlined,
+.trending-repo-metric .material-symbols-outlined {
   font-size: 1rem;
+}
+
+.trending-repo-metric {
+  font-size: 0.8125rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.375rem;
+  background: var(--bg-secondary, rgba(0, 0, 0, 0.05));
 }
 
 .trending-repo-actions {
   display: flex;
   gap: 0.5rem;
   margin-top: auto;
+  flex-wrap: wrap;
+}
+
+.trending-error .hd-btn {
+  margin-top: 0.75rem;
 }
 
 .trending-count-selector {
@@ -117,6 +166,16 @@
 
   .trending-period-selector {
     justify-content: center;
+  }
+
+  .trending-filters {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .trending-filter-field,
+  .trending-filter-search {
+    width: 100%;
   }
 
   .trending-count-selector {

--- a/quarkus-app/src/main/resources/i18n.properties
+++ b/quarkus-app/src/main/resources/i18n.properties
@@ -2695,6 +2695,19 @@ trending_show_less=Show less
 trending_show_more=Show more
 trending_stars={count} stars
 trending_visit_repo=Visit repository
+trending_period_selector_aria=Trending period selector
+trending_filter_language=Language
+trending_filter_language_all=All languages
+trending_filter_min_stars=Minimum stars
+trending_filter_min_any=Any amount
+trending_filter_search=Search
+trending_filter_search_placeholder=Search by name or owner…
+trending_filter_apply=Apply
+trending_retry=Retry
+trending_no_results=No repositories match the current filters.
+trending_stars_today={count} stars today
+trending_forks={count} forks
+trending_contributors={count} contributors
 
 
 # Profile - Speaker Talks

--- a/quarkus-app/src/main/resources/i18n_en.properties
+++ b/quarkus-app/src/main/resources/i18n_en.properties
@@ -2695,6 +2695,19 @@ trending_show_less=Show less
 trending_show_more=Show more
 trending_stars={count} stars
 trending_visit_repo=Visit repository
+trending_period_selector_aria=Trending period selector
+trending_filter_language=Language
+trending_filter_language_all=All languages
+trending_filter_min_stars=Minimum stars
+trending_filter_min_any=Any amount
+trending_filter_search=Search
+trending_filter_search_placeholder=Search by name or owner…
+trending_filter_apply=Apply
+trending_retry=Retry
+trending_no_results=No repositories match the current filters.
+trending_stars_today={count} stars today
+trending_forks={count} forks
+trending_contributors={count} contributors
 
 
 # Profile - Speaker Talks

--- a/quarkus-app/src/main/resources/i18n_es.properties
+++ b/quarkus-app/src/main/resources/i18n_es.properties
@@ -2696,6 +2696,19 @@ trending_show_less=Mostrar menos
 trending_show_more=Mostrar más
 trending_stars={count} estrellas
 trending_visit_repo=Visitar repositorio
+trending_period_selector_aria=Selector de período de tendencias
+trending_filter_language=Lenguaje
+trending_filter_language_all=Todos los lenguajes
+trending_filter_min_stars=Estrellas mínimas
+trending_filter_min_any=Cualquier cantidad
+trending_filter_search=Buscar
+trending_filter_search_placeholder=Buscar por nombre u owner…
+trending_filter_apply=Aplicar
+trending_retry=Reintentar
+trending_no_results=Ningún repositorio coincide con los filtros actuales.
+trending_stars_today={count} estrellas hoy
+trending_forks={count} forks
+trending_contributors={count} contribuidores
 
 # Profile - Speaker Talks
 profile_speaker_talks_title=Mis Charlas

--- a/quarkus-app/src/main/resources/templates/TrendingResource/index.html
+++ b/quarkus-app/src/main/resources/templates/TrendingResource/index.html
@@ -13,24 +13,67 @@
         <div class="hd-card trending-card">
             <h1 class="hd-page-title">{i18n:trending_heading}</h1>
 
-            <div class="trending-period-selector">
-                <a href="/trending?period=daily&count={count}"
-                   class="hd-btn {#if period == 'daily'}hd-btn-primary{#else}hd-btn-secondary{/if}">
+            <div class="trending-period-selector" role="group" aria-label="{i18n:trending_period_selector_aria}">
+                <a href="/trending?period=daily&count={count}{#if selectedLanguage}&lang={selectedLanguage}{/if}{#if minStars}&minStars={minStars}{/if}{#if query}&q={query}{/if}"
+                   class="hd-btn {#if period == 'daily'}hd-btn-primary{#else}hd-btn-secondary{/if}" aria-current="{#if period == 'daily'}page{#else}false{/if}">
                     {i18n:trending_period_daily}
                 </a>
-                <a href="/trending?period=weekly&count={count}"
-                   class="hd-btn {#if period == 'weekly'}hd-btn-primary{#else}hd-btn-secondary{/if}">
+                <a href="/trending?period=weekly&count={count}{#if selectedLanguage}&lang={selectedLanguage}{/if}{#if minStars}&minStars={minStars}{/if}{#if query}&q={query}{/if}"
+                   class="hd-btn {#if period == 'weekly'}hd-btn-primary{#else}hd-btn-secondary{/if}" aria-current="{#if period == 'weekly'}page{#else}false{/if}">
                     {i18n:trending_period_weekly}
                 </a>
-                <a href="/trending?period=monthly&count={count}"
-                   class="hd-btn {#if period == 'monthly'}hd-btn-primary{#else}hd-btn-secondary{/if}">
+                <a href="/trending?period=monthly&count={count}{#if selectedLanguage}&lang={selectedLanguage}{/if}{#if minStars}&minStars={minStars}{/if}{#if query}&q={query}{/if}"
+                   class="hd-btn {#if period == 'monthly'}hd-btn-primary{#else}hd-btn-secondary{/if}" aria-current="{#if period == 'monthly'}page{#else}false{/if}">
                     {i18n:trending_period_monthly}
                 </a>
             </div>
 
+            <form method="get" action="/trending" class="trending-filters" role="search">
+                <input type="hidden" name="period" value="{period}" />
+                <input type="hidden" name="count" value="{count}" />
+
+                <div class="trending-filter-field">
+                    <label for="trendingLang" class="trending-filter-label">{i18n:trending_filter_language}</label>
+                    <select id="trendingLang" name="lang" class="hd-form-input trending-filter-select" aria-label="{i18n:trending_filter_language}">
+                        <option value="" {#if !selectedLanguage}selected{/if}>{i18n:trending_filter_language_all}</option>
+                        {#for lang in languages}
+                        <option value="{lang}" {#if selectedLanguage == lang}selected{/if}>{lang}</option>
+                        {/for}
+                    </select>
+                </div>
+
+                <div class="trending-filter-field">
+                    <label for="trendingMinStars" class="trending-filter-label">{i18n:trending_filter_min_stars}</label>
+                    <select id="trendingMinStars" name="minStars" class="hd-form-input trending-filter-select" aria-label="{i18n:trending_filter_min_stars}">
+                        <option value="" {#if !minStars}selected{/if}>{i18n:trending_filter_min_any}</option>
+                        <option value="100" {#if minStars == 100}selected{/if}>100</option>
+                        <option value="1000" {#if minStars == 1000}selected{/if}>1 000</option>
+                        <option value="10000" {#if minStars == 10000}selected{/if}>10 000</option>
+                        <option value="50000" {#if minStars == 50000}selected{/if}>50 000</option>
+                    </select>
+                </div>
+
+                <div class="trending-filter-field trending-filter-search">
+                    <label for="trendingQuery" class="trending-filter-label">{i18n:trending_filter_search}</label>
+                    <input id="trendingQuery" type="search" name="q" value="{query}"
+                           class="hd-form-input" placeholder="{i18n:trending_filter_search_placeholder}"
+                           aria-label="{i18n:trending_filter_search}" />
+                </div>
+
+                <button type="submit" class="hd-btn hd-btn-sm hd-btn-primary trending-filter-apply">
+                    {i18n:trending_filter_apply}
+                </button>
+            </form>
+
             {#if repos.isEmpty()}
-            <div class="hd-alert hd-alert-info">
+            <div class="hd-alert hd-alert-info trending-error" role="alert">
                 <p>{i18n:trending_error_loading}</p>
+                {#if selectedLanguage || minStars || query}
+                <p>{i18n:trending_no_results}</p>
+                {/if}
+                <a href="/trending?period={period}&count={count}" class="hd-btn hd-btn-sm hd-btn-secondary">
+                    {i18n:trending_retry}
+                </a>
             </div>
             {#else}
             <div class="hd-grid trending-grid">
@@ -57,15 +100,36 @@
                     <div class="trending-repo-meta">
                         {#if repo.language}
                         <span class="trending-repo-language">
-                            <span class="material-symbols-outlined">code</span>
+                            <span class="material-symbols-outlined" aria-hidden="true">code</span>
                             {repo.language}
                         </span>
                         {/if}
 
                         {#if repo.stars > 0}
-                        <span class="trending-repo-stars">
-                            <span class="material-symbols-outlined">star</span>
+                        <span class="trending-repo-stars" aria-label="{i18n:trending_stars(repo.stars)}">
+                            <span class="material-symbols-outlined" aria-hidden="true">star</span>
                             {i18n:trending_stars(repo.stars)}
+                        </span>
+                        {/if}
+
+                        {#if repo.starsToday > 0}
+                        <span class="trending-repo-metric" aria-label="{i18n:trending_stars_today(repo.starsToday)}">
+                            <span class="material-symbols-outlined" aria-hidden="true">trending_up</span>
+                            {i18n:trending_stars_today(repo.starsToday)}
+                        </span>
+                        {/if}
+
+                        {#if repo.forks > 0}
+                        <span class="trending-repo-metric" aria-label="{i18n:trending_forks(repo.forks)}">
+                            <span class="material-symbols-outlined" aria-hidden="true">fork_right</span>
+                            {i18n:trending_forks(repo.forks)}
+                        </span>
+                        {/if}
+
+                        {#if repo.contributors > 0}
+                        <span class="trending-repo-metric" aria-label="{i18n:trending_contributors(repo.contributors)}">
+                            <span class="material-symbols-outlined" aria-hidden="true">groups</span>
+                            {i18n:trending_contributors(repo.contributors)}
                         </span>
                         {/if}
                     </div>
@@ -80,13 +144,13 @@
             </div>
             {/if}
 
-            <div class="trending-count-selector">
+            <div class="trending-count-selector" role="group" aria-label="{i18n:trending_show_more}">
                 <span>{i18n:trending_show_more}:</span>
-                <a href="/trending?period={period}&count=1"
+                <a href="/trending?period={period}&count=1{#if selectedLanguage}&lang={selectedLanguage}{/if}{#if minStars}&minStars={minStars}{/if}{#if query}&q={query}{/if}"
                    class="hd-btn hd-btn-sm {#if count == 1}hd-btn-primary{#else}hd-btn-secondary{/if}">1</a>
-                <a href="/trending?period={period}&count=5"
+                <a href="/trending?period={period}&count=5{#if selectedLanguage}&lang={selectedLanguage}{/if}{#if minStars}&minStars={minStars}{/if}{#if query}&q={query}{/if}"
                    class="hd-btn hd-btn-sm {#if count == 5}hd-btn-primary{#else}hd-btn-secondary{/if}">5</a>
-                <a href="/trending?period={period}&count=10"
+                <a href="/trending?period={period}&count=10{#if selectedLanguage}&lang={selectedLanguage}{/if}{#if minStars}&minStars={minStars}{/if}{#if query}&q={query}{/if}"
                    class="hd-btn hd-btn-sm {#if count == 10}hd-btn-primary{#else}hd-btn-secondary{/if}">10</a>
             </div>
 

--- a/quarkus-app/src/test/java/com/scanales/homedir/trending/TrendingResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/trending/TrendingResourceTest.java
@@ -22,7 +22,11 @@ public class TrendingResourceTest {
         "/trending?period=weekly&count=10",
         "/trending?period=invalid",
         "/trending?count=1",
-        "/trending?count=100");
+        "/trending?count=100",
+        "/trending?period=daily&count=5&lang=JavaScript",
+        "/trending?period=daily&count=5&minStars=1000",
+        "/trending?period=daily&count=5&q=react",
+        "/trending?period=daily&count=5&lang=Go&minStars=10&q=goname");
   }
 
   @ParameterizedTest(name = "{0}")

--- a/quarkus-app/src/test/java/com/scanales/homedir/trending/TrendingServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/trending/TrendingServiceTest.java
@@ -96,6 +96,122 @@ public class TrendingServiceTest {
   }
 
   @Test
+  public void testParseHtmlExtractsStarsToday() {
+    List<TrendingRepo> repos = trendingService.parseHtml(fixtureHtml);
+
+    TrendingRepo react = repos.get(0);
+    assertEquals(1234, react.starsToday());
+    assertEquals(45678, react.stars(), "total stars should differ from stars today");
+
+    TrendingRepo goname =
+        repos.stream().filter(r -> r.name().equals("goname")).findFirst().orElseThrow();
+    assertEquals(3, goname.starsToday());
+  }
+
+  @Test
+  public void testParseHtmlExtractsForks() {
+    List<TrendingRepo> repos = trendingService.parseHtml(fixtureHtml);
+
+    TrendingRepo react = repos.get(0);
+    assertEquals(12345, react.forks());
+
+    TrendingRepo hdl =
+        repos.stream().filter(r -> r.name().equals("hdl-lang")).findFirst().orElseThrow();
+    assertEquals(34, hdl.forks());
+  }
+
+  @Test
+  public void testParseHtmlExtractsContributors() {
+    List<TrendingRepo> repos = trendingService.parseHtml(fixtureHtml);
+
+    TrendingRepo react = repos.get(0);
+    assertEquals(1001, react.contributors());
+
+    TrendingRepo ruff = repos.stream().filter(r -> r.name().equals("ruff")).findFirst().orElseThrow();
+    assertEquals(89, ruff.contributors());
+  }
+
+  @Test
+  public void testParseHtmlFillsDescriptionEsFromCatalog() {
+    List<TrendingRepo> repos = trendingService.parseHtml(fixtureHtml);
+
+    TrendingRepo react = repos.get(0);
+    assertEquals(
+        "Biblioteca declarativa, eficiente y flexible de JavaScript para construir interfaces de usuario.",
+        react.descriptionEs());
+
+    TrendingRepo ruff = repos.stream().filter(r -> r.name().equals("ruff")).findFirst().orElseThrow();
+    assertEquals("Linter y formateador de Python extremadamente rápido, escrito en Rust.", ruff.descriptionEs());
+  }
+
+  @Test
+  public void testParseHtmlDescriptionEsFallsBackToNull() {
+    List<TrendingRepo> repos = trendingService.parseHtml(fixtureHtml);
+
+    TrendingRepo goname =
+        repos.stream().filter(r -> r.name().equals("goname")).findFirst().orElseThrow();
+    assertNull(goname.descriptionEs(), "unknown repos should have null descriptionEs");
+  }
+
+  @Test
+  public void testFilterReposByLanguage() {
+    List<TrendingRepo> repos = trendingService.parseHtml(fixtureHtml);
+
+    List<TrendingRepo> rust = trendingService.filterRepos(repos, "Rust", null, null);
+    assertEquals(1, rust.size());
+    assertEquals("ruff", rust.get(0).name());
+
+    List<TrendingRepo> none = trendingService.filterRepos(repos, "Kotlin", null, null);
+    assertTrue(none.isEmpty());
+  }
+
+  @Test
+  public void testFilterReposByMinStars() {
+    List<TrendingRepo> repos = trendingService.parseHtml(fixtureHtml);
+
+    List<TrendingRepo> big = trendingService.filterRepos(repos, null, 1000, null);
+    assertEquals(3, big.size(), "react, ruff, langchain have >= 1000 stars");
+    assertTrue(big.stream().allMatch(r -> r.stars() >= 1000));
+
+    List<TrendingRepo> huge = trendingService.filterRepos(repos, null, 100000, null);
+    assertTrue(huge.isEmpty());
+  }
+
+  @Test
+  public void testFilterReposByQuery() {
+    List<TrendingRepo> repos = trendingService.parseHtml(fixtureHtml);
+
+    List<TrendingRepo> byName = trendingService.filterRepos(repos, null, null, "react");
+    assertEquals(1, byName.size());
+    assertEquals("react", byName.get(0).name());
+
+    List<TrendingRepo> byOwner = trendingService.filterRepos(repos, null, null, "astral");
+    assertEquals(1, byOwner.size());
+    assertEquals("ruff", byOwner.get(0).name());
+
+    List<TrendingRepo> combined = trendingService.filterRepos(repos, null, null, "langchain");
+    assertEquals(1, combined.size());
+  }
+
+  @Test
+  public void testFilterReposNullInputs() {
+    assertNull(trendingService.filterRepos(null, null, null, null));
+    assertTrue(trendingService.filterRepos(List.of(), null, null, null).isEmpty());
+
+    List<TrendingRepo> repos = trendingService.parseHtml(fixtureHtml);
+    assertEquals(repos.size(), trendingService.filterRepos(repos, null, null, null).size());
+    assertEquals(repos.size(), trendingService.filterRepos(repos, "", null, "").size());
+  }
+
+  @Test
+  public void testExtractLanguages() {
+    List<TrendingRepo> repos = trendingService.parseHtml(fixtureHtml);
+
+    List<String> languages = trendingService.extractLanguages(repos);
+    assertEquals(List.of("Go", "JavaScript", "Python", "Rust"), languages);
+  }
+
+  @Test
   public void testParseHtmlHandlesMissingLanguage() {
     List<TrendingRepo> repos = trendingService.parseHtml(fixtureHtml);
 

--- a/quarkus-app/src/test/java/com/scanales/homedir/trending/TrendingServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/trending/TrendingServiceTest.java
@@ -127,7 +127,8 @@ public class TrendingServiceTest {
     TrendingRepo react = repos.get(0);
     assertEquals(1001, react.contributors());
 
-    TrendingRepo ruff = repos.stream().filter(r -> r.name().equals("ruff")).findFirst().orElseThrow();
+    TrendingRepo ruff =
+        repos.stream().filter(r -> r.name().equals("ruff")).findFirst().orElseThrow();
     assertEquals(89, ruff.contributors());
   }
 
@@ -140,8 +141,11 @@ public class TrendingServiceTest {
         "Biblioteca declarativa, eficiente y flexible de JavaScript para construir interfaces de usuario.",
         react.descriptionEs());
 
-    TrendingRepo ruff = repos.stream().filter(r -> r.name().equals("ruff")).findFirst().orElseThrow();
-    assertEquals("Linter y formateador de Python extremadamente rápido, escrito en Rust.", ruff.descriptionEs());
+    TrendingRepo ruff =
+        repos.stream().filter(r -> r.name().equals("ruff")).findFirst().orElseThrow();
+    assertEquals(
+        "Linter y formateador de Python extremadamente rápido, escrito en Rust.",
+        ruff.descriptionEs());
   }
 
   @Test

--- a/quarkus-app/src/test/resources/fixtures/trending/github-trending-daily.html
+++ b/quarkus-app/src/test/resources/fixtures/trending/github-trending-daily.html
@@ -7,6 +7,18 @@
     <p class="col-9 color-fg-muted my-1">A declarative, efficient, and flexible JavaScript library for building user interfaces.</p>
     <span itemprop="programmingLanguage">JavaScript</span>
     45,678 stars today
+    <div class="d-inline-block mr-3">
+      <a class="Link--muted" href="/facebook/react/stargazers">1,234</a>
+    </div>
+    <span class="d-inline-block mr-3">stars today</span>
+    <div class="d-inline-block mr-3">
+      <a class="Link--muted" href="/facebook/react/forks">12,345</a>
+    </div>
+    <span class="d-inline-block mr-3">forks</span>
+    <div class="d-inline-block mr-3">
+      <a class="Link--muted" href="/facebook/react/forks">1,001</a>
+    </div>
+    <span class="d-inline-block mr-3">contributors</span>
   </article>
   <article class="Box-row">
     <h2 class="h3 lh-condensed">
@@ -15,6 +27,18 @@
     <p class="col-9 color-fg-muted my-1">An extremely fast Python linter and code formatter, written in Rust.</p>
     <span itemprop="programmingLanguage">Rust</span>
     1,234 stars today
+    <div class="d-inline-block mr-3">
+      <a class="Link--muted" href="/astral-sh/ruff/stargazers">456</a>
+    </div>
+    <span class="d-inline-block mr-3">stars today</span>
+    <div class="d-inline-block mr-3">
+      <a class="Link--muted" href="/astral-sh/ruff/forks">5,678</a>
+    </div>
+    <span class="d-inline-block mr-3">forks</span>
+    <div class="d-inline-block mr-3">
+      <a class="Link--muted" href="/astral-sh/ruff/forks">89</a>
+    </div>
+    <span class="d-inline-block mr-3">contributors</span>
   </article>
   <article class="Box-row">
     <h2 class="h3 lh-condensed">
@@ -23,6 +47,18 @@
     <p class="col-9 color-fg-muted my-1">Building applications with LLMs through composability</p>
     <span itemprop="programmingLanguage">Python</span>
     2,345 stars today
+    <div class="d-inline-block mr-3">
+      <a class="Link--muted" href="/langchain-ai/langchain/stargazers">890</a>
+    </div>
+    <span class="d-inline-block mr-3">stars today</span>
+    <div class="d-inline-block mr-3">
+      <a class="Link--muted" href="/langchain-ai/langchain/forks">1,111</a>
+    </div>
+    <span class="d-inline-block mr-3">forks</span>
+    <div class="d-inline-block mr-3">
+      <a class="Link--muted" href="/langchain-ai/langchain/forks">45</a>
+    </div>
+    <span class="d-inline-block mr-3">contributors</span>
   </article>
   <article class="Box-row">
     <h2 class="h3 lh-condensed">
@@ -31,6 +67,18 @@
     <p class="col-9 color-fg-muted my-1">A hardware description language</p>
     <!-- no language span -->
     567 stars today
+    <div class="d-inline-block mr-3">
+      <a class="Link--muted" href="/hdl/hdl-lang/stargazers">12</a>
+    </div>
+    <span class="d-inline-block mr-3">stars today</span>
+    <div class="d-inline-block mr-3">
+      <a class="Link--muted" href="/hdl/hdl-lang/forks">34</a>
+    </div>
+    <span class="d-inline-block mr-3">forks</span>
+    <div class="d-inline-block mr-3">
+      <a class="Link--muted" href="/hdl/hdl-lang/forks">5</a>
+    </div>
+    <span class="d-inline-block mr-3">contributors</span>
   </article>
   <article class="Box-row">
     <h2 class="h3 lh-condensed">
@@ -39,6 +87,18 @@
     <!-- no description p tag -->
     <span itemprop="programmingLanguage">Go</span>
     100 stars today
+    <div class="d-inline-block mr-3">
+      <a class="Link--muted" href="/nouser/goname/stargazers">3</a>
+    </div>
+    <span class="d-inline-block mr-3">stars today</span>
+    <div class="d-inline-block mr-3">
+      <a class="Link--muted" href="/nouser/goname/forks">7</a>
+    </div>
+    <span class="d-inline-block mr-3">forks</span>
+    <div class="d-inline-block mr-3">
+      <a class="Link--muted" href="/nouser/goname/forks">2</a>
+    </div>
+    <span class="d-inline-block mr-3">contributors</span>
   </article>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Complete implementation of issue #1284 for the **Trending Repositories** section (`/trending`):

1. **Full i18n (EN + ES)** — required:
   - The 12 new keys (`trending_filter_*`, `trending_retry`, `trending_no_results`, `trending_stars_today`, `trending_forks`, `trending_contributors`, `trending_period_selector_aria`) were added to the 3 live bundles: `i18n.properties` (fallback), `i18n_en.properties` and `i18n_es.properties`.
   - Corresponding methods added to the message bundle interface `AppMessages.java` (`@MessageBundle("i18n")`), required for Qute strict-rendering.
   - Local validation with `scripts/validate_i18n.py`: **I18N VALIDATION PASSED** (2727 identical keys across the 3 bundles, all Qute references resolve).

2. **Localized descriptions (`descriptionEs`)** — required:
   - New `TrendingDescriptionCatalog` with curated Spanish descriptions (owner/name → ES description).
   - Fallback to `null` when the repo is not in the catalog: the template shows the original GitHub description.
   - The template shows the ES description only when `resolvedLocaleCode == 'es'`.

3. **Feature improvements:**
   - New metrics on each card: ⭐ stars today, forks and contributors (parsed from the GitHub Trending HTML).
   - Filters: language select (extracted dynamically from the repos), `minStars` and `q` search (name/owner). They preserve the period (`daily`/`weekly`/`monthly`).
   - Cache TTL reduced from 48h to **6h** (recommendation from `cache-audit.md`).
   - UX: "Retry" button in the empty state, aria-labels in the period selector, responsive styles (`trending-filters`, metrics, 768px media query).

## Related Issues

- **Closes #1284**

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation

## PR Risk Label

- **pr:risk-low** — Trending section only; no changes to security, authentication, user data or existing external API (the new API params are additive).

## Self-Attestation

- [x] **pr:traceability-ok** — every change is tied to issue #1284 (full i18n, descriptionEs and improvements).
- [x] **pr:acceptance-ok** — issue criteria met: keys in the live bundle + interface, ES descriptions with fallback, filters and metrics.
- [x] **pr:tests-ok** — 70/70 trending tests green (21 `TrendingServiceTest`, 39 `TrendingResourceTest`, 1 smoke, 4 cache, 5 observability).
- [x] **pr:i18n-ok** — EN + ES keys in the 3 live bundles + `AppMessages.java` interface; `validate_i18n.py` PASSED.

Note: the `pr:*` labels could not be applied due to user permissions (`AddLabelsToLabelable` denied); they are declared here as checkboxes for the automation.

## Test Plan

1. `mvnw test -Dtest="TrendingServiceTest,TrendingResourceTest,TrendingSmokeTest,TrendingCachePersistenceTest,TrendingObservabilityEmissionTest"` → **Tests run: 70, Failures: 0, Errors: 0** — BUILD SUCCESS.
2. Manual verification in `quarkus:dev`:
   - `/trending` → 200 with real cards (filters, metrics, links).
   - Filters `?lang=JavaScript&minStars=1000&q=react` → 200 with filtered repos.
   - "Retry" button and aria-labels present in the HTML.
3. Local i18n validation: `python scripts/validate_i18n.py` → PASSED (parity 2727/2727/2727).

## Known Limitations

- **Spanish rendering depends on global bug #1267** (P0, already assigned to `scanalesespinoza`): Quarkus does not apply the ES locale to message bundles (`setLocale` ignored), so the whole site — including production — shows English text even with `lang="es"`. The ES keys are 100% available and will activate automatically once #1267 is resolved. This PR does not alter that resolution (out of scope).

## Screenshots

Not applicable (code/template change; functional verification documented above).