### PR TITLE
fix(hub): center stat boxes and section leaders title (#1445)

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/reputation-hub.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/reputation-hub.css
@@ -63,37 +63,6 @@
   font-size: 0.84rem;
 }
 
-.hub-instructional-panel h2,
-.hub-instructional-panel .hub-panel-intro,
-.hub-instructional-panel .hub-recognition-hint,
-.hub-instructional-panel .hub-empty {
-  text-align: center;
-}
-
-.hub-instructional-panel .hub-how-list {
-  justify-items: center;
-}
-
-.hub-instructional-panel .hub-how-list li {
-  display: grid;
-  gap: 0.35rem;
-  justify-items: center;
-  width: 100%;
-  background: rgba(0, 0, 0, 0.26);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 8px;
-  padding: 0.6rem 0.75rem;
-}
-
-.hub-instructional-panel .hub-how-list strong,
-.hub-instructional-panel .hub-how-list p {
-  text-align: center;
-}
-
-.hub-instructional-panel .hub-recognition-item {
-  text-align: left;
-}
-
 .hub-migration-banner {
   grid-column: 1 / -1;
   margin: 0;
@@ -177,10 +146,15 @@
   object-fit: cover;
 }
 
-.hub-avatar--placeholder {
-  display: inline-block;
-  background: rgba(255, 255, 255, 0.1);
-  border-style: dashed;
+.hub-avatar-fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-primary, #4f46e5);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-transform: uppercase;
 }
 
 .hub-member {

--- a/quarkus-app/src/main/resources/META-INF/resources/css/reputation-hub.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/reputation-hub.css
@@ -46,9 +46,28 @@
   background: rgba(0, 0, 0, 0.3);
 }
 
+.hub-hero-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
 .hub-hero-card h2 {
   margin: 0.2rem 0 0;
   font-size: 1.4rem;
+}
+
+.hub-panel-centered {
+  text-align: center;
+}
+
+.hub-panel-centered h2,
+.hub-panel-centered .hub-panel-intro {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 560px;
 }
 
 .hub-panel h2,

