### PR TITLE
fix: resolve-issue endpoint now requires admin authorization (#1518)

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/homedir/public_/BountyHunterApiResource.java
+++ b/quarkus-app/src/main/java/com/scanales/homedir/public_/BountyHunterApiResource.java
@@ -81,6 +81,14 @@ public class BountyHunterApiResource {
   @Path("/resolve-issue")
   @Consumes(MediaType.APPLICATION_JSON)
   public Response resolveIssue(ResolveIssueRequest request) {
+    // Authorization: only an admin may record a resolution, matching the
+    // /validate-issue path. Without this check anyone can mint points for any
+    // userId, causing unbounded leaderboard inflation.
+    if (request.validatedBy() == null || !configService.isAdminUser(request.validatedBy())) {
+      return Response.status(Response.Status.FORBIDDEN)
+          .entity(Map.of("success", false, "error", "Only admin users may resolve issues"))
+          .build();
+    }
     BountyHunterScore score =
         service.recordIssueResolution(
             request.userId(), request.issueNumber(), request.prNumber(), request.labelName());
@@ -156,5 +164,6 @@ public class BountyHunterApiResource {
       String userId, String issueNumber, String labelName, String validatedBy) {}
 
   public record ResolveIssueRequest(
-      String userId, String issueNumber, String prNumber, String labelName) {}
+      String userId, String issueNumber, String prNumber, String labelName,
+      String validatedBy) {}
 }

--- a/quarkus-app/src/test/java/com/scanales/homedir/public_/BountyHunterApiResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/public_/BountyHunterApiResourceTest.java
@@ -201,6 +201,49 @@ class BountyHunterApiResourceTest {
   }
 
   @Test
+  void resolveIssue_nonAdminUser_returnsForbidden() {
+    given()
+        .contentType(ContentType.JSON)
+        .body(
+            """
+        {
+          "userId": "testuser",
+          "issueNumber": "123",
+          "prNumber": "456",
+          "labelName": "feature-request",
+          "validatedBy": "non-admin"
+        }
+        """)
+        .when()
+        .post("/api/bounty-hunters/resolve-issue")
+        .then()
+        .statusCode(403)
+        .body("success", equalTo(false))
+        .body("error", equalTo("Only admin users may resolve issues"));
+  }
+
+  @Test
+  void resolveIssue_missingValidatedBy_returnsForbidden() {
+    given()
+        .contentType(ContentType.JSON)
+        .body(
+            """
+        {
+          "userId": "testuser",
+          "issueNumber": "123",
+          "prNumber": "456",
+          "labelName": "feature-request"
+        }
+        """)
+        .when()
+        .post("/api/bounty-hunters/resolve-issue")
+        .then()
+        .statusCode(403)
+        .body("success", equalTo(false))
+        .body("error", equalTo("Only admin users may resolve issues"));
+  }
+
+  @Test
   void getEligibleLabels_returnsLabelList() {
     List<IssueImpactLabel> labels =
         List.of(

--- a/quarkus-app/src/test/java/com/scanales/homedir/public_/BountyHunterApiResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/homedir/public_/BountyHunterApiResourceTest.java
@@ -174,6 +174,7 @@ class BountyHunterApiResourceTest {
         new BountyHunterScore(
             "testuser", 20L, 0L, 20L, BountyHunterLevel.NONE, 0, 1, Instant.now());
 
+    when(configService.isAdminUser("admin")).thenReturn(true);
     when(service.recordIssueResolution("testuser", "123", "456", "feature-request"))
         .thenReturn(score);
 
@@ -185,7 +186,8 @@ class BountyHunterApiResourceTest {
           "userId": "testuser",
           "issueNumber": "123",
           "prNumber": "456",
-          "labelName": "feature-request"
+          "labelName": "feature-request",
+          "validatedBy": "admin"
         }
         """)
         .when()


### PR DESCRIPTION
## Summary

`POST /api/bounty-hunters/resolve-issue` called `recordIssueResolution(...)` with zero authorization. The sibling endpoint `/validate-issue` validates the caller as admin via `isAdminUser(validatedBy)` inside the service, but the resolve path performed no validation at all — anyone could mint Bounty Hunter points for any `userId`, causing unbounded leaderboard inflation.

### Fix

Added an admin authorization check to the `resolveIssue` endpoint, matching the pattern used by `validateIssue`:

1. Added `validatedBy` field to `ResolveIssueRequest`
2. Before calling `service.recordIssueResolution(...)`, check `configService.isAdminUser(request.validatedBy())`
3. If the caller is not an admin, return `403 Forbidden`

```java
if (request.validatedBy() == null || !configService.isAdminUser(request.validatedBy())) {
  return Response.status(Response.Status.FORBIDDEN)
      .entity(Map.of("success", false, "error", "Only admin users may resolve issues"))
      .build();
}
```

Now both `/validate-issue` and `/resolve-issue` require an authorized admin, closing the public point-inflation vector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restricted issue resolution to authorized administrators.
  - Requests without a validating administrator are rejected with a 403 Forbidden response.
  - Added validation of the administrator identity before recording issue resolutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->