### PR TITLE
fix(a11y): ensure focus indicators meet WCAG AA contrast (3:1)

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/dev-login.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/dev-login.css
@@ -123,7 +123,8 @@ body.dev-login-page {
 }
 
 .dev-form-input:focus-visible {
-    outline: none;
+    outline: 2px solid #ffd700;
+    outline-offset: 2px;
     border-color: #ffd700;
     box-shadow: 0 0 10px rgba(255, 215, 0, 0.3);
     background: rgba(0, 0, 0, 0.5);

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -13,6 +13,21 @@
   box-sizing: border-box;
 }
 
+/* WCAG 2.4.7 / 1.4.11 — Global focus-visible baseline (3:1 contrast minimum).
+   Ensures every interactive element has a visible focus indicator for keyboard users.
+   Specific component styles below override this with tailored indicators. */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[tabindex]:focus-visible,
+summary:focus-visible {
+  outline: 2px solid var(--color-accent, #ffd700);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 .text-nowrap {
   white-space: nowrap;
 }
@@ -327,6 +342,13 @@ footer {
 .nav-link.nav-link-active {
   opacity: 1;
   border-bottom-color: var(--color-accent);
+}
+
+.hd-nav-link:focus-visible,
+.nav-link:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 .hd-user-area {
@@ -1037,12 +1059,14 @@ footer {
   border-color: rgba(var(--white-rgb), 0.16);
 }
 
-.homedir-main.admin-context-main .form-input:focus,
-.homedir-main.admin-context-main .form-select:focus,
-.homedir-main.admin-context-main .form-textarea:focus,
-.homedir-main.admin-context-main .hd-form-input:focus {
+.homedir-main.admin-context-main .form-input:focus-visible,
+.homedir-main.admin-context-main .form-select:focus-visible,
+.homedir-main.admin-context-main .form-textarea:focus-visible,
+.homedir-main.admin-context-main .hd-form-input:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
   border-color: rgba(255, 215, 0, 0.5);
-  box-shadow: 0 0 0 2px rgba(255, 215, 0, 0.14);
+  box-shadow: 0 0 0 2px rgba(255, 215, 0, 0.3);
 }
 
 .admin-shell-header {
@@ -2972,6 +2996,13 @@ footer {
   color: var(--color-text-main);
 }
 
+.dropdown-item:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  background: rgba(var(--white-rgb), 0.1);
+  color: var(--color-text-main);
+}
+
 .dropdown-item .material-symbols-outlined {
   font-size: 1.2rem;
   opacity: 0.8;
@@ -3380,8 +3411,9 @@ footer {
   font-family: inherit;
 }
 
-.hd-form-input:focus {
-  outline: 2px solid #a64bf4;
+.hd-form-input:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
   border-color: transparent;
 }
 
@@ -3418,6 +3450,11 @@ footer {
   background: rgba(var(--white-rgb), 0.2);
   color: var(--color-accent);
   transform: translateY(-2px);
+}
+
+.hd-tab:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 .hd-tab.active {
@@ -6481,6 +6518,8 @@ footer {
 }
 .skip-link:focus {
   top: 0;
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 /* Error pages */

--- a/quarkus-app/src/main/resources/META-INF/resources/css/retro-theme.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/retro-theme.css
@@ -4,11 +4,16 @@ body {
 
 a,
 a:hover,
-a:focus,
 a:active,
 a:visited {
   text-decoration: none;
   color: inherit;
+}
+
+a:focus-visible {
+  outline: 2px solid var(--color-accent, #ffd700);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 html,

--- a/tests/e2e/tests/focus-indicators-wcag.spec.ts
+++ b/tests/e2e/tests/focus-indicators-wcag.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * WCAG 2.4.7 / 1.4.11 — Focus indicator visibility tests.
+ *
+ * Verifies that all interactive elements have a visible focus indicator
+ * with sufficient contrast (3:1 minimum) when navigated via keyboard.
+ */
+test.describe('Focus indicators — WCAG AA compliance (#1459)', () => {
+  test('nav links have visible focus-visible outline', async ({ page }) => {
+    await page.goto('/');
+    // Tab to the first focusable element (skip link or nav link)
+    await page.keyboard.press('Tab');
+    // Keep tabbing until we hit a nav link
+    for (let i = 0; i < 10; i++) {
+      const focused = page.locator(':focus-visible');
+      const tag = await focused.evaluate((el) => el.tagName + '.' + (el.className || ''));
+      if (tag.includes('nav-link') || tag.includes('hd-nav-link')) break;
+      await page.keyboard.press('Tab');
+    }
+    const focused = page.locator(':focus-visible');
+    const outlineStyle = await focused.evaluate((el) => {
+      const cs = window.getComputedStyle(el);
+      return {
+        outlineWidth: cs.outlineWidth,
+        outlineStyle: cs.outlineStyle,
+        outlineColor: cs.outlineColor,
+      };
+    });
+    expect(outlineStyle.outlineStyle).not.toBe('none');
+    expect(outlineStyle.outlineWidth).not.toBe('0px');
+  });
+
+  test('skip-link has visible focus outline', async ({ page }) => {
+    await page.goto('/');
+    await page.keyboard.press('Tab');
+    const focused = page.locator(':focus-visible');
+    const isSkipLink = await focused.evaluate(
+      (el) => el.classList.contains('skip-link') || el.getAttribute('href') === '#main-content',
+    );
+    if (isSkipLink) {
+      const outline = await focused.evaluate((el) => {
+        const cs = window.getComputedStyle(el);
+        return { width: cs.outlineWidth, style: cs.outlineStyle };
+      });
+      expect(outline.style).not.toBe('none');
+    }
+  });
+
+  test('login button has visible focus-visible outline', async ({ page }) => {
+    await page.goto('/');
+    // Find the login button
+    const loginBtn = page.locator('.hd-login-btn, .login-btn-nav').first();
+    await loginBtn.focus();
+    const outline = await loginBtn.evaluate((el) => {
+      const cs = window.getComputedStyle(el);
+      return {
+        outlineWidth: cs.outlineWidth,
+        outlineStyle: cs.outlineStyle,
+        outlineColor: cs.outlineColor,
+      };
+    });
+    expect(outline.outlineStyle).not.toBe('none');
+    expect(outline.outlineWidth).not.toBe('0px');
+  });
+
+  test('locale select has visible focus-visible outline', async ({ page }) => {
+    await page.goto('/');
+    const localeSelect = page.locator('.header-locale-select').first();
+    if (await localeSelect.isVisible()) {
+      await localeSelect.focus();
+      const outline = await localeSelect.evaluate((el) => {
+        const cs = window.getComputedStyle(el);
+        return { width: cs.outlineWidth, style: cs.outlineStyle };
+      });
+      expect(outline.style).not.toBe('none');
+    }
+  });
+
+  test('dev login form inputs have visible focus outline', async ({ page }) => {
+    await page.goto('/login.html');
+    const emailInput = page.locator('.dev-form-input').first();
+    if (await emailInput.isVisible()) {
+      await emailInput.focus();
+      const outline = await emailInput.evaluate((el) => {
+        const cs = window.getComputedStyle(el);
+        return { width: cs.outlineWidth, style: cs.outlineStyle };
+      });
+      expect(outline.style).not.toBe('none');
+      expect(outline.width).not.toBe('0px');
+    }
+  });
+
+  test('no element removes outline completely (outline: none audit)', async ({ page }) => {
+    await page.goto('/');
+    // Check that the global focus-visible rule is applied
+    const hasGlobalFocusRule = await page.evaluate(() => {
+      const el = document.createElement('a');
+      document.body.appendChild(el);
+      el.focus();
+      // Force :focus-visible by adding tabindex and focusing
+      el.setAttribute('tabindex', '0');
+      el.focus();
+      const cs = window.getComputedStyle(el);
+      const hasOutline = cs.outlineStyle !== 'none' && cs.outlineWidth !== '0px';
+      el.remove();
+      return hasOutline;
+    });
+    expect(hasGlobalFocusRule).toBe(true);
+  });
+});

--- a/tests/e2e/tests/focus-indicators-wcag.spec.ts
+++ b/tests/e2e/tests/focus-indicators-wcag.spec.ts
@@ -1,111 +1,269 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * WCAG 2.4.7 / 1.4.11 — Focus indicator visibility tests.
+ * WCAG 2.4.7 / 1.4.11 — Focus indicator visibility and contrast tests.
  *
- * Verifies that all interactive elements have a visible focus indicator
- * with sufficient contrast (3:1 minimum) when navigated via keyboard.
+ * Verifies that interactive elements have a visible focus indicator with
+ * sufficient contrast (3:1 minimum) when navigated via keyboard.
  */
+
+/**
+ * Parse a CSS color string into RGB channels.
+ * Handles hex (#rrggbb, #rgb), rgb(), and rgba() formats.
+ * Returns null for named colors or unparseable values.
+ */
+function parseColor(color: string): [number, number, number] | null {
+  color = color.trim();
+  // hex #rrggbb
+  const hex6 = color.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i);
+  if (hex6) {
+    return [parseInt(hex6[1], 16), parseInt(hex6[2], 16), parseInt(hex6[3], 16)];
+  }
+  // hex #rgb
+  const hex3 = color.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/i);
+  if (hex3) {
+    return [
+      parseInt(hex3[1] + hex3[1], 16),
+      parseInt(hex3[2] + hex3[2], 16),
+      parseInt(hex3[3] + hex3[3], 16),
+    ];
+  }
+  // rgb(r, g, b) or rgba(r, g, b, a)
+  const rgbMatch = color.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+  if (rgbMatch) {
+    return [parseInt(rgbMatch[1]), parseInt(rgbMatch[2]), parseInt(rgbMatch[3])];
+  }
+  return null;
+}
+
+/**
+ * Calculate the relative luminance of an RGB color per WCAG 2.1.
+ * https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+ */
+function relativeLuminance(r: number, g: number, b: number): number {
+  const toLinear = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+}
+
+/**
+ * Calculate the contrast ratio between two RGB colors per WCAG 2.1.
+ * Returns a ratio between 1:1 and 21:1.
+ */
+function contrastRatio(
+  c1: [number, number, number],
+  c2: [number, number, number],
+): number {
+  const l1 = relativeLuminance(c1[0], c1[1], c1[2]);
+  const l2 = relativeLuminance(c2[0], c2[1], c2[2]);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
+ * Get the effective background color *behind* an element by walking up the DOM
+ * starting from the element's parent. This is the adjacent color against which
+ * an outline (drawn outside the border) is measured for contrast.
+ * Skips semi-transparent backgrounds (alpha < 0.9) to find a more opaque ancestor.
+ */
+async function getEffectiveBackground(
+  page: import('@playwright/test').Page,
+  selector: string,
+): Promise<[number, number, number]> {
+  return page.locator(selector).evaluate((el) => {
+    // Start from parent — the outline is drawn outside the element's border,
+    // so contrast is measured against what's behind/around the element.
+    let current: Element | null = el.parentElement;
+    while (current) {
+      const bg = window.getComputedStyle(current).backgroundColor;
+      if (bg && bg !== 'rgba(0, 0, 0, 0)' && bg !== 'transparent') {
+        // Extract alpha if present
+        const rgbaMatch = bg.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*([\d.]+))?\s*\)/);
+        if (rgbaMatch) {
+          const alpha = rgbaMatch[4] !== undefined ? parseFloat(rgbaMatch[4]) : 1.0;
+          // Only use this background if it's sufficiently opaque
+          if (alpha >= 0.9) {
+            return [parseInt(rgbaMatch[1]), parseInt(rgbaMatch[2]), parseInt(rgbaMatch[3])];
+          }
+        }
+      }
+      current = current.parentElement;
+    }
+    // Fallback: body background or black
+    const bodyBg = window.getComputedStyle(document.body).backgroundColor;
+    const m = bodyBg.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+    if (m) return [parseInt(m[1]), parseInt(m[2]), parseInt(m[3])];
+    return [0, 0, 0];
+  });
+}
+
+/**
+ * Assert that an element has a visible focus indicator with ≥ 3:1 contrast.
+ * Checks outline width, style, and contrast ratio against effective background.
+ */
+async function assertFocusIndicator(
+  page: import('@playwright/test').Page,
+  selector: string,
+  elementName: string,
+) {
+  const el = page.locator(selector);
+  const outline = await el.evaluate((node) => {
+    const cs = window.getComputedStyle(node);
+    return {
+      outlineWidth: cs.outlineWidth,
+      outlineStyle: cs.outlineStyle,
+      outlineColor: cs.outlineColor,
+    };
+  });
+
+  // 1. Outline must not be none or zero-width
+  expect(outline.outlineStyle, `${elementName}: outline style must not be none`).not.toBe('none');
+  expect(outline.outlineWidth, `${elementName}: outline width must not be 0px`).not.toBe('0px');
+
+  // 2. Calculate contrast ratio of outline color vs effective background
+  const outlineRgb = parseColor(outline.outlineColor);
+  const bgRgb = await getEffectiveBackground(page, selector);
+
+  if (outlineRgb) {
+    const ratio = contrastRatio(outlineRgb, bgRgb);
+    expect(
+      ratio,
+      `${elementName}: outline contrast ratio must be ≥ 3:1 (got ${ratio.toFixed(2)}:1)`,
+    ).toBeGreaterThanOrEqual(3.0);
+  }
+}
+
 test.describe('Focus indicators — WCAG AA compliance (#1459)', () => {
-  test('nav links have visible focus-visible outline', async ({ page }) => {
+  test('nav links have visible focus-visible outline with 3:1 contrast', async ({ page }) => {
     await page.goto('/');
-    // Tab to the first focusable element (skip link or nav link)
-    await page.keyboard.press('Tab');
-    // Keep tabbing until we hit a nav link
-    for (let i = 0; i < 10; i++) {
-      const focused = page.locator(':focus-visible');
-      const tag = await focused.evaluate((el) => el.tagName + '.' + (el.className || ''));
-      if (tag.includes('nav-link') || tag.includes('hd-nav-link')) break;
+    // Tab through focusable elements until we reach a nav link
+    let foundNav = false;
+    for (let i = 0; i < 15; i++) {
       await page.keyboard.press('Tab');
+      const focusedTag = await page.locator(':focus-visible').evaluate((el) => {
+        return el.tagName + ' ' + (el.className || '');
+      });
+      if (focusedTag.includes('nav-link') || focusedTag.includes('hd-nav-link')) {
+        foundNav = true;
+        break;
+      }
     }
-    const focused = page.locator(':focus-visible');
-    const outlineStyle = await focused.evaluate((el) => {
-      const cs = window.getComputedStyle(el);
-      return {
-        outlineWidth: cs.outlineWidth,
-        outlineStyle: cs.outlineStyle,
-        outlineColor: cs.outlineColor,
-      };
-    });
-    expect(outlineStyle.outlineStyle).not.toBe('none');
-    expect(outlineStyle.outlineWidth).not.toBe('0px');
+    expect(foundNav, 'Should reach a nav link via keyboard Tab').toBe(true);
+    await assertFocusIndicator(page, ':focus-visible', 'nav link');
   });
 
-  test('skip-link has visible focus outline', async ({ page }) => {
+  test('skip-link has visible focus outline with 3:1 contrast', async ({ page }) => {
     await page.goto('/');
     await page.keyboard.press('Tab');
-    const focused = page.locator(':focus-visible');
-    const isSkipLink = await focused.evaluate(
-      (el) => el.classList.contains('skip-link') || el.getAttribute('href') === '#main-content',
-    );
-    if (isSkipLink) {
-      const outline = await focused.evaluate((el) => {
-        const cs = window.getComputedStyle(el);
-        return { width: cs.outlineWidth, style: cs.outlineStyle };
-      });
-      expect(outline.style).not.toBe('none');
-    }
+    const focusedInfo = await page.locator(':focus-visible').evaluate((el) => ({
+      isSkipLink: el.classList.contains('skip-link') || el.getAttribute('href') === '#main-content',
+      className: el.className,
+    }));
+    expect(focusedInfo.isSkipLink, 'First Tab target should be the skip-link').toBe(true);
+    await assertFocusIndicator(page, ':focus-visible', 'skip-link');
   });
 
-  test('login button has visible focus-visible outline', async ({ page }) => {
+  test('login button has visible focus-visible outline with 3:1 contrast', async ({ page }) => {
     await page.goto('/');
-    // Find the login button
     const loginBtn = page.locator('.hd-login-btn, .login-btn-nav').first();
+    await expect(loginBtn).toBeVisible();
     await loginBtn.focus();
-    const outline = await loginBtn.evaluate((el) => {
-      const cs = window.getComputedStyle(el);
-      return {
-        outlineWidth: cs.outlineWidth,
-        outlineStyle: cs.outlineStyle,
-        outlineColor: cs.outlineColor,
-      };
-    });
-    expect(outline.outlineStyle).not.toBe('none');
-    expect(outline.outlineWidth).not.toBe('0px');
+    await assertFocusIndicator(page, '.hd-login-btn, .login-btn-nav', 'login button');
   });
 
-  test('locale select has visible focus-visible outline', async ({ page }) => {
+  test('locale select has visible focus-visible outline with 3:1 contrast', async ({ page }) => {
     await page.goto('/');
     const localeSelect = page.locator('.header-locale-select').first();
-    if (await localeSelect.isVisible()) {
-      await localeSelect.focus();
-      const outline = await localeSelect.evaluate((el) => {
-        const cs = window.getComputedStyle(el);
-        return { width: cs.outlineWidth, style: cs.outlineStyle };
-      });
-      expect(outline.style).not.toBe('none');
-    }
+    await expect(localeSelect).toBeVisible();
+    await localeSelect.focus();
+    await assertFocusIndicator(page, '.header-locale-select', 'locale select');
   });
 
-  test('dev login form inputs have visible focus outline', async ({ page }) => {
+  test('dev login form inputs have visible focus outline with 3:1 contrast', async ({ page }) => {
     await page.goto('/login.html');
     const emailInput = page.locator('.dev-form-input').first();
-    if (await emailInput.isVisible()) {
-      await emailInput.focus();
-      const outline = await emailInput.evaluate((el) => {
-        const cs = window.getComputedStyle(el);
-        return { width: cs.outlineWidth, style: cs.outlineStyle };
+    await expect(emailInput).toBeVisible();
+    await emailInput.focus();
+    // Use nth(0) to avoid strict mode violation (there are 2 .dev-form-input elements)
+    const outline = await emailInput.evaluate((node) => {
+      const cs = window.getComputedStyle(node);
+      return {
+        outlineWidth: cs.outlineWidth,
+        outlineStyle: cs.outlineStyle,
+        outlineColor: cs.outlineColor,
+      };
+    });
+    expect(outline.outlineStyle, 'dev login input: outline style must not be none').not.toBe('none');
+    expect(outline.outlineWidth, 'dev login input: outline width must not be 0px').not.toBe('0px');
+    // Dev login page has its own dark background — verify contrast
+    const outlineRgb = parseColor(outline.outlineColor);
+    if (outlineRgb) {
+      const bgRgb = await page.locator('.dev-form-input').first().evaluate((el) => {
+        let current: Element | null = el.parentElement;
+        while (current) {
+          const bg = window.getComputedStyle(current).backgroundColor;
+          if (bg && bg !== 'rgba(0, 0, 0, 0)' && bg !== 'transparent') {
+            const rgbaMatch = bg.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*([\d.]+))?\s*\)/);
+            if (rgbaMatch) {
+              const alpha = rgbaMatch[4] !== undefined ? parseFloat(rgbaMatch[4]) : 1.0;
+              if (alpha >= 0.9) {
+                return [parseInt(rgbaMatch[1]), parseInt(rgbaMatch[2]), parseInt(rgbaMatch[3])];
+              }
+            }
+          }
+          current = current.parentElement;
+        }
+        return [0, 0, 0];
       });
-      expect(outline.style).not.toBe('none');
-      expect(outline.width).not.toBe('0px');
+      const ratio = contrastRatio(outlineRgb, bgRgb);
+      expect(
+        ratio,
+        `dev login input: outline contrast ratio must be ≥ 3:1 (got ${ratio.toFixed(2)}:1)`,
+      ).toBeGreaterThanOrEqual(3.0);
     }
   });
 
-  test('no element removes outline completely (outline: none audit)', async ({ page }) => {
+  test('global :focus-visible audit on rendered interactive elements', async ({ page }) => {
     await page.goto('/');
-    // Check that the global focus-visible rule is applied
-    const hasGlobalFocusRule = await page.evaluate(() => {
-      const el = document.createElement('a');
-      document.body.appendChild(el);
-      el.focus();
-      // Force :focus-visible by adding tabindex and focusing
-      el.setAttribute('tabindex', '0');
-      el.focus();
-      const cs = window.getComputedStyle(el);
-      const hasOutline = cs.outlineStyle !== 'none' && cs.outlineWidth !== '0px';
-      el.remove();
-      return hasOutline;
-    });
-    expect(hasGlobalFocusRule).toBe(true);
+    // Audit rendered interactive elements on the page, not a detached anchor
+    const interactiveSelectors = [
+      'a[href]',
+      'button',
+      'input',
+      'select',
+      'textarea',
+      '[tabindex]',
+    ];
+    for (const selector of interactiveSelectors) {
+      const elements = page.locator(selector);
+      const count = await elements.count();
+      for (let i = 0; i < Math.min(count, 5); i++) {
+        const el = elements.nth(i);
+        if (!(await el.isVisible())) continue;
+        await el.focus();
+        const outline = await el.evaluate((node) => {
+          const cs = window.getComputedStyle(node);
+          return {
+            outlineWidth: cs.outlineWidth,
+            outlineStyle: cs.outlineStyle,
+            outlineColor: cs.outlineColor,
+            tag: node.tagName,
+            className: node.className || '',
+          };
+        });
+        // Every visible interactive element must have a non-none outline
+        expect(
+          outline.outlineStyle,
+          `${outline.tag}.${outline.className}: outline must not be none`,
+        ).not.toBe('none');
+        expect(
+          outline.outlineWidth,
+          `${outline.tag}.${outline.className}: outline width must not be 0px`,
+        ).not.toBe('0px');
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Add global `:focus-visible` baseline for all interactive elements (`a`, `button`, `input`, `select`, `textarea`, `[tabindex]`, `summary`) using `2px solid var(--color-accent)` outline with `2px` offset — ensures 3:1 contrast against dark backgrounds per WCAG 1.4.11
- Fix `.hd-form-input:focus` → `:focus-visible` with `outline-offset` and consistent `var(--color-accent)` color (was `#a64bf4` with no offset)
- Fix admin form inputs — add explicit outline, raise box-shadow opacity from 0.14 to 0.3 for sufficient contrast
- Fix `.skip-link:focus` — add outline (was position-only change)
- Add `:focus-visible` to nav links, dropdown items, and tabs (previously only `:hover`)
- Fix `retro-theme.css` `a:focus` → `a:focus-visible` with visible outline (was `text-decoration:none` only, actively removing any focus indicator)
- Fix `dev-login.css` `.dev-form-input:focus-visible` — replace `outline:none` with `2px solid #ffd700` outline (was relying on low-opacity box-shadow only)
- Add Playwright E2E tests verifying focus indicator visibility across key interactive elements

Closes #1459

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Security fix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Platform/infrastructure change

## PR Risk Label (required — apply exactly one)

- [x] `pr:risk-low` — CSS-only accessibility fix, no logic changes
- [ ] `pr:risk-medium` — Features, refactors, new dependencies (min 2 approvals, 1 code owner)
- [ ] `pr:risk-high` — Security, breaking changes, data migration (min 2 approvals, code owners + security)
- [ ] `pr:risk-critical` — Auth, encryption, financial, compliance (min 3 approvals, code owners + security)

## Self-Attestation Labels (apply all that apply)

- [x] `pr:traceability-ok` — `Closes #1459` present, issue exists with priority + type labels
- [x] `pr:acceptance-ok` — Focus indicators have sufficient contrast (acceptance criteria met)
- [x] `pr:tests-ok` — Playwright E2E tests added (6 new tests, all passing)
- [ ] `pr:i18n-ok` — No user-facing text changes (CSS-only)

## Test Plan

- [x] Code compiles (`./mvnw compile`)
- [x] Playwright E2E tests pass (6 new + 10 existing = 16/16 green)
- [x] Manual verification: focus indicators visible on nav links, login button, locale select, skip-link, dev login inputs
- [x] Global `:focus-visible` audit: no `outline: none` remaining on interactive elements

## Changes by file

| File | Change |
|------|--------|
| `homedir.css` | Global `:focus-visible` baseline + fixes for `.hd-form-input`, admin forms, `.skip-link`, nav links, dropdown items, tabs |
| `retro-theme.css` | `a:focus` → `a:focus-visible` with visible outline |
| `dev-login.css` | Replace `outline: none` with `2px solid #ffd700` |
| `tests/e2e/tests/focus-indicators-wcag.spec.ts` | New Playwright E2E tests (6 cases) |

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard focus indicators across navigation, links, forms, tabs, dropdowns, skip links, and login controls.
  * Added clearer accent-colored focus outlines with improved spacing and visibility.
  * Updated focus behavior to show indicators when navigating by keyboard, without adding unnecessary outlines during pointer interaction.

* **Tests**
  * Added end-to-end coverage verifying visible, non-zero focus indicators across key interface controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->