### PR TITLE
fix(css): truncate header logo subtitle gracefully on tablet/mobile (Closes #1489)

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -262,6 +262,7 @@ footer {
   display: flex;
   flex-direction: column;
   line-height: 1.2;
+  min-width: 0;
 }
 
 .hd-logo-title {
@@ -277,6 +278,11 @@ footer {
   font-size: 0.55rem;
   opacity: 0.8;
   letter-spacing: 2px;
+  min-width: 0;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .hd-main-nav {
@@ -6322,6 +6328,7 @@ footer {
 
 .header-left {
   flex: 1;
+  min-width: 0;
   display: flex;
   justify-content: flex-start;
 }

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -6333,6 +6333,11 @@ footer {
   justify-content: flex-start;
 }
 
+.header-logo-link {
+  min-width: 0;
+  max-width: 100%;
+}
+
 .nav-actions.header-center {
   flex: 2;
   display: flex;


### PR DESCRIPTION
Closes #1489

## Summary

On tablet/mobile viewports (<1024px) the header logo subtitle "Platform by OpenSourceSantiago" was spilling into adjacent header areas. Root cause: `.header-logo-link` (the flex wrapper around logo icon + text) defaulted to `min-width: auto`, so it refused to shrink below its content's intrinsic width (~300px). This broke the 3-column header: between 960–1024px it overlapped `.header-center` (nav links), and on mobile it pushed the top row out of layout.

## Solution

Complete the flex shrink chain started in #1488 by constraining the missing intermediate link:

```css
.header-logo-link {
  min-width: 0;      /* allow the logo text block to shrink */
  max-width: 100%;   /* never exceed the header-left column */
}
```

With this, the existing `white-space: nowrap; overflow: hidden; text-overflow: ellipsis` on `.logo-subtitle` actually engages on narrow viewports: the subtitle truncates with an ellipsis inside its own container and no longer overlaps `.header-center`. No HTML, JS, or i18n changes needed (no user-facing text added).

## Test Plan

- [ ] `cd quarkus-app && ./mvnw quarkus:dev`
- [ ] Browser devtools at 320px, 768px and 1000px widths
- [ ] Subtitle truncates with ellipsis inside `.header-left`, no overlap with `.header-center`
- [ ] Desktop >=1024px unaffected (layout unchanged)

## Note

This change builds on the truncation properties added in #1488 (not yet merged to `main`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved header layout behavior on narrow screens.
  * Long logo text, subtitles, and links now truncate cleanly with ellipses instead of overflowing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->