### PR TITLE
fix(ui): avatar fallback placeholder + CSP allow Discord/Google avatar CDNs (Closes #1485)

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/security/CspHeaderFilter.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/security/CspHeaderFilter.java
@@ -38,7 +38,7 @@ public class CspHeaderFilter implements ContainerResponseFilter {
             + "';"
             + " style-src 'self' https://fonts.googleapis.com 'unsafe-inline';"
             + " font-src 'self' https://fonts.gstatic.com;"
-            + " img-src 'self' data: https://cdn.simpleicons.org https://homedir.opensourcesantiago.io https://avatars.githubusercontent.com https://santiago.devopsdayschile.cl;"
+            + " img-src 'self' data: https://cdn.simpleicons.org https://homedir.opensourcesantiago.io https://avatars.githubusercontent.com https://lh3.googleusercontent.com https://cdn.discordapp.com https://santiago.devopsdayschile.cl;"
             + " connect-src 'self';"
             + " object-src 'none';"
             + " base-uri 'self';"

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -2856,6 +2856,10 @@ footer {
   border: 1px solid rgba(var(--white-rgb), 0.5);
 }
 
+.hd-avatar-fallback-hidden {
+  display: none;
+}
+
 .user-menu-btn-styled {
   background: none;
   border: none;

--- a/quarkus-app/src/main/resources/META-INF/resources/js/core-bundle.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/core-bundle.js
@@ -594,6 +594,21 @@ document.addEventListener('DOMContentLoaded', () => {
       if (dropdown) dropdown.classList.remove('show');
     }
   });
+
+  // Avatar fallback: when an external avatar fails to load, hide the broken
+  // <img> and reveal the initial-based placeholder next to it.
+  document.querySelectorAll('[data-hd-avatar-img]').forEach((img) => {
+    img.addEventListener('error', () => {
+      const fallbackSelector = img.getAttribute('data-hd-avatar-fallback');
+      if (fallbackSelector) {
+        const fallback = img.parentElement.querySelector(fallbackSelector);
+        if (fallback) {
+          fallback.classList.remove('hd-avatar-fallback-hidden');
+        }
+      }
+      img.classList.add('hd-avatar-fallback-hidden');
+    });
+  });
 });
 (function () {
     const origFetch = window.fetch;

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -50,16 +50,13 @@
             <article class="hd-card hd-profile-spotlight">
                 <div class="hd-profile-avatar-wrap">
                     {#if picture??}
-                    <img src="{picture}" alt="{name}" class="hd-profile-avatar">
-                    {#else}
-                    {#if github != null && github.avatarUrl != null}
-                    <img src="{github.avatarUrl}" alt="{name}" class="hd-profile-avatar">
+                    <img src="{picture}" alt="{name}" class="hd-profile-avatar" data-hd-avatar-img data-hd-avatar-fallback=".hd-profile-avatar-fallback">
+                    {#else if github != null && github.avatarUrl != null}
+                    <img src="{github.avatarUrl}" alt="{name}" class="hd-profile-avatar" data-hd-avatar-img data-hd-avatar-fallback=".hd-profile-avatar-fallback">
                     {#else if discord != null && discord.avatarUrl != null}
-                    <img src="{discord.avatarUrl}" alt="{name}" class="hd-profile-avatar">
-                    {#else}
-                    <span class="hd-profile-avatar-fallback">{userInitial}</span>
+                    <img src="{discord.avatarUrl}" alt="{name}" class="hd-profile-avatar" data-hd-avatar-img data-hd-avatar-fallback=".hd-profile-avatar-fallback">
                     {/if}
-                    {/if}
+                    <span class="hd-profile-avatar-fallback{#if picture?? || (github != null && github.avatarUrl != null) || (discord != null && discord.avatarUrl != null)} hd-avatar-fallback-hidden{/if}">{userInitial}</span>
                 </div>
                 <div class="hd-profile-spotlight-main">
                     <h3>{name}</h3>

--- a/quarkus-app/src/main/resources/templates/fragments/header.html
+++ b/quarkus-app/src/main/resources/templates/fragments/header.html
@@ -52,16 +52,16 @@
       <div class="user-menu-toggle">
         <a href="/private/profile" class="user-profile-link user-profile-link-styled">
           {#if userSession.avatarUrl}
-          <img src="{userSession.avatarUrl}" alt="{i18n:header_avatar_alt}" class="avatar-circle header-avatar-circle">
-          {#else}
-          <div class="avatar-circle header-avatar-fallback">
+          <img src="{userSession.avatarUrl}" alt="{i18n:header_avatar_alt}" class="avatar-circle header-avatar-circle"
+            data-hd-avatar-img data-hd-avatar-fallback=".header-avatar-fallback">
+          {/if}
+          <div class="avatar-circle header-avatar-fallback{#if userSession.avatarUrl} hd-avatar-fallback-hidden{/if}">
             {#if userSession.displayName}
             {userSession.displayName.substring(0,1)}
             {#else}
             {userInitial}
             {/if}
           </div>
-          {/if}
           <span class="user-name">
             {#if userSession.questClass}
             <span title="{userSession.questClass.displayName}" class="user-class-icon" aria-hidden="true">

--- a/quarkus-app/src/test/java/com/scanales/homedir/private_/ProfileResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/private_/ProfileResourceTest.java
@@ -653,6 +653,20 @@ public class ProfileResourceTest {
         .body(containsString("data-profile-nav=\"overview-panel\""));
   }
 
+  @Test
+  public void profileAvatarRendersFallbackMarkup() {
+    // setup() links GitHub with an avatar, so the spotlight <img> must include
+    // the fallback hooks used by the JS onerror handler (issue #1485).
+    given()
+        .when()
+        .get("/private/profile")
+        .then()
+        .statusCode(200)
+        .body(containsString("data-hd-avatar-img"))
+        .body(containsString("hd-profile-avatar-fallback"))
+        .body(containsString("hd-avatar-fallback-hidden"));
+  }
+
   private String currentUserEmail() {
     Object emailAttr = securityIdentity.getAttribute("email");
     if (emailAttr != null && !emailAttr.toString().isBlank()) {

--- a/quarkus-app/src/test/java/com/scanales/homedir/security/CspHeaderTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/security/CspHeaderTest.java
@@ -54,6 +54,8 @@ public class CspHeaderTest {
     MatcherAssert.assertThat(cspHeader, containsString("img-src"));
     MatcherAssert.assertThat(cspHeader, containsString("https://cdn.simpleicons.org"));
     MatcherAssert.assertThat(cspHeader, containsString("https://avatars.githubusercontent.com"));
+    MatcherAssert.assertThat(cspHeader, containsString("https://lh3.googleusercontent.com"));
+    MatcherAssert.assertThat(cspHeader, containsString("https://cdn.discordapp.com"));
     MatcherAssert.assertThat(cspHeader, containsString("https://santiago.devopsdayschile.cl"));
   }
 


### PR DESCRIPTION
## Summary

Fixes user avatars not displaying in the site header and profile page. When an external avatar fails to load (network timeout, CSP block, 404), the `<img>` rendered a broken-image icon with no fallback.

This PR:

1. **Adds a graceful fallback** — both the header avatar (`fragments/header.html`) and the profile spotlight (`profile.html`) now always render the initial-based placeholder in the DOM, hidden only while the external avatar loads. A JS handler in `core-bundle.js` listens for `error` on `[data-hd-avatar-img]` elements, hides the broken `<img>` and reveals the placeholder (no broken image icons). Inline `onerror` is not used because CSP `script-src` has no `unsafe-inline`; the handler lives in the nonce-served `core-bundle.js`.

2. **Fixes CSP `img-src`** — `CspHeaderFilter.java` now allows `https://cdn.discordapp.com` (Discord avatars were blocked) and `https://lh3.googleusercontent.com` (Google OIDC `picture` claim — it was actually missing from the allow-list despite being documented as allowed in the issue).

## Linked Issue

Closes #1485

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## PR Risk Label (required — apply exactly one)

- [x] `pr:risk-high` — Security, breaking changes, data migration (modifies the CSP security header `img-src`)

## Self-Attestation Labels (apply all that apply)

- [x] `pr:traceability-ok` — `Closes #1485` present, issue exists with priority + type labels (`bug`, `priority:P2`)
- [x] `pr:acceptance-ok` — All acceptance criteria met: `onerror` fallback hides broken `<img>` and shows initial-based placeholder in header (24px) and profile (72px); `cdn.discordapp.com` (and `lh3.googleusercontent.com`) allowed in CSP; CSP test updated
- [x] `pr:tests-ok` — Tests added/updated: `CspHeaderTest` domain assertions + `ProfileResourceTest.profileAvatarRendersFallbackMarkup`
- [ ] `pr:i18n-ok` — N/A (no user-facing text added)

## Test Plan

- [x] Code compiles (`./mvnw test`)
- [x] Unit tests pass (`./mvnw test` — full suite: 146 test classes, 0 failures/errors)
- [x] Targeted tests pass (`./mvnw test -Dtest=CspHeaderTest,ProfileResourceTest`)
- [x] JS syntax check (`node --check core-bundle.js`)
- [ ] Manual verification performed — validate with GitHub-linked user, Discord-linked user, Google-only user, and on "Slow 3G"/offline
- [ ] i18n keys updated (EN + ES) if user-facing text added — N/A

## Breaking Changes

None

## Additional Notes

- The avatar fallback is a pure front-end enhancement; a full local avatar proxy/cache (like `SpeakerPhotoProxyService`) is intentionally deferred to a follow-up as noted in the issue.
- The issue's root-cause table stated `lh3.googleusercontent.com` was already in `img-src`, but it was not — this PR fixes that gap too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for avatar images hosted by Google and Discord.
  * Improved avatar fallback behavior when profile images fail to load.
  * Updated profile and account menus to display fallback avatars seamlessly.

* **Bug Fixes**
  * Prevented broken avatar images from leaving empty or missing visual elements.
  * Added coverage to verify avatar fallback rendering and supported image sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->