### PR TITLE
fix(docs): remove TODO placeholders rendered on the /docs page

### DIFF
--- a/quarkus-app/src/main/resources/templates/pages/docs.html
+++ b/quarkus-app/src/main/resources/templates/pages/docs.html
@@ -8,7 +8,6 @@
   <div class="hd-page">
     <h1 class="hd-page-title">Documentación y recursos</h1>
     <p class="hd-page-intro">
-      @-- TODO --
       Aprende cómo instalar, configurar y extender Homedir para tus eventos.
     </p>
   </div>
@@ -18,21 +17,18 @@
   <div class="hd-page">
     <ul class="hd-link-list">
       <li class="hd-link-item">
-        @-- TODO: enlaza a README principal en GitHub --
         <a href="https://github.com/os-santiago/homedir" target="_blank" rel="noopener" class="hd-link">
           <img src="https://cdn.simpleicons.org/github/white" alt="" width="16" height="16"
             style="vertical-align: text-bottom; margin-right: 4px;"> Repositorio en GitHub
         </a>
       </li>
       <li class="hd-link-item">
-        @-- TODO: enlaza a documentación técnica si existe --
         <a href="https://github.com/os-santiago/homedir/tree/main/docs" target="_blank" rel="noopener" class="hd-link">
           <span class="material-symbols-outlined"
             style="font-size: 18px; vertical-align: text-bottom; margin-right: 4px;">menu_book</span> Documentación
           técnica
         </a>
       </li>
-      @-- TODO: agrega más enlaces oficiales según exista contenido --
     </ul>
   </div>
 </section>


### PR DESCRIPTION
## Summary

The `/docs` page carried four development markers written as `@-- ... --`. Qute has no comment syntax of that shape, so it printed all four as ordinary text on the live page: one above the intro paragraph, three inside the link list.

This deletes those four lines from `quarkus-app/src/main/resources/templates/pages/docs.html` and nothing else. No Qute expression, tag or HTML element changed, and the links the markers referred to are already on the page.

The `/contacto` half of the issue no longer applies. That template already uses `{i18n:...}` keys throughout, with no placeholders and no disabled demo form. Searching the repository for `@--` now returns nothing.

## Linked Issue

Closes #1296

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## PR Risk Label (required — apply exactly one)

- [x] `pr:risk-low` — Docs, typos, config tweaks (min 1 approval)

## Self-Attestation Labels (apply all that apply)

- [x] `pr:traceability-ok` — Closes #1296, and the issue carries `bug` and `priority:P2`
- [x] `pr:acceptance-ok` — the placeholder text no longer reaches the rendered page

Not claimed: `pr:tests-ok`, since no test covers this template and none was added, and `pr:i18n-ok`, for the reason in Additional Notes.

## Test Plan

- [x] Code compiles (`./mvnw package -DskipTests`, so Quarkus augmentation parsed and validated the template)
- [x] Unit tests pass (`tests_cov` green on CI)
- [ ] E2E tests pass (not run locally)
- [ ] Manual verification performed (the rendered page was not opened in a browser)
- [ ] i18n keys updated (no user-facing text was added, so no key changed)

## Breaking Changes

None

## Additional Notes

`docs.html` hardcodes its Spanish strings instead of reading `{i18n:...}` keys the way `contacto.html` does, so the page ignores the EN locale. That is a separate defect, overlapping #1465 and #1280, and this PR leaves it alone.
