### PR TITLE
fix: keep reputation hub ranking rows aligned when avatar is missing

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/reputation-hub.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/reputation-hub.css
@@ -177,6 +177,12 @@
   object-fit: cover;
 }
 
+.hub-avatar--placeholder {
+  display: inline-block;
+  background: rgba(255, 255, 255, 0.1);
+  border-style: dashed;
+}
+
 .hub-member {
   display: grid;
   gap: 0.15rem;

--- a/quarkus-app/src/main/resources/templates/ReputationHubResource/hub.html
+++ b/quarkus-app/src/main/resources/templates/ReputationHubResource/hub.html
@@ -74,6 +74,8 @@
                 <span class="hub-rank">#{standing.leader.rank}</span>
                 {#if standing.leader.avatarUrl}
                   <img class="hub-avatar" src="{standing.leader.avatarUrl}" alt="{standing.leader.displayName}"/>
+                {#else}
+                  <span class="hub-avatar hub-avatar--placeholder" aria-hidden="true"></span>
                 {/if}
                 <div class="hub-member">
                   {#if standing.leader.profilePath}
@@ -127,6 +129,8 @@
                   <span class="hub-rank">#{entry.rank}</span>
                   {#if entry.avatarUrl}
                     <img class="hub-avatar" src="{entry.avatarUrl}" alt="{entry.displayName}"/>
+                  {#else}
+                    <span class="hub-avatar hub-avatar--placeholder" aria-hidden="true"></span>
                   {/if}
                   <div class="hub-member">
                     {#if entry.profilePath}
@@ -155,6 +159,8 @@
                 <span class="hub-rank">#{entry.rank}</span>
                 {#if entry.avatarUrl}
                   <img class="hub-avatar" src="{entry.avatarUrl}" alt="{entry.displayName}"/>
+                {#else}
+                  <span class="hub-avatar hub-avatar--placeholder" aria-hidden="true"></span>
                 {/if}
                 <div class="hub-member">
                   {#if entry.profilePath}
@@ -180,6 +186,8 @@
                 <span class="hub-rank">#{entry.rank}</span>
                 {#if entry.avatarUrl}
                   <img class="hub-avatar" src="{entry.avatarUrl}" alt="{entry.displayName}"/>
+                {#else}
+                  <span class="hub-avatar hub-avatar--placeholder" aria-hidden="true"></span>
                 {/if}
                 <div class="hub-member">
                   {#if entry.profilePath}
@@ -205,6 +213,8 @@
                 <span class="hub-rank">#{entry.rank}</span>
                 {#if entry.avatarUrl}
                   <img class="hub-avatar" src="{entry.avatarUrl}" alt="{entry.displayName}"/>
+                {#else}
+                  <span class="hub-avatar hub-avatar--placeholder" aria-hidden="true"></span>
                 {/if}
                 <div class="hub-member">
                   {#if entry.profilePath}

--- a/quarkus-app/src/test/java/com/scanales/homedir/public_/ReputationHubResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/public_/ReputationHubResourceTest.java
@@ -249,4 +249,19 @@ class ReputationHubResourceTest {
         .body(containsString("data-recognition-type=\"recommended\""))
         .body(containsString("/js/reputation-recognition.js?v="));
   }
+
+  @Test
+  void reputationHubRendersPlaceholderAvatarWhenUserHasNoAvatarOrHandle() {
+    assertTrue(
+        reputationEngineService.trackQuestCompleted("noavatar@example.com", "quest-noavatar"));
+
+    given()
+        .header("Accept-Language", "en")
+        .when()
+        .get("/comunidad/reputation-hub")
+        .then()
+        .statusCode(200)
+        .body(containsString("noavatar@example.com"))
+        .body(containsString("hub-avatar--placeholder"));
+  }
 }


### PR DESCRIPTION
## Summary

Fixes inconsistent alignment in the Reputation Hub leaderboard rows (`/comunidad/reputation-hub`). Each row uses a CSS grid of 4 columns (rank, avatar, member, score), but the avatar was conditionally rendered. When a user had no avatar, the missing `<img>` collapsed the grid to 3 columns and the score shifted into the member column, appearing visually attached to the name (e.g. `name + score` instead of `name + handle + score`).

This PR renders a placeholder avatar element whenever a user has no avatar, so every row always has the same 4-column structure and the score stays in its own aligned column.

## Linked Issue

Closes #1484

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## PR Risk Label (required — apply exactly one)

- [x] `pr:risk-medium` — Features, refactors, new dependencies (min 2 approvals, 1 code owner)

## Self-Attestation Labels (apply all that apply)

- [x] `pr:traceability-ok` — `Closes #N` present, issue exists with priority + type labels
- [x] `pr:acceptance-ok` — All acceptance criteria from linked issue are met
- [x] `pr:tests-ok` — Tests added/updated for new functionality

## Test Plan

- [x] Code compiles (`./mvnw compile` or equivalent)
- [x] Unit tests pass (`./mvnw test -Dtest=ReputationHubResourceTest`)
- [x] Manual verification performed
- [ ] i18n keys updated (EN + ES) if user-facing text added — N/A (no user-facing text added; placeholder is `aria-hidden`)

## Breaking Changes

None

## Additional Notes

- The placeholder is a `<span class="hub-avatar hub-avatar--placeholder">` (dashed neutral circle) so the avatar column width stays identical to rows with a real avatar.
- Applied to all 5 leaderboard blocks: featured standings, category leaderboards, and weekly/monthly/rising leaderboards.
- Added regression test `reputationHubRendersPlaceholderAvatarWhenUserHasNoAvatarOrHandle`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added consistent placeholder avatars for reputation-hub leaders and entries without profile images.
  * Placeholder avatars now preserve the expected dimensions and use a subtle dashed-border style.
  * Improved handling of profiles missing both an avatar and a handle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->