### PR TITLE
fix: add visual hierarchy to delivery velocity metrics cards

### DIFF
--- a/quarkus-app/src/main/resources/templates/ProjectsResource/proyectos.html
+++ b/quarkus-app/src/main/resources/templates/ProjectsResource/proyectos.html
@@ -442,20 +442,28 @@
   .project-hd-velocity-card {
     display: flex;
     flex-direction: column;
-    gap: 0.45rem;
+    gap: 0.5rem;
   }
 
   .project-hd-velocity-card h3 {
     margin: 0;
-    font-size: 1.35rem;
-    line-height: 1.2;
+    font-size: 2.1rem;
+    font-weight: 800;
+    line-height: 1.05;
+    color: var(--color-accent, #ffd700);
+    letter-spacing: -0.02em;
   }
 
   .project-hd-velocity-kpis {
     display: grid;
-    gap: 0.3rem;
-    font-size: 0.76rem;
-    opacity: 0.92;
+    grid-template-columns: 1fr;
+    gap: 0.35rem;
+    margin-top: 0.1rem;
+    padding-top: 0.6rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    font-size: 0.74rem;
+    line-height: 1.35;
+    opacity: 0.85;
   }
 
   .project-hd-full {


### PR DESCRIPTION
## Summary

Closes #1462

The delivery velocity cards rendered the headline commit count and the three
supporting KPIs at a flat visual weight, so the section read like a plain list
with no hierarchy.

## Changes (CSS-only, no i18n keys changed)

In `templates/ProjectsResource/proyectos.html` (embedded `<style>` block):

- `.project-hd-velocity-card h3` (the hero commit count) is now larger
  (2.1rem), bolder (800), and accent-colored (`var(--color-accent)`), giving the
  primary metric clear dominance.
- `.project-hd-velocity-kpis` now has a top divider and muted styling, visually
  separating the secondary stats from the hero metric.

## Verification

- `./mvnw compile` succeeds (template/Qute augmentation valid).
- Visual: hero number stands out as the primary metric; supporting KPIs are
  grouped below a divider. No layout shift on the 3-column velocity grid.

Note: the issue referenced `homedir.css` lines 436-457, but the velocity styles
actually live in the project dashboard template's embedded style block (line
numbers had drifted).