### PR TITLE
fix(ui): align grid card buttons and stretch event cards

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -5622,6 +5622,10 @@ footer {
   letter-spacing: 1px;
 }
 
+.home-priority-grid .home-priority-actions {
+  margin-top: auto;
+}
+
 .home-priority-spotlight {
   display: flex;
   flex-direction: column;

--- a/quarkus-app/src/main/resources/templates/EventsDirectoryResource/eventos.html
+++ b/quarkus-app/src/main/resources/templates/EventsDirectoryResource/eventos.html
@@ -133,21 +133,23 @@
       </div>
 
       <div class="event-countdown-panel">
-        <p class="event-countdown-label">{i18n:events_countdown_title}</p>
-        <strong class="event-countdown-value {#if event.ongoing}is-live{/if}">
-          {#if event.ongoing}{i18n:events_countdown_live_badge}{#else}{i18n:events_countdown_days_short(event.daysUntil)}{/if}
-        </strong>
-        <p class="event-countdown-caption">
-          {#if event.ongoing}
-          {i18n:events_countdown_live}
-          {#else if event.daysUntil == 0}
-          {i18n:events_countdown_today}
-          {#else if event.daysUntil == 1}
-          {i18n:events_countdown_tomorrow}
-          {#else}
-          {i18n:events_countdown_days(event.daysUntil)}
-          {/if}
-        </p>
+        <div class="event-countdown-info">
+          <p class="event-countdown-label">{i18n:events_countdown_title}</p>
+          <strong class="event-countdown-value {#if event.ongoing}is-live{/if}">
+            {#if event.ongoing}{i18n:events_countdown_live_badge}{#else}{i18n:events_countdown_days_short(event.daysUntil)}{/if}
+          </strong>
+          <p class="event-countdown-caption">
+            {#if event.ongoing}
+            {i18n:events_countdown_live}
+            {#else if event.daysUntil == 0}
+            {i18n:events_countdown_today}
+            {#else if event.daysUntil == 1}
+            {i18n:events_countdown_tomorrow}
+            {#else}
+            {i18n:events_countdown_days(event.daysUntil)}
+            {/if}
+          </p>
+        </div>
         <span class="btn btn--primary event-highlight-open">{i18n:btn_view_details}</span>
       </div>
     </a>
@@ -203,7 +205,7 @@
     display: grid;
     grid-template-columns: 92px minmax(0, 1fr) 160px;
     gap: 0.9rem;
-    align-items: center;
+    align-items: stretch;
     text-decoration: none;
     color: inherit;
     min-height: 172px;
@@ -222,6 +224,7 @@
     overflow: hidden;
     border: 2px solid rgba(255, 255, 255, 0.22);
     background: rgba(0, 0, 0, 0.25);
+    align-self: center;
   }
 
   .event-highlight-logo {
@@ -368,9 +371,13 @@
     border-left: 1px solid rgba(255, 255, 255, 0.18);
     padding-left: 0.75rem;
     min-height: 120px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .event-countdown-info {
+    margin: auto 0;
     display: grid;
-    align-content: center;
-    justify-items: start;
     gap: 0.15rem;
   }
 
@@ -399,7 +406,7 @@
   }
 
   .event-highlight-open {
-    margin-top: 0.4rem;
+    margin-top: auto;
     font-size: 0.74rem;
     padding: 0.28rem 0.54rem;
   }
@@ -487,6 +494,14 @@
       align-items: baseline;
       gap: 0.45rem;
       flex-wrap: wrap;
+    }
+
+    .event-countdown-info {
+      display: contents;
+    }
+
+    .event-highlight-open {
+      margin-top: 0.4rem;
     }
 
     .event-countdown-value {


### PR DESCRIPTION
## Summary

Fixes the systemic card grid misalignment: CTA buttons inside grid cards were not pinned to a consistent baseline when card content lengths varied. Two grids were misaligned; the other audited components already used the correct pattern.

Changes:
- **`.home-priority-grid` (home page)**: added `.home-priority-grid .home-priority-actions { margin-top: auto }` so both priority cards' CTA buttons align at the same bottom baseline. Scoped to the grid so the hero `.home-priority-actions` (which relies on `margin-top: 0.8rem`) is unaffected.
- **Event cards in `/eventos`**: changed `.event-highlight-card` to `align-items: stretch`, kept the logo box centered via `align-self: center`, made `.event-countdown-panel` a flex column and pinned `.event-highlight-open` to the bottom with `margin-top: auto`. The countdown label/value/caption were wrapped in `.event-countdown-info` with `margin: auto 0` so they stay vertically centered while the button is bottom-aligned. At `<=760px` the wrapper uses `display: contents` and the button keeps `margin-top: 0.4rem` to preserve the existing mobile layout exactly.

Audit results for the remaining components (no changes needed, already compliant):
- **Projects page cards**: `.project-hd-feature-card` / `.project-hd-capability-card` are flex columns with `.project-hd-link { margin-top: auto }` — already pinned.
- **Achievement cards**: `.achievement-guide { margin-top: auto }` in a flex column already pins the claim/verify buttons to the bottom.
- **Community page cards**: `.page-grid` is a single full-width shell; `.community-pulse` cards already stretch to equal height (grid default `align-items: stretch`).

## Linked Issue

Closes #1442

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Security fix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Platform/infrastructure change

## PR Risk Label (required — apply exactly one)

- [ ] `pr:risk-low` — Docs, typos, config tweaks (min 1 approval)
- [x] `pr:risk-medium` — Features, refactors, new dependencies (min 2 approvals, 1 code owner)
- [ ] `pr:risk-high` — Security, breaking changes, data migration (min 2 approvals, code owners + security)
- [ ] `pr:risk-critical` — Auth, encryption, financial, compliance (min 3 approvals, code owners + security)

## Self-Attestation Labels (apply all that apply)

- [x] `pr:traceability-ok` — `Closes #N` present, issue exists with priority + type labels
- [x] `pr:acceptance-ok` — All acceptance criteria from linked issue are met
- [ ] `pr:tests-ok` — Tests added/updated for new functionality
- [ ] `pr:i18n-ok` — i18n complete (EN + ES) for user-facing changes

## Test Plan

- [x] Code compiles (`./mvnw compile` or equivalent)
- [x] Unit tests pass (`./mvnw test`)
- [ ] E2E tests pass (if applicable)
- [x] Manual verification performed
- [ ] i18n keys updated (EN + ES) if user-facing text added

Relevant page-rendering tests pass with the changes:
`HomeTimelineTest` (10), `PublicExperienceSmokeTest` (3, fetches `/eventos` HTML), `HomePastEventsTest` (6), `HomeResourceRedirectTest` (5), `HomeMemberOnboardingTest` (1) — 0 failures.

## Breaking Changes

None

## Additional Notes

CSS-only change; no new dependencies, no i18n keys, no backend logic touched. Responsive breakpoints preserved for event cards at `<=760px` and `<=480px` (the `<=480px` block already re-lays out the countdown panel).