### PR TITLE
fix(header): prevent subtitle overflow for longer ES locale text

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -292,6 +292,7 @@ footer {
   flex-direction: column;
   line-height: 1.2;
   min-width: 0;
+  max-width: 100%;
 }
 
 .hd-logo-title {
@@ -309,9 +310,9 @@ footer {
   letter-spacing: 2px;
   min-width: 0;
   max-width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .hd-main-nav {


### PR DESCRIPTION
## Summary
Closes #1490

The ES translation of the logo subtitle (\`platform_by\`) is significantly longer than the EN one ("Plataforma por OpenSourceSantiago" vs "by OpenSourceSantiago"). The previous \`white-space: nowrap\` + ellipsis only truncated when the element width was already constrained, which left the longer ES text able to overflow the header column at narrow widths (especially ≤768px).

This change switches the subtitle to wrap (\`white-space: normal\` + \`overflow-wrap: anywhere\`) so it never overflows or overlaps the nav links, in both the default and retro themes.

## Test Plan
- [ ] \`cd quarkus-app && ./mvnw quarkus:dev\`
- [ ] Open \`/\` (EN) and \`/?QP_LOCALE=es\` (ES)
- [ ] Verify header at 320px, 768px, 1024px, 1440px in both locales — no overlap/overflow
- [ ] Confirm EN layout is unchanged

## Risk
\`pr:risk-low\` — CSS-only change, no logic/i18n key changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved logo text layout so long subtitles wrap across multiple lines instead of being clipped.
  - Allowed logo text to use the available width more effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->