### PR TITLE
docs(agents): document SCC autonomous SDLC automation in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,14 @@ This guide helps AI agents (like Claude Code, Devin, etc.) understand how to col
 - **License**: Apache 2.0
 - **Philosophy**: Educational, community-driven, open source
 
+### SCC (Autonomous SDLC Automation)
+
+**SCC** is an autonomous SDLC automation owned and maintained by `scanalesespinoza` (Sergio Canales). It drives the autonomous issue → PR → merge pipeline for Homedir.
+
+- **Do NOT modify, remove, or break** SCC scripts, workflows, labels (`scc-*`), or related automation unless it is **100% necessary** and explicitly approved by Sergio.
+- SCC-related files include (non-exhaustive): `platform/scripts/pipeline-orchestrator.sh`, `platform/scripts/homedir-github-webhook.py`, `scripts/ci/label_pr_state.py`, `platform/scripts/split-multi-criteria-issue.sh`, `tests/test_webhook_validation.py`, and the `scc-*` labels on issues/PRs.
+- When in doubt about whether a change affects SCC, leave it alone and escalate to Sergio.
+
 ## Labels Guide for AI Agents
 
 Understanding and using labels correctly is crucial for effective contribution. Here's the complete label system:


### PR DESCRIPTION
## Summary
- Adds a dedicated "SCC (Autonomous SDLC Automation)" subsection to `AGENTS.md` under Project Context.
- Documents that SCC is owned and maintained by `scanalesespinoza` (Sergio Canales) and must not be modified, removed, or broken unless explicitly approved by Sergio.
- Lists the key SCC-related files and `scc-*` labels so future AI agent sessions can identify and avoid unintended disruption of the autonomous SDLC pipeline.

Closes #1515

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Security fix
- [ ] Breaking change
- [ ] Platform/infrastructure change

## PR Risk Label
- [x] `pr:risk-low` — Docs, typos, config tweaks (min 1 approval)
- [ ] `pr:risk-medium` — Features, refactors, new dependencies
- [ ] `pr:risk-high` — Security, breaking changes, data migration
- [ ] `pr:risk-critical` — Auth, encryption, financial, compliance

## Self-Attestation Labels
- [x] `pr:traceability-ok` — `Closes #1515` present, issue exists with priority + type labels
- [x] `pr:acceptance-ok` — All acceptance criteria from #1515 are met
- [ ] `pr:tests-ok` — N/A (documentation-only change, no new functionality)
- [ ] `pr:i18n-ok` — N/A (no user-facing text added)

## Test Plan
- [x] `grep -A6 "### SCC (Autonomous SDLC Automation)" AGENTS.md` shows the new section
- [x] No code or tests affected (docs-only)
- [x] Branch naming follows convention: `docs/...`

Generated with [Devin](https://devin.ai)