### PR TITLE
feat(projects): move Top Contributors section above Delivery Velocity for visibility

### DIFF
--- a/quarkus-app/src/main/resources/templates/ProjectsResource/proyectos.html
+++ b/quarkus-app/src/main/resources/templates/ProjectsResource/proyectos.html
@@ -64,6 +64,28 @@
   </article>
 </section>
 
+<section class="page-grid">
+  <div class="section-header project-hd-full">
+    <p class="section-subtitle">{i18n:project_dashboard_team_subtitle}</p>
+    <h2 class="page-title">{i18n:project_dashboard_team_title}</h2>
+  </div>
+  <article class="section-card project-hd-contributors-card project-hd-full">
+    {#if dashboard.topContributors.isEmpty()}
+    <p class="project-hd-empty">{i18n:project_dashboard_empty_contributors}</p>
+    {#else}
+    <div class="project-hd-contributors-grid">
+      {#for c in dashboard.topContributors}
+      <a href="{c.htmlUrl}" target="_blank" rel="noopener" class="project-hd-contributor-item" title="{c.login}">
+        <img src="{c.avatarUrl}" alt="{c.login}">
+        <strong>{c.login}</strong>
+        <small>{c.contributions} {i18n:project_dashboard_contribs_unit}</small>
+      </a>
+      {/for}
+    </div>
+    {/if}
+  </article>
+</section>
+
 <section class="page-grid project-hd-panorama-grid">
   <article class="section-card project-hd-progress-card">
     <div class="project-hd-progress-head">
@@ -183,28 +205,6 @@
     </a>
   </article>
   {/for}
-</section>
-
-<section class="page-grid">
-  <div class="section-header project-hd-full">
-    <p class="section-subtitle">{i18n:project_dashboard_team_subtitle}</p>
-    <h2 class="page-title">{i18n:project_dashboard_team_title}</h2>
-  </div>
-  <article class="section-card project-hd-contributors-card project-hd-full">
-    {#if dashboard.topContributors.isEmpty()}
-    <p class="project-hd-empty">{i18n:project_dashboard_empty_contributors}</p>
-    {#else}
-    <div class="project-hd-contributors-grid">
-      {#for c in dashboard.topContributors}
-      <a href="{c.htmlUrl}" target="_blank" rel="noopener" class="project-hd-contributor-item" title="{c.login}">
-        <img src="{c.avatarUrl}" alt="{c.login}">
-        <strong>{c.login}</strong>
-        <small>{c.contributions} {i18n:project_dashboard_contribs_unit}</small>
-      </a>
-      {/for}
-    </div>
-    {/if}
-  </article>
 </section>
 
 <style>

--- a/quarkus-app/src/test/java/com/scanales/homedir/public_/ProjectsResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/public_/ProjectsResourceTest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -65,5 +66,25 @@ public class ProjectsResourceTest {
         .then()
         .statusCode(303)
         .header("Location", endsWith("/proyectos"));
+  }
+
+  @Test
+  public void topContributorsSectionRendersBeforeDeliveryVelocity() {
+    String html =
+        given()
+            .accept("text/html")
+            .when()
+            .get("/proyectos")
+            .then()
+            .statusCode(200)
+            .extract()
+            .asString();
+    int contributorsIndex = html.indexOf("project-hd-contributors-card");
+    int velocityIndex = html.indexOf("project-hd-velocity-grid");
+    assertTrue(contributorsIndex >= 0, "Top Contributors section should be rendered");
+    assertTrue(velocityIndex >= 0, "Delivery Velocity section should be rendered");
+    assertTrue(
+        contributorsIndex < velocityIndex,
+        "Top Contributors section should appear before Delivery Velocity");
   }
 }


### PR DESCRIPTION
## Summary

Moves the **Top Contributors** section on the Projects page (`/proyectos`) from the bottom of the page to a prominent position right after the Metrics grid and before the Progress + Releases panorama, as requested in the linked issue to increase contributor visibility and recognition.

New section order:

1. Hero header
2. Metrics grid
3. Top Contributors (moved here)
4. Progress + Releases panorama
5. Delivery Velocity
6. Features grid
7. Capabilities grid

No markup, styles, i18n keys, or Java code were modified beyond reordering the existing section block.

## Linked Issue

Closes #1463

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Security fix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Platform/infrastructure change

## PR Risk Label (required — apply exactly one)

- [x] `pr:risk-low` — UI layout reorder, no logic or data changes (min 1 approval)
- [ ] `pr:risk-medium` — Features, refactors, new dependencies (min 2 approvals, 1 code owner)
- [ ] `pr:risk-high` — Security, breaking changes, data migration (min 2 approvals, code owners + security)
- [ ] `pr:risk-critical` — Auth, encryption, financial, compliance (min 3 approvals, code owners + security)

## Self-Attestation Labels (apply all that apply)

- [x] `pr:traceability-ok` — `Closes #1463` present, issue exists with priority (`priority:P2`) + type (`enhancement`) labels
- [x] `pr:acceptance-ok` — Section moved above Delivery Velocity / right after the metrics grid as specified in the issue
- [x] `pr:tests-ok` — Added `topContributorsSectionRendersBeforeDeliveryVelocity` test asserting render order
- [x] `pr:i18n-ok` — No user-facing text added; existing EN + ES keys are reused unchanged

## Test Plan

- [x] Code compiles (`./mvnw compile` via test run)
- [x] Unit tests pass: `./mvnw test -Dtest=ProjectsResourceTest` → `Tests run: 4, Failures: 0, Errors: 0`
- [ ] E2E tests pass (if applicable)
- [x] Manual verification performed (template inspection confirms new order)
- [x] i18n keys updated (EN + ES) if user-facing text added → N/A, no text changes

## Breaking Changes

None

## Additional Notes

The change is a pure block move inside `ProjectsResource/proyectos.html`; the contributors card keeps its original classes (`project-hd-contributors-card`, `project-hd-full`) so all existing responsive styles apply without modification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reordered the project page sections so Top Contributors now appears immediately after project metrics and before Delivery Velocity.
  * Preserved existing contributor links and empty-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->