### PR TITLE
fix: consolidate duplicate locale resolution and support path/param locale

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/config/LocaleResponseFilter.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/config/LocaleResponseFilter.java
@@ -2,23 +2,18 @@ package com.scanales.homedir.config;
 
 import com.scanales.homedir.service.UserProfileService;
 import com.scanales.homedir.util.AdminUtils;
+import com.scanales.homedir.util.LocaleResolver;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;
-import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.ext.Provider;
 import java.util.Locale;
-import java.util.Set;
 import org.jboss.resteasy.reactive.server.ServerResponseFilter;
 
 @Provider
 public class LocaleResponseFilter {
-
-  private static final String COOKIE_NAME = "QP_LOCALE";
-  private static final Set<String> SUPPORTED_LANGS = Set.of("en", "es");
-  private static final String DEFAULT_LANG = "en";
 
   @Inject SecurityIdentity identity;
 
@@ -38,23 +33,11 @@ public class LocaleResponseFilter {
 
   private String resolveLocaleCode(ContainerRequestContext requestContext) {
     String profileLang = normalizeLang(resolveProfileLocale());
-    if (profileLang != null) {
-      return profileLang;
-    }
-
-    Cookie localeCookie = requestContext.getCookies().get(COOKIE_NAME);
-    String cookieLang = normalizeLang(localeCookie != null ? localeCookie.getValue() : null);
-    if (cookieLang != null) {
-      return cookieLang;
-    }
-
-    for (Locale locale : requestContext.getAcceptableLanguages()) {
-      String headerLang = normalizeLang(locale != null ? locale.getLanguage() : null);
-      if (headerLang != null) {
-        return headerLang;
-      }
-    }
-    return DEFAULT_LANG;
+    String cookieLang = LocaleResolver.cookieFromRequest(requestContext);
+    String pathLang = LocaleResolver.pathFromRequest(requestContext);
+    String paramLang = LocaleResolver.paramFromRequest(requestContext);
+    return LocaleResolver.resolve(profileLang, paramLang, pathLang, cookieLang,
+        requestContext.getAcceptableLanguages());
   }
 
   private String resolveProfileLocale() {
@@ -75,13 +58,6 @@ public class LocaleResponseFilter {
   }
 
   private String normalizeLang(String language) {
-    if (language == null || language.isBlank()) {
-      return null;
-    }
-    String normalized = language.trim().toLowerCase(Locale.ROOT);
-    if (normalized.contains("-")) {
-      normalized = normalized.substring(0, normalized.indexOf('-'));
-    }
-    return SUPPORTED_LANGS.contains(normalized) ? normalized : null;
+    return LocaleResolver.normalizeOrNull(language);
   }
 }

--- a/quarkus-app/src/main/java/com/scanales/homedir/config/LocaleResponseFilter.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/config/LocaleResponseFilter.java
@@ -36,8 +36,8 @@ public class LocaleResponseFilter {
     String cookieLang = LocaleResolver.cookieFromRequest(requestContext);
     String pathLang = LocaleResolver.pathFromRequest(requestContext);
     String paramLang = LocaleResolver.paramFromRequest(requestContext);
-    return LocaleResolver.resolve(profileLang, paramLang, pathLang, cookieLang,
-        requestContext.getAcceptableLanguages());
+    return LocaleResolver.resolve(
+        profileLang, paramLang, pathLang, cookieLang, requestContext.getAcceptableLanguages());
   }
 
   private String resolveProfileLocale() {

--- a/quarkus-app/src/main/java/com/scanales/homedir/util/LocaleResolver.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/util/LocaleResolver.java
@@ -2,8 +2,8 @@ package com.scanales.homedir.util;
 
 import com.scanales.homedir.service.UserProfileService;
 import io.quarkus.arc.Arc;
-import io.vertx.ext.web.RoutingContext;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.vertx.ext.web.RoutingContext;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -14,18 +14,19 @@ import java.util.Set;
 /**
  * Single source of truth for resolving the active UI locale.
  *
- * <p>Replaces the previously duplicated logic in {@link TemplateLocaleUtil} and
- * {@code LocaleResponseFilter}. Both must now resolve through this class so they
- * can never disagree (see epic #1267 — "duplicate locale resolution").
+ * <p>Replaces the previously duplicated logic in {@link TemplateLocaleUtil} and {@code
+ * LocaleResponseFilter}. Both must now resolve through this class so they can never disagree (see
+ * epic #1267 — "duplicate locale resolution").
  *
  * <p>Precedence (highest first):
+ *
  * <ol>
- *   <li>explicit request parameter {@code ?lang=}</li>
- *   <li>URL path prefix {@code /en/} or {@code /es/}</li>
- *   <li>authenticated user profile preference</li>
- *   <li>the {@code QP_LOCALE} cookie</li>
- *   <li>the {@code Accept-Language} header</li>
- *   <li>default locale {@code en}</li>
+ *   <li>explicit request parameter {@code ?lang=}
+ *   <li>URL path prefix {@code /en/} or {@code /es/}
+ *   <li>authenticated user profile preference
+ *   <li>the {@code QP_LOCALE} cookie
+ *   <li>the {@code Accept-Language} header
+ *   <li>default locale {@code en}
  * </ol>
  */
 public final class LocaleResolver {

--- a/quarkus-app/src/main/java/com/scanales/homedir/util/LocaleResolver.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/util/LocaleResolver.java
@@ -1,0 +1,228 @@
+package com.scanales.homedir.util;
+
+import com.scanales.homedir.service.UserProfileService;
+import io.quarkus.arc.Arc;
+import io.vertx.ext.web.RoutingContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.HttpHeaders;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Single source of truth for resolving the active UI locale.
+ *
+ * <p>Replaces the previously duplicated logic in {@link TemplateLocaleUtil} and
+ * {@code LocaleResponseFilter}. Both must now resolve through this class so they
+ * can never disagree (see epic #1267 — "duplicate locale resolution").
+ *
+ * <p>Precedence (highest first):
+ * <ol>
+ *   <li>explicit request parameter {@code ?lang=}</li>
+ *   <li>URL path prefix {@code /en/} or {@code /es/}</li>
+ *   <li>authenticated user profile preference</li>
+ *   <li>the {@code QP_LOCALE} cookie</li>
+ *   <li>the {@code Accept-Language} header</li>
+ *   <li>default locale {@code en}</li>
+ * </ol>
+ */
+public final class LocaleResolver {
+
+  public static final Set<String> SUPPORTED_LANGS = Set.of("en", "es");
+  public static final String DEFAULT_LANG = "en";
+  public static final String COOKIE_NAME = "QP_LOCALE";
+  public static final String PARAM_NAME = "lang";
+
+  private LocaleResolver() {}
+
+  public static String resolve(
+      String profileLocale,
+      String explicitParam,
+      String pathLocale,
+      String cookieLocale,
+      List<Locale> acceptableLanguages) {
+    String normalized = normalizeOrNull(explicitParam);
+    if (normalized != null) {
+      return normalized;
+    }
+    normalized = normalizeOrNull(pathLocale);
+    if (normalized != null) {
+      return normalized;
+    }
+    normalized = normalizeOrNull(profileLocale);
+    if (normalized != null) {
+      return normalized;
+    }
+    normalized = normalizeOrNull(cookieLocale);
+    if (normalized != null) {
+      return normalized;
+    }
+    normalized = normalizeFromAcceptable(acceptableLanguages);
+    if (normalized != null) {
+      return normalized;
+    }
+    return DEFAULT_LANG;
+  }
+
+  /** Resolve using the request-scoped context (profile, path and param come from Arc). */
+  public static String resolveFromCookie(String cookieLocale, HttpHeaders headers) {
+    return resolve(
+        resolveProfileLocale(),
+        resolveParamLocale(),
+        resolvePathLocale(),
+        cookieLocale,
+        headers != null ? headers.getAcceptableLanguages() : List.of());
+  }
+
+  public static String resolveFromRequest(ContainerRequestContext requestContext) {
+    return resolve(
+        resolveProfileLocale(),
+        paramFromRequest(requestContext),
+        pathFromRequest(requestContext),
+        cookieFromRequest(requestContext),
+        requestContext.getAcceptableLanguages());
+  }
+
+  public static String resolveProfileLocale() {
+    try {
+      SecurityIdentity identity = Arc.container().instance(SecurityIdentity.class).get();
+      if (identity == null || identity.isAnonymous()) {
+        return null;
+      }
+      String userId = AdminUtils.getClaim(identity, "email");
+      if (userId == null || userId.isBlank()) {
+        userId = identity.getPrincipal() != null ? identity.getPrincipal().getName() : null;
+      }
+      if (userId == null || userId.isBlank()) {
+        return null;
+      }
+      UserProfileService userProfiles = Arc.container().instance(UserProfileService.class).get();
+      if (userProfiles == null) {
+        return null;
+      }
+      return userProfiles
+          .find(userId.toLowerCase(Locale.ROOT))
+          .map(com.scanales.homedir.model.UserProfile::getPreferredLocale)
+          .orElse(null);
+    } catch (Exception ignored) {
+      return null;
+    }
+  }
+
+  public static String resolveCookieLocale() {
+    return cookieFromArc();
+  }
+
+  public static String resolvePathLocale() {
+    return pathFromArc();
+  }
+
+  public static String resolveParamLocale() {
+    return paramFromArc();
+  }
+
+  public static String cookieFromRequest(ContainerRequestContext requestContext) {
+    if (requestContext == null) {
+      return null;
+    }
+    Cookie cookie = requestContext.getCookies().get(COOKIE_NAME);
+    return cookie != null ? cookie.getValue() : null;
+  }
+
+  public static String pathFromRequest(ContainerRequestContext requestContext) {
+    if (requestContext == null) {
+      return null;
+    }
+    return pathFromPath(requestContext.getUriInfo().getPath());
+  }
+
+  public static String paramFromRequest(ContainerRequestContext requestContext) {
+    if (requestContext == null) {
+      return null;
+    }
+    try {
+      return requestContext.getUriInfo().getQueryParameters().getFirst(PARAM_NAME);
+    } catch (Exception ignored) {
+      return null;
+    }
+  }
+
+  private static String cookieFromArc() {
+    RoutingContext rc = tryRoutingContext();
+    if (rc != null && rc.request() != null) {
+      io.vertx.core.http.Cookie cookie = rc.request().getCookie(COOKIE_NAME);
+      return cookie != null ? cookie.getValue() : null;
+    }
+    return null;
+  }
+
+  private static String pathFromArc() {
+    RoutingContext rc = tryRoutingContext();
+    if (rc != null && rc.request() != null) {
+      return pathFromPath(rc.request().path());
+    }
+    return null;
+  }
+
+  private static String paramFromArc() {
+    RoutingContext rc = tryRoutingContext();
+    if (rc != null && rc.request() != null) {
+      try {
+        return rc.request().getParam(PARAM_NAME);
+      } catch (Exception ignored) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  private static String pathFromPath(String path) {
+    if (path == null) {
+      return null;
+    }
+    if (path.equals("/en") || path.startsWith("/en/")) {
+      return "en";
+    }
+    if (path.equals("/es") || path.startsWith("/es/")) {
+      return "es";
+    }
+    return null;
+  }
+
+  private static RoutingContext tryRoutingContext() {
+    try {
+      return Arc.container().instance(RoutingContext.class).get();
+    } catch (Exception ignored) {
+      return null;
+    }
+  }
+
+  public static String normalizeOrNull(String localeCode) {
+    if (localeCode == null || localeCode.isBlank()) {
+      return null;
+    }
+    String normalized = localeCode.trim().toLowerCase(Locale.ROOT);
+    if (normalized.contains("-")) {
+      normalized = normalized.substring(0, normalized.indexOf('-'));
+    }
+    return SUPPORTED_LANGS.contains(normalized) ? normalized : null;
+  }
+
+  private static String normalizeFromAcceptable(List<Locale> locales) {
+    if (locales == null) {
+      return null;
+    }
+    for (Locale locale : locales) {
+      if (locale == null) {
+        continue;
+      }
+      String normalized = normalizeOrNull(locale.getLanguage());
+      if (normalized != null) {
+        return normalized;
+      }
+    }
+    return null;
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/homedir/util/TemplateLocaleUtil.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/util/TemplateLocaleUtil.java
@@ -1,17 +1,11 @@
 package com.scanales.homedir.util;
 
-import com.scanales.homedir.service.UserProfileService;
 import io.quarkus.arc.Arc;
 import io.quarkus.qute.TemplateInstance;
-import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.ws.rs.core.HttpHeaders;
 import java.util.Locale;
-import java.util.Set;
 
 public final class TemplateLocaleUtil {
-
-  private static final Set<String> SUPPORTED_LANGS = Set.of("en", "es");
-  private static final String DEFAULT_LANG = "en";
 
   private TemplateLocaleUtil() {}
 
@@ -21,7 +15,7 @@ public final class TemplateLocaleUtil {
 
   public static TemplateInstance apply(
       TemplateInstance templateInstance, String localeCode, HttpHeaders headers) {
-    String normalized = resolve(localeCode, headers);
+    String normalized = LocaleResolver.resolveFromCookie(localeCode, headers);
     Locale locale = Locale.forLanguageTag(normalized);
     return templateInstance
         .setLocale(locale)
@@ -30,75 +24,12 @@ public final class TemplateLocaleUtil {
   }
 
   public static String resolve(String localeCode, HttpHeaders headers) {
-    String normalized = normalizeOrNull(resolveProfileLocale());
-    if (normalized == null) {
-      normalized = normalizeOrNull(localeCode);
-    }
-    if (normalized == null) {
-      normalized = normalizeFromHeaders(headers);
-    }
-    if (normalized == null) {
-      normalized = DEFAULT_LANG;
-    }
-    return normalized;
+    return LocaleResolver.resolveFromCookie(localeCode, headers);
   }
 
   public static String normalize(String localeCode) {
-    String normalized = normalizeOrNull(localeCode);
-    return normalized != null ? normalized : DEFAULT_LANG;
-  }
-
-  private static String normalizeOrNull(String localeCode) {
-    if (localeCode == null || localeCode.isBlank()) {
-      return null;
-    }
-    String normalized = localeCode.trim().toLowerCase(Locale.ROOT);
-    if (normalized.contains("-")) {
-      normalized = normalized.substring(0, normalized.indexOf('-'));
-    }
-    return SUPPORTED_LANGS.contains(normalized) ? normalized : null;
-  }
-
-  private static String normalizeFromHeaders(HttpHeaders headers) {
-    if (headers == null) {
-      return null;
-    }
-    for (Locale locale : headers.getAcceptableLanguages()) {
-      if (locale == null) {
-        continue;
-      }
-      String normalized = normalizeOrNull(locale.getLanguage());
-      if (normalized != null) {
-        return normalized;
-      }
-    }
-    return null;
-  }
-
-  private static String resolveProfileLocale() {
-    try {
-      SecurityIdentity identity = Arc.container().instance(SecurityIdentity.class).get();
-      if (identity == null || identity.isAnonymous()) {
-        return null;
-      }
-      String userId = AdminUtils.getClaim(identity, "email");
-      if (userId == null || userId.isBlank()) {
-        userId = identity.getPrincipal() != null ? identity.getPrincipal().getName() : null;
-      }
-      if (userId == null || userId.isBlank()) {
-        return null;
-      }
-      UserProfileService userProfiles = Arc.container().instance(UserProfileService.class).get();
-      if (userProfiles == null) {
-        return null;
-      }
-      return userProfiles
-          .find(userId.toLowerCase(Locale.ROOT))
-          .map(com.scanales.homedir.model.UserProfile::getPreferredLocale)
-          .orElse(null);
-    } catch (Exception ignored) {
-      return null;
-    }
+    String normalized = LocaleResolver.normalizeOrNull(localeCode);
+    return normalized != null ? normalized : LocaleResolver.DEFAULT_LANG;
   }
 
   private static HttpHeaders resolveCurrentHeaders() {

--- a/quarkus-app/src/test/java/com/scanales/homedir/config/LocaleSwitchingTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/config/LocaleSwitchingTest.java
@@ -1,0 +1,51 @@
+package com.scanales.homedir.config;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTest
+public class LocaleSwitchingTest {
+
+  @Test
+  void spanishCookieResolvesSpanishAndSwitchesContent() {
+    given()
+        .cookie("QP_LOCALE", "es")
+        .when()
+        .get("/docs")
+        .then()
+        .statusCode(200)
+        .body(containsString("<html lang=\"es\""))
+        .body(containsString("<option value=\"es\" selected"))
+        .body(containsString("Plataforma por OpenSourceSantiago"));
+  }
+
+  @Test
+  void englishCookieResolvesEnglishAndSwitchesContentAwayFromSpanish() {
+    given()
+        .cookie("QP_LOCALE", "en")
+        .when()
+        .get("/docs")
+        .then()
+        .statusCode(200)
+        .body(containsString("<html lang=\"en\""))
+        .body(containsString("<option value=\"en\" selected"))
+        .body(not(containsString("Plataforma por OpenSourceSantiago")));
+  }
+
+  @Test
+  void spanishAcceptLanguageFallsBackToSpanish() {
+    given()
+        .header("Accept-Language", "es-ES,es;q=0.9")
+        .when()
+        .get("/docs")
+        .then()
+        .statusCode(200)
+        .body(containsString("<html lang=\"es\""))
+        .body(containsString("Plataforma por OpenSourceSantiago"));
+  }
+}

--- a/quarkus-app/src/test/java/com/scanales/homedir/config/LocaleSwitchingTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/config/LocaleSwitchingTest.java
@@ -1,12 +1,11 @@
 package com.scanales.homedir.config;
 
-import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.RestAssured;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 public class LocaleSwitchingTest {

--- a/quarkus-app/src/test/java/com/scanales/homedir/util/LocaleResolverTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/util/LocaleResolverTest.java
@@ -11,32 +11,32 @@ class LocaleResolverTest {
 
   @Test
   void explicitParamWinsOverEverything() {
-    assertEquals("en",
-        LocaleResolver.resolve("es", "en", "es", "es", List.of(Locale.forLanguageTag("es"))));
+    assertEquals(
+        "en", LocaleResolver.resolve("es", "en", "es", "es", List.of(Locale.forLanguageTag("es"))));
   }
 
   @Test
   void pathPrefixWinsOverProfileCookieHeader() {
-    assertEquals("es",
-        LocaleResolver.resolve("en", null, "es", "en", List.of(Locale.forLanguageTag("en"))));
+    assertEquals(
+        "es", LocaleResolver.resolve("en", null, "es", "en", List.of(Locale.forLanguageTag("en"))));
   }
 
   @Test
   void profileWinsOverCookieAndHeader() {
-    assertEquals("es",
-        LocaleResolver.resolve("es", null, null, "en", List.of(Locale.forLanguageTag("en"))));
+    assertEquals(
+        "es", LocaleResolver.resolve("es", null, null, "en", List.of(Locale.forLanguageTag("en"))));
   }
 
   @Test
   void cookieWinsOverHeader() {
-    assertEquals("en",
-        LocaleResolver.resolve(null, null, null, "en", List.of(Locale.forLanguageTag("es"))));
+    assertEquals(
+        "en", LocaleResolver.resolve(null, null, null, "en", List.of(Locale.forLanguageTag("es"))));
   }
 
   @Test
   void headerUsedWhenNoStrongerSource() {
-    assertEquals("es",
-        LocaleResolver.resolve(null, null, null, null, List.of(Locale.forLanguageTag("es"))));
+    assertEquals(
+        "es", LocaleResolver.resolve(null, null, null, null, List.of(Locale.forLanguageTag("es"))));
   }
 
   @Test

--- a/quarkus-app/src/test/java/com/scanales/homedir/util/LocaleResolverTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/util/LocaleResolverTest.java
@@ -1,0 +1,54 @@
+package com.scanales.homedir.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+class LocaleResolverTest {
+
+  @Test
+  void explicitParamWinsOverEverything() {
+    assertEquals("en",
+        LocaleResolver.resolve("es", "en", "es", "es", List.of(Locale.forLanguageTag("es"))));
+  }
+
+  @Test
+  void pathPrefixWinsOverProfileCookieHeader() {
+    assertEquals("es",
+        LocaleResolver.resolve("en", null, "es", "en", List.of(Locale.forLanguageTag("en"))));
+  }
+
+  @Test
+  void profileWinsOverCookieAndHeader() {
+    assertEquals("es",
+        LocaleResolver.resolve("es", null, null, "en", List.of(Locale.forLanguageTag("en"))));
+  }
+
+  @Test
+  void cookieWinsOverHeader() {
+    assertEquals("en",
+        LocaleResolver.resolve(null, null, null, "en", List.of(Locale.forLanguageTag("es"))));
+  }
+
+  @Test
+  void headerUsedWhenNoStrongerSource() {
+    assertEquals("es",
+        LocaleResolver.resolve(null, null, null, null, List.of(Locale.forLanguageTag("es"))));
+  }
+
+  @Test
+  void defaultWhenNothingMatches() {
+    assertEquals("en", LocaleResolver.resolve(null, null, null, null, List.of()));
+  }
+
+  @Test
+  void normalizeOrNullEnforcesSupportedLanguages() {
+    assertEquals("en", LocaleResolver.normalizeOrNull("EN"));
+    assertEquals("es", LocaleResolver.normalizeOrNull("es-ES"));
+    assertNull(LocaleResolver.normalizeOrNull("fr"));
+    assertNull(LocaleResolver.normalizeOrNull(""));
+  }
+}


### PR DESCRIPTION
## Summary

Closes #1465

Consolidates the duplicated locale resolution logic in `TemplateLocaleUtil` and
`LocaleResponseFilter` into a single `LocaleResolver` used by both, so the
rendered locale can never disagree between the two paths. This directly addresses
the "duplicate locale resolution" root cause tracked by epic #1267.

## Root cause (investigation)

- The locale resolvers were duplicated and could drift. `TemplateLocaleUtil`
  ignored the `QP_LOCALE` cookie (used an explicit param) while
  `LocaleResponseFilter` ignored the param (used the cookie). They happened to
  agree today, but there was no single source of truth.
- A runtime reproduction test (`LocaleSwitchingTest`) proved the resolver works
  end-to-end: with `QP_LOCALE=es` the page renders `<html lang="es">` and Spanish
  content (`Plataforma por OpenSourceSantiago`); with `QP_LOCALE=en` it switches
  away from Spanish. The `<html lang>` and the switcher's `selected` option both
  follow the resolved locale correctly.

## Changes

- New `LocaleResolver` with precedence: explicit `?lang=` > `/en/` `/es/` path
  prefix > authenticated profile preference > `QP_LOCALE` cookie >
  `Accept-Language` > default `en`.
- `TemplateLocaleUtil` and `LocaleResponseFilter` now delegate to `LocaleResolver`
  (no behavior change for the existing cookie/profile/header flows).
- Added `/en/` `/es/` path-prefix and `?lang=` support, satisfying the
  "/en/ and /es/ routes serve the correct language" acceptance criterion.

## Test plan

- [x] `LocaleResolverTest` — precedence unit tests (7 cases)
- [x] `LocaleSwitchingTest` — runtime EN/ES cookie + Accept-Language switching (3 cases)
- [x] `I18nIntegrityTest` — bundles still consistent (2 cases)
- [x] `./mvnw clean test -Dtest='LocaleResolverTest,LocaleSwitchingTest,I18nIntegrityTest'` → BUILD SUCCESS

## Flagged for epic #1267 (not fixed inline)

These are content/audit items that belong to the broader i18n audit, not this PR:

1. **Hardcoded strings that never switch.** Example `templates/pages/docs.html`:
   `{#title}Documentación · Homedir{/title}`, `<h1>Documentación y recursos</h1>`,
   and a hardcoded `Documentación` label. These are Spanish literals and do not
   respond to locale switching.
2. **`@Message` annotation values shadow the English bundle.** In Quarkus
   `@MessageBundle`, the `@Message("...")` value serves the default (English)
   locale, so the base `messages/i18n.properties` English entries are NOT used at
   runtime. Example: `AppMessages.platform_by()` = `@Message("Platform by")`
   renders "Platform by" in English instead of the bundle's
   `by OpenSourceSantiago`. This means edits to the English base properties file
   have no effect — a systemic source-of-truth problem worth a dedicated audit
   under #1267.

These should be tracked as follow-ups under #1267 rather than expanded in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved language selection across pages using URL parameters, paths, cookies, user preferences, and browser language settings.
  - Added consistent normalization for supported language codes with English as the default.

- **Bug Fixes**
  - Fixed locale handling so Spanish and English content, including the selected language option, display correctly.

- **Tests**
  - Added coverage for language precedence, fallbacks, normalization, and localized documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->