### PR TITLE
fix(i18n): remove docs TODO placeholders and migrate keys to canonical messages/ bundles

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/config/AppMessages.java
@@ -2860,6 +2860,21 @@ public interface AppMessages {
   @Message("Login")
   String nav_login();
 
+  @Message("Documentation · Homedir")
+  String docs_page_title();
+
+  @Message("Documentation and resources")
+  String docs_title();
+
+  @Message("Learn how to install, configure, and extend Homedir for your events.")
+  String docs_intro();
+
+  @Message("GitHub repository")
+  String docs_link_github();
+
+  @Message("Technical documentation")
+  String docs_link_technical();
+
   @Message("Contact")
   String contacto_title();
 

--- a/quarkus-app/src/main/resources/messages/i18n.properties
+++ b/quarkus-app/src/main/resources/messages/i18n.properties
@@ -289,6 +289,13 @@ nav_reputation_hub=Reputation Hub
 nav_quests=Quests
 nav_login=Login
 
+# --- Docs page ---
+docs_page_title=Documentation · Homedir
+docs_title=Documentation and resources
+docs_intro=Learn how to install, configure, and extend Homedir for your events.
+docs_link_github=GitHub repository
+docs_link_technical=Technical documentation
+
 # --- Contact page ---
 contacto_title=Contact
 contacto_intro=If you want to use Homedir in your community or event, let's talk.

--- a/quarkus-app/src/main/resources/messages/i18n_es.properties
+++ b/quarkus-app/src/main/resources/messages/i18n_es.properties
@@ -220,6 +220,13 @@ nav_reputation_hub=Reputación
 nav_quests=Misiones
 nav_login=Ingresar
 
+# --- Docs page ---
+docs_page_title=Documentación · Homedir
+docs_title=Documentación y recursos
+docs_intro=Aprende cómo instalar, configurar y extender Homedir para tus eventos.
+docs_link_github=Repositorio en GitHub
+docs_link_technical=Documentación técnica
+
 # --- Contact page ---
 contacto_title=Contacto
 contacto_intro=Si quieres usar Homedir en tu comunidad o evento, conversemos.

--- a/quarkus-app/src/main/resources/templates/pages/docs.html
+++ b/quarkus-app/src/main/resources/templates/pages/docs.html
@@ -1,38 +1,32 @@
 {#include layout/main}
 
-{#title}Documentación · Homedir{/title}
+{#title}{i18n:docs_page_title}{/title}
 
 {#body}
 
 <section class="hd-section hd-section-page-header">
   <div class="hd-page">
-    <h1 class="hd-page-title">Documentación y recursos</h1>
-    <p class="hd-page-intro">
-      @-- TODO --
-      Aprende cómo instalar, configurar y extender Homedir para tus eventos.
-    </p>
+    <h1 class="hd-page-title">{i18n:docs_title}</h1>
+    <p class="hd-page-intro">{i18n:docs_intro}</p>
   </div>
 </section>
 
 <section class="hd-section hd-section-page-content">
   <div class="hd-page">
     <ul class="hd-link-list">
+      <!-- TODO: add more official links as official content becomes available -->
       <li class="hd-link-item">
-        @-- TODO: enlaza a README principal en GitHub --
         <a href="https://github.com/os-santiago/homedir" target="_blank" rel="noopener" class="hd-link">
           <img src="https://cdn.simpleicons.org/github/white" alt="" width="16" height="16"
-            style="vertical-align: text-bottom; margin-right: 4px;"> Repositorio en GitHub
+            style="vertical-align: text-bottom; margin-right: 4px;"> {i18n:docs_link_github}
         </a>
       </li>
       <li class="hd-link-item">
-        @-- TODO: enlaza a documentación técnica si existe --
         <a href="https://github.com/os-santiago/homedir/tree/main/docs" target="_blank" rel="noopener" class="hd-link">
           <span class="material-symbols-outlined"
-            style="font-size: 18px; vertical-align: text-bottom; margin-right: 4px;">menu_book</span> Documentación
-          técnica
+            style="font-size: 18px; vertical-align: text-bottom; margin-right: 4px;">menu_book</span> {i18n:docs_link_technical}
         </a>
       </li>
-      @-- TODO: agrega más enlaces oficiales según exista contenido --
     </ul>
   </div>
 </section>

--- a/quarkus-app/src/test/java/com/scanales/homedir/public_/DocsPageSmokeTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/public_/DocsPageSmokeTest.java
@@ -1,0 +1,29 @@
+package com.scanales.homedir.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class DocsPageSmokeTest {
+
+  @Test
+  void docsPageDoesNotExposeTodoPlaceholders() {
+    given().when().get("/docs").then().statusCode(200).body(not(containsString("@-- TODO")));
+  }
+
+  @Test
+  void docsPageShowsOfficialLinks() {
+    given()
+        .when()
+        .get("/docs")
+        .then()
+        .statusCode(200)
+        .body(anyOf(containsString("GitHub repository"), containsString("Repositorio en GitHub")))
+        .body(containsString("https://github.com/os-santiago/homedir"));
+  }
+}


### PR DESCRIPTION
## Summary
Rebases and completes ranto-dev05's PR #1532 onto current main, fixing the i18n refactor break.

- Removes the visible \`@-- TODO --\` placeholders from the /docs page.
- Replaces hardcoded Spanish copy with \`{i18n:*}\` references (docs_page_title, docs_title, docs_intro, docs_link_github, docs_link_technical).
- Migrates the new keys into the canonical \`messages/i18n.properties\` + \`messages/i18n_es.properties\` bundles (the deprecated flat \`i18n*.properties\` are no longer used).
- Adds \`DocsPageSmokeTest\` asserting no TODO placeholders are exposed and the official links render.

Original work by @ranto-dev05 (PR #1532); rebased/continued here because #1532 was based on a pre-i18n-refactor main and failed \`Validate i18n files\`.

Closes #1296

## Test Plan
- [x] \`python3 scripts/validate_i18n.py\` passes
- [x] \`DocsPageSmokeTest\` added
- [x] Spotless clean