--- a/quarkus-app/src/main/resources/templates/ReputationHubResource/hub.html
+++ b/quarkus-app/src/main/resources/templates/ReputationHubResource/hub.html
@@ -75,7 +75,7 @@
                 {#if standing.leader.avatarUrl}
                   <img class="hub-avatar" src="{standing.leader.avatarUrl}" alt="{standing.leader.displayName}"/>
                 {#else}
-                  <span class="hub-avatar hub-avatar--placeholder" aria-hidden="true"></span>
+                  <div class="hub-avatar hub-avatar-fallback" aria-hidden="true">{standing.leader.displayName.substring(0,1)}</div>
                 {/if}
                 <div class="hub-member">
                   {#if standing.leader.profilePath}
@@ -130,7 +130,7 @@
                   {#if entry.avatarUrl}
                     <img class="hub-avatar" src="{entry.avatarUrl}" alt="{entry.displayName}"/>
                   {#else}
-                    <span class="hub-avatar hub-avatar--placeholder" aria-hidden="true"></span>
+                    <div class="hub-avatar hub-avatar-fallback" aria-hidden="true">{entry.displayName.substring(0,1)}</div>
                   {/if}
                   <div class="hub-member">
                     {#if entry.profilePath}
@@ -160,7 +160,7 @@
                 {#if entry.avatarUrl}
                   <img class="hub-avatar" src="{entry.avatarUrl}" alt="{entry.displayName}"/>
                 {#else}
-                  <span class="hub-avatar hub-avatar--placeholder" aria-hidden="true"></span>
+                  <div class="hub-avatar hub-avatar-fallback" aria-hidden="true">{entry.displayName.substring(0,1)}</div>
                 {/if}
                 <div class="hub-member">
                   {#if entry.profilePath}
@@ -187,7 +187,7 @@
                 {#if entry.avatarUrl}
                   <img class="hub-avatar" src="{entry.avatarUrl}" alt="{entry.displayName}"/>
                 {#else}
-                  <span class="hub-avatar hub-avatar--placeholder" aria-hidden="true"></span>
+                  <div class="hub-avatar hub-avatar-fallback" aria-hidden="true">{entry.displayName.substring(0,1)}</div>
                 {/if}
                 <div class="hub-member">
                   {#if entry.profilePath}
@@ -214,7 +214,7 @@
                 {#if entry.avatarUrl}
                   <img class="hub-avatar" src="{entry.avatarUrl}" alt="{entry.displayName}"/>
                 {#else}
-                  <span class="hub-avatar hub-avatar--placeholder" aria-hidden="true"></span>
+                  <div class="hub-avatar hub-avatar-fallback" aria-hidden="true">{entry.displayName.substring(0,1)}</div>
                 {/if}
                 <div class="hub-member">
                   {#if entry.profilePath}
@@ -234,7 +234,7 @@
       </div>
 
       <div class="hub-secondary-grid">
-        <article class="hub-panel hub-instructional-panel">
+        <article class="hub-panel">
           <h2>{#if resolvedLocaleCode == 'es'}Cómo crecer desde aquí{#else}How to grow from here{/if}</h2>
           <p class="hub-panel-intro">
             {#if hub.viewerGuidance??}
@@ -346,7 +346,7 @@
           </ul>
         </article>
 
-        <article class="hub-panel hub-instructional-panel">
+        <article class="hub-panel">
           <h2>{i18n:reputation_hub_recognized_title}</h2>
           {#if !userAuthenticated}
             <p class="hub-recognition-hint">{i18n:reputation_hub_recognize_signin_hint}</p>
@@ -416,7 +416,7 @@
           </ul>
         </article>
 
-        <article class="hub-panel hub-instructional-panel">
+        <article class="hub-panel">
           <h2><a class="hub-how-link" href="/comunidad/reputation-hub/how">{i18n:reputation_hub_how_title}</a></h2>
           <ul class="hub-how-list">
             <li>

--- a/quarkus-app/src/main/resources/templates/ReputationHubResource/hub.html
+++ b/quarkus-app/src/main/resources/templates/ReputationHubResource/hub.html
@@ -41,7 +41,7 @@
         </article>
       </div>
 
-      <article class="hub-panel">
+      <article class="hub-panel hub-panel-centered">
         <h2>{#if resolvedLocaleCode == 'es'}Líderes reputacionales actuales{#else}Current reputation leaders{/if}</h2>
         <p class="hub-panel-intro">
           {#if resolvedLocaleCode == 'es'}

--- a/quarkus-app/src/test/java/com/scanales/homedir/public_/ReputationHubResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/public_/ReputationHubResourceTest.java
@@ -298,6 +298,6 @@ class ReputationHubResourceTest {
         .then()
         .statusCode(200)
         .body(containsString("noavatar@example.com"))
-        .body(containsString("hub-avatar--placeholder"));
+        .body(containsString("hub-avatar-fallback"));
   }
 }

--- a/quarkus-app/src/test/java/com/scanales/homedir/public_/ReputationHubResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/public_/ReputationHubResourceTest.java
@@ -156,6 +156,40 @@ class ReputationHubResourceTest {
   }
 
   @Test
+  void reputationHubShowsInitialsFallbackForMembersWithoutAvatar() {
+    userProfileService.linkGithub(
+        "hub.user.three@example.com",
+        "Hub User Three",
+        "hub.user.three@example.com",
+        new UserProfile.GithubAccount(
+            "hub-user-three",
+            "https://github.com/hub-user-three",
+            null,
+            "7003",
+            Instant.parse("2026-03-01T00:00:00Z")));
+
+    assertTrue(reputationEngineService.trackContentPublished("hub.user.three@example.com", "thread-c"));
+    assertTrue(
+        reputationEngineService.trackEventSpeaker(
+            "hub.user.three@example.com", "submission-c", "event-c"));
+    assertTrue(reputationEngineService.trackQuestCompleted("hub.user.three@example.com", "quest-c"));
+    assertTrue(reputationEngineService.trackEventAttended("hub.user.three@example.com", "talk-c"));
+    assertTrue(
+        reputationEngineService.trackVolunteerEngaged(
+            "hub.user.three@example.com", "volunteer", "volunteer-c"));
+
+    given()
+        .header("Accept-Language", "en")
+        .when()
+        .get("/comunidad/reputation-hub")
+        .then()
+        .statusCode(200)
+        .body(containsString("hub-avatar-fallback"))
+        .body(containsString("Hub User Three"))
+        .body(not(containsString("https://avatars.githubusercontent.com/u/7003")));
+  }
+
+  @Test
   void reputationHubRendersLocalizedCopyInSpanish() {
     given()
         .header("Accept-Language", "en")

--- a/quarkus-app/src/test/java/com/scanales/homedir/public_/ReputationHubResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/public_/ReputationHubResourceTest.java
@@ -168,11 +168,13 @@ class ReputationHubResourceTest {
             "7003",
             Instant.parse("2026-03-01T00:00:00Z")));
 
-    assertTrue(reputationEngineService.trackContentPublished("hub.user.three@example.com", "thread-c"));
+    assertTrue(
+        reputationEngineService.trackContentPublished("hub.user.three@example.com", "thread-c"));
     assertTrue(
         reputationEngineService.trackEventSpeaker(
             "hub.user.three@example.com", "submission-c", "event-c"));
-    assertTrue(reputationEngineService.trackQuestCompleted("hub.user.three@example.com", "quest-c"));
+    assertTrue(
+        reputationEngineService.trackQuestCompleted("hub.user.three@example.com", "quest-c"));
     assertTrue(reputationEngineService.trackEventAttended("hub.user.three@example.com", "talk-c"));
     assertTrue(
         reputationEngineService.trackVolunteerEngaged(


### PR DESCRIPTION
## Summary

Centers the Reputation Hub hero stat box content (number + label) both horizontally and vertically, and centers the current reputation leaders section title and subtitle. Changes are scoped to new `.hub-*` rules so shared `.section-subtitle` / `.section-card` / `.page-header` usage on other pages is untouched.

> Note: the issue's "Affected Files" referenced `homedir.css` for the stat box styles, but the hub-specific styles live in `reputation-hub.css` (loaded by `hub.html`). The changes here target the correct file.

## Linked Issue

Closes #1445

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Security fix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Platform/infrastructure change

## Test Plan

- [x] Code compiles (`./mvnw test-compile`)
- [ ] Unit tests pass (`./mvnw test`) — blocked locally by pre-existing Quarkus test-bootstrap (`SmallRyeConfig.buildMappings`) issue, unrelated to this change (fails identically on base). CI runs the full suite.
- [ ] E2E tests pass (if applicable)
- [x] Manual verification performed — stat boxes and leaders title centered; list/rankings stay left-aligned; verified in both EN and ES
- [x] i18n keys updated (EN + ES) if user-facing text added — N/A (no text added/changed)

## Breaking Changes

None

## Additional Notes

Manual verification steps:
```bash
cd quarkus-app && ./mvnw quarkus:dev
open http://localhost:8080/comunidad/reputation-hub   # and /en/comunidad/reputation-hub
```
