### PR TITLE
test: fix AdminViewAccessTest after campaigns removal

### DIFF
--- a/quarkus-app/src/test/java/com/scanales/homedir/admin/AdminViewAccessTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/admin/AdminViewAccessTest.java
@@ -15,19 +15,7 @@ public class AdminViewAccessTest {
   @Test
   @TestSecurity(user = "viewer@example.org")
   public void viewerCanOpenReadOnlyBackofficePages() {
-    given()
-        .when()
-        .get("/private/admin")
-        .then()
-        .statusCode(200)
-        .body(containsString("/private/admin/campaigns"));
-
-    given()
-        .when()
-        .get("/private/admin/campaigns")
-        .then()
-        .statusCode(200)
-        .body(containsString("id=\"campaignsProcessNav\""));
+    given().when().get("/private/admin").then().statusCode(200);
 
     given().when().get("/private/admin/events/new").then().statusCode(200);
 
@@ -63,15 +51,6 @@ public class AdminViewAccessTest {
   @Test
   @TestSecurity(user = "viewer@example.org")
   public void viewerCannotRunBackofficeMutations() {
-    given()
-        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-        .formParam("action", "approve")
-        .formParam("draftIds", "draft-1")
-        .when()
-        .post("/private/admin/campaigns/bulk-action")
-        .then()
-        .statusCode(403);
-
     given()
         .contentType(MediaType.APPLICATION_JSON)
         .body(

--- a/quarkus-app/src/test/java/com/scanales/homedir/admin/AdminViewAccessTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/admin/AdminViewAccessTest.java
@@ -1,7 +1,6 @@
 package com.scanales.homedir.admin;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.containsString;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;


### PR DESCRIPTION
## Fix Test Failures

The previous PR #1534 removed the campaigns module but didn't update all test assertions.

### Changes
- Remove assertions expecting /private/admin/campaigns link in admin hub
- Remove test accessing /private/admin/campaigns page  
- Remove test for campaigns bulk-action endpoint

### Test Results
```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```

### Related
- Fixes test failures in PR #1534
- Follow-up to campaigns module retirement

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated access-control coverage for viewer permissions.
  * Retained checks for allowed and restricted actions involving insights initiatives, speaker talks, and error resolution.
  * Removed outdated campaign navigation and bulk-action checks.
  * Improved test coverage accuracy so permission checks better reflect current viewer access behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